### PR TITLE
fix: sync VERSION with release and fix release-please config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,21 +42,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * use remote_theme for GitHub Pages cayman theme ([73b2067](https://github.com/tansuasici/claude-code-kit/commit/73b20671e1b985adf83dd2e238f42b132a400bd8))
 * wire decisions.md into session boot and protected changes workflow ([0e0014b](https://github.com/tansuasici/claude-code-kit/commit/0e0014b83cd9111f42b4ad7c7a24d9ec3f237927))
 
-## [1.0.0] - 2026-03-13
-
-### Added
-
-- Core `CLAUDE.md` instruction set with session boot, plan-first workflow, scope discipline, and verification rules
-- `CODEBASE_MAP.md` project mapping template
-- 9 agent behavior guides in `agent_docs/` (workflow, debugging, testing, conventions, subagents, hooks, skills, contracts, prompting)
-- 9 deterministic hooks: protect-files, branch-protect, block-dangerous-commands, conventional-commit, secret-scan, auto-lint, auto-format, task-complete-notify, skill-extract-reminder
-- 4 custom agents: code-reviewer, security-reviewer, qa-reviewer, planner
-- Skill extraction system with skill-extractor meta-skill
-- Session state tracking via `tasks/` (todo, lessons, decisions, handoff)
-- 3 stack templates: Next.js, Node API, Python FastAPI
-- One-line installer (`install.sh`) with `--template`, `--profile`, `--upgrade`, `--diff`, `--gitignore` flags
-- Uninstaller (`uninstall.sh`) with `--dry-run`, `--keep-tasks`, `--force` flags
-- Utility scripts: doctor.sh, validate.sh, statusline.sh, convert.sh
-- CI validation workflow (markdown lint, link check, template validation)
-
-[1.0.0]: https://github.com/tansuasici/claude-code-kit/releases/tag/v1.0.0

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-1.0.0
+1.1.0 # x-release-please-version

--- a/install.sh
+++ b/install.sh
@@ -136,9 +136,9 @@ run_diff() {
 
   # Show version comparison
   REMOTE_VERSION="unknown"
-  [ -f "$TMPDIR/VERSION" ] && REMOTE_VERSION=$(cat "$TMPDIR/VERSION" | tr -d '[:space:]')
+  [ -f "$TMPDIR/VERSION" ] && REMOTE_VERSION=$(cat "$TMPDIR/VERSION" | sed 's/ *#.*//' | tr -d '[:space:]')
   LOCAL_VERSION="not installed"
-  [ -f "$DEST/VERSION" ] && LOCAL_VERSION=$(cat "$DEST/VERSION" | tr -d '[:space:]')
+  [ -f "$DEST/VERSION" ] && LOCAL_VERSION=$(cat "$DEST/VERSION" | sed 's/ *#.*//' | tr -d '[:space:]')
   echo ""
   echo -e "  Local:  ${YELLOW}v${LOCAL_VERSION}${NC}"
   echo -e "  Latest: ${GREEN}v${REMOTE_VERSION}${NC}"
@@ -516,7 +516,7 @@ fi
 # Read version from downloaded kit
 KIT_VERSION="unknown"
 if [ -f "$TMPDIR/VERSION" ]; then
-  KIT_VERSION=$(cat "$TMPDIR/VERSION" | tr -d '[:space:]')
+  KIT_VERSION=$(cat "$TMPDIR/VERSION" | sed 's/ *#.*//' | tr -d '[:space:]')
 fi
 
 # Determine source for CLAUDE.md and CODEBASE_MAP.md

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,12 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "changelog-path": "CHANGELOG.md",
-      "extra-files": ["VERSION"]
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "VERSION"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

- Updates `VERSION` to `1.1.0` with `x-release-please-version` marker so release-please can auto-update it
- Fixes `release-please-config.json` to use `type: "generic"` updater for the `VERSION` file
- Strips marker comments (`# x-release-please-version`) when reading VERSION in `install.sh`
- Removes duplicate manual `[1.0.0]` changelog section (release-please tracks all history)

## Root cause

release-please couldn't update the VERSION file because:
1. Config used string shorthand (`"VERSION"`) instead of object with `type: "generic"`
2. File had no `x-release-please-version` marker for the generic updater to locate

## Test plan

- [ ] Verify `cat VERSION` shows `1.1.0 # x-release-please-version`
- [ ] Verify next release-please run updates VERSION correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)