### PR TITLE
fix: remove invalid extra-files param from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,3 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
-        with:
-          release-type: simple
-          extra-files: |
-            VERSION


### PR DESCRIPTION
## Summary

- Removes `release-type` and `extra-files` params from the action call — these are already defined in `release-please-config.json`
- Eliminates the "Unexpected input 'extra-files'" warning in CI

## Test plan

- [ ] Verify release workflow runs without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)