### PR TITLE
fix: exclude CHANGELOG.md from markdown lint

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,6 +19,7 @@ jobs:
           globs: |
             **/*.md
             !node_modules/**
+            !CHANGELOG.md
           config: .markdownlint.json
 
   link-check:


### PR DESCRIPTION
## Summary

- Excludes `CHANGELOG.md` from markdownlint CI check
- release-please auto-generates CHANGELOG with its own formatting (dashes, double blank lines) that conflicts with our lint rules
- This unblocks the release PR (#6)

## Test plan

- [ ] Verify markdown lint passes with CHANGELOG.md excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)