### PR TITLE
fix: add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to release.yml so the workflow can be manually triggered from GitHub Actions UI

## Test plan

- [ ] Verify workflow can be triggered manually via Actions → Release → Run workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)