### PR TITLE
fix: harden shell scripts for robustness

### DIFF
--- a/.claude/hooks/auto-format.sh
+++ b/.claude/hooks/auto-format.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 INPUT=$(cat)
 
-TOOL_NAME=$(echo "$INPUT" | grep -o '"tool_name":"[^"]*"' | cut -d'"' -f4)
+TOOL_NAME=$(echo "$INPUT" | grep -oE '"tool_name"\s*:\s*"[^"]*"' | sed 's/.*:\s*"//;s/"$//')
 
 # Only run after file edits
 case "$TOOL_NAME" in
@@ -18,7 +18,7 @@ case "$TOOL_NAME" in
   *) exit 0 ;;
 esac
 
-FILE_PATH=$(echo "$INPUT" | grep -o '"file_path":"[^"]*"' | cut -d'"' -f4 || echo "")
+FILE_PATH=$(echo "$INPUT" | grep -oE '"file_path"\s*:\s*"[^"]*"' | sed 's/.*:\s*"//;s/"$//' || echo "")
 [ -z "$FILE_PATH" ] && exit 0
 [ ! -f "$FILE_PATH" ] && exit 0
 
@@ -33,6 +33,8 @@ while [ "$PROJECT_ROOT" != "/" ]; do
   fi
   PROJECT_ROOT=$(dirname "$PROJECT_ROOT")
 done
+# If no project marker found, fall back to the file's directory
+[ "$PROJECT_ROOT" = "/" ] && PROJECT_ROOT="$DIR"
 
 case "$EXT" in
   js|jsx|ts|tsx|mjs|cjs|json|css|scss|md|yaml|yml|html)

--- a/.claude/hooks/auto-lint.sh
+++ b/.claude/hooks/auto-lint.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 INPUT=$(cat)
 
-TOOL_NAME=$(echo "$INPUT" | grep -o '"tool_name":"[^"]*"' | cut -d'"' -f4)
+TOOL_NAME=$(echo "$INPUT" | grep -oE '"tool_name"\s*:\s*"[^"]*"' | sed 's/.*:\s*"//;s/"$//')
 
 # Only run after file edits
 case "$TOOL_NAME" in
@@ -18,7 +18,7 @@ case "$TOOL_NAME" in
   *) exit 0 ;;
 esac
 
-FILE_PATH=$(echo "$INPUT" | grep -o '"file_path":"[^"]*"' | cut -d'"' -f4 || echo "")
+FILE_PATH=$(echo "$INPUT" | grep -oE '"file_path"\s*:\s*"[^"]*"' | sed 's/.*:\s*"//;s/"$//' || echo "")
 [ -z "$FILE_PATH" ] && exit 0
 [ ! -f "$FILE_PATH" ] && exit 0
 
@@ -33,6 +33,8 @@ while [ "$PROJECT_ROOT" != "/" ]; do
   fi
   PROJECT_ROOT=$(dirname "$PROJECT_ROOT")
 done
+# If no project marker found, fall back to the file's directory
+[ "$PROJECT_ROOT" = "/" ] && PROJECT_ROOT="$DIR"
 
 case "$EXT" in
   js|jsx|ts|tsx|mjs|cjs)

--- a/.claude/hooks/block-dangerous-commands.sh
+++ b/.claude/hooks/block-dangerous-commands.sh
@@ -10,12 +10,12 @@ set -euo pipefail
 
 INPUT=$(cat)
 
-TOOL_NAME=$(echo "$INPUT" | grep -o '"tool_name":"[^"]*"' | cut -d'"' -f4)
+TOOL_NAME=$(echo "$INPUT" | grep -oE '"tool_name"\s*:\s*"[^"]*"' | sed 's/.*:\s*"//;s/"$//')
 
 # Only check Bash tool
 [ "$TOOL_NAME" != "Bash" ] && exit 0
 
-COMMAND=$(echo "$INPUT" | grep -o '"command":"[^"]*"' | cut -d'"' -f4 || echo "")
+COMMAND=$(echo "$INPUT" | grep -oE '"command"\s*:\s*"[^"]*"' | sed 's/.*:\s*"//;s/"$//' || echo "")
 [ -z "$COMMAND" ] && exit 0
 
 BLOCKED=false
@@ -27,12 +27,12 @@ if echo "$COMMAND" | grep -qE 'rm\s+-(r|rf|fr)\s+/'; then
   REASON="Recursive delete on root directory"
 fi
 
-if echo "$COMMAND" | grep -qE 'rm\s+-(r|rf|fr)\s+~'; then
+if echo "$COMMAND" | grep -qE 'rm\s+-(r|rf|fr)\s+(~|\$HOME)\b'; then
   BLOCKED=true
   REASON="Recursive delete on home directory"
 fi
 
-if echo "$COMMAND" | grep -qE 'rm\s+-(r|rf|fr)\s+\.(/?\s*$|\s|;|&|\|)'; then
+if echo "$COMMAND" | grep -qE 'rm\s+-(r|rf|fr)\s+\.\s*($|[;&|])'; then
   BLOCKED=true
   REASON="Recursive delete on current directory"
 fi

--- a/.claude/hooks/branch-protect.sh
+++ b/.claude/hooks/branch-protect.sh
@@ -10,12 +10,12 @@ set -euo pipefail
 
 INPUT=$(cat)
 
-TOOL_NAME=$(echo "$INPUT" | grep -o '"tool_name":"[^"]*"' | cut -d'"' -f4)
+TOOL_NAME=$(echo "$INPUT" | grep -oE '"tool_name"\s*:\s*"[^"]*"' | sed 's/.*:\s*"//;s/"$//')
 
 # Only check Bash tool
 [ "$TOOL_NAME" != "Bash" ] && exit 0
 
-COMMAND=$(echo "$INPUT" | grep -o '"command":"[^"]*"' | cut -d'"' -f4 || echo "")
+COMMAND=$(echo "$INPUT" | grep -oE '"command"\s*:\s*"[^"]*"' | sed 's/.*:\s*"//;s/"$//' || echo "")
 [ -z "$COMMAND" ] && exit 0
 
 # Check for force push (check first — always block regardless of branch)
@@ -39,7 +39,10 @@ fi
 
 # Check for bare `git push` when on main/master (no branch specified)
 if echo "$COMMAND" | grep -qE '^git\s+push(\s+-u)?(\s+origin)?\s*$'; then
-  CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+  CURRENT_BRANCH=$(git branch --show-current 2>/dev/null) || CURRENT_BRANCH=""
+  if [ -z "$CURRENT_BRANCH" ]; then
+    exit 0  # Cannot determine branch, allow the push
+  fi
   if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ]; then
     echo "BLOCKED: You are on '$CURRENT_BRANCH' — bare 'git push' would push to protected branch"
     echo ""

--- a/.claude/hooks/conventional-commit.sh
+++ b/.claude/hooks/conventional-commit.sh
@@ -11,12 +11,12 @@ set -euo pipefail
 
 INPUT=$(cat)
 
-TOOL_NAME=$(echo "$INPUT" | grep -o '"tool_name":"[^"]*"' | cut -d'"' -f4)
+TOOL_NAME=$(echo "$INPUT" | grep -oE '"tool_name"\s*:\s*"[^"]*"' | sed 's/.*:\s*"//;s/"$//')
 
 # Only check Bash tool
 [ "$TOOL_NAME" != "Bash" ] && exit 0
 
-COMMAND=$(echo "$INPUT" | grep -o '"command":"[^"]*"' | cut -d'"' -f4 || echo "")
+COMMAND=$(echo "$INPUT" | grep -oE '"command"\s*:\s*"[^"]*"' | sed 's/.*:\s*"//;s/"$//' || echo "")
 [ -z "$COMMAND" ] && exit 0
 
 # Only check git commit commands
@@ -24,12 +24,12 @@ if ! echo "$COMMAND" | grep -qE 'git\s+commit'; then
   exit 0
 fi
 
-# Extract commit message from -m flag
-MSG=$(echo "$COMMAND" | grep -oE '\-m\s*"[^"]*"' | sed 's/-m\s*"//;s/"$//' || echo "")
+# Extract commit message from -m/--message flag
+MSG=$(echo "$COMMAND" | grep -oE '(-m|--message)\s*"[^"]*"' | sed 's/\(-m\|--message\)\s*"//;s/"$//' || echo "")
 
 # Also try single quotes
 if [ -z "$MSG" ]; then
-  MSG=$(echo "$COMMAND" | grep -oE "\-m\s*'[^']*'" | sed "s/-m\s*'//;s/'$//" || echo "")
+  MSG=$(echo "$COMMAND" | grep -oE "(-m|--message)\s*'[^']*'" | sed "s/\(-m\|--message\)\s*'//;s/'$//" || echo "")
 fi
 
 # If using heredoc or no -m flag, skip validation

--- a/.claude/hooks/protect-files.sh
+++ b/.claude/hooks/protect-files.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 INPUT=$(cat)
 
-TOOL_NAME=$(echo "$INPUT" | grep -o '"tool_name":"[^"]*"' | cut -d'"' -f4)
+TOOL_NAME=$(echo "$INPUT" | grep -oE '"tool_name"\s*:\s*"[^"]*"' | sed 's/.*:\s*"//;s/"$//')
 
 # Only check file-writing tools
 case "$TOOL_NAME" in
@@ -19,7 +19,7 @@ case "$TOOL_NAME" in
 esac
 
 # Extract file path from tool input
-FILE_PATH=$(echo "$INPUT" | grep -o '"file_path":"[^"]*"' | cut -d'"' -f4 || echo "")
+FILE_PATH=$(echo "$INPUT" | grep -oE '"file_path"\s*:\s*"[^"]*"' | sed 's/.*:\s*"//;s/"$//' || echo "")
 [ -z "$FILE_PATH" ] && exit 0
 
 BASENAME=$(basename "$FILE_PATH")

--- a/.claude/hooks/secret-scan.sh
+++ b/.claude/hooks/secret-scan.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 INPUT=$(cat)
 
-TOOL_NAME=$(echo "$INPUT" | grep -o '"tool_name":"[^"]*"' | cut -d'"' -f4)
+TOOL_NAME=$(echo "$INPUT" | grep -oE '"tool_name"\s*:\s*"[^"]*"' | sed 's/.*:\s*"//;s/"$//')
 
 # Only run after file edits
 case "$TOOL_NAME" in
@@ -18,7 +18,7 @@ case "$TOOL_NAME" in
   *) exit 0 ;;
 esac
 
-FILE_PATH=$(echo "$INPUT" | grep -o '"file_path":"[^"]*"' | cut -d'"' -f4 || echo "")
+FILE_PATH=$(echo "$INPUT" | grep -oE '"file_path"\s*:\s*"[^"]*"' | sed 's/.*:\s*"//;s/"$//' || echo "")
 [ -z "$FILE_PATH" ] && exit 0
 [ ! -f "$FILE_PATH" ] && exit 0
 
@@ -37,32 +37,32 @@ esac
 FINDINGS=""
 
 # AWS keys
-if grep -nE 'AKIA[0-9A-Z]{16}' "$FILE_PATH" 2>/dev/null; then
+if grep -nE 'AKIA[0-9A-Z]{16}' "$FILE_PATH" >/dev/null 2>&1; then
   FINDINGS="${FINDINGS}\n  - AWS Access Key ID detected"
 fi
 
 # Generic API key patterns (key = "...", api_key: "...", etc.)
-if grep -nE '(api[_-]?key|api[_-]?secret|auth[_-]?token|access[_-]?token|secret[_-]?key)\s*[=:]\s*["\x27][A-Za-z0-9+/=_-]{20,}["\x27]' "$FILE_PATH" 2>/dev/null; then
+if grep -nE '(api[_-]?key|api[_-]?secret|auth[_-]?token|access[_-]?token|secret[_-]?key)\s*[=:]\s*["\x27][A-Za-z0-9+/=_-]{20,}["\x27]' "$FILE_PATH" >/dev/null 2>&1; then
   FINDINGS="${FINDINGS}\n  - API key or token assignment detected"
 fi
 
 # Private keys
-if grep -nE 'BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY' "$FILE_PATH" 2>/dev/null; then
+if grep -nE 'BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY' "$FILE_PATH" >/dev/null 2>&1; then
   FINDINGS="${FINDINGS}\n  - Private key detected"
 fi
 
 # Common password patterns
-if grep -nE '(password|passwd|pwd)\s*[=:]\s*["\x27][^"\x27]{8,}["\x27]' "$FILE_PATH" 2>/dev/null; then
+if grep -nE '(password|passwd|pwd)\s*[=:]\s*["\x27][^"\x27]{8,}["\x27]' "$FILE_PATH" >/dev/null 2>&1; then
   FINDINGS="${FINDINGS}\n  - Hardcoded password detected"
 fi
 
 # JWT tokens
-if grep -nE 'eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}' "$FILE_PATH" 2>/dev/null; then
+if grep -nE 'eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}' "$FILE_PATH" >/dev/null 2>&1; then
   FINDINGS="${FINDINGS}\n  - JWT token detected"
 fi
 
 # GitHub tokens
-if grep -nE '(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{36,}' "$FILE_PATH" 2>/dev/null; then
+if grep -nE '(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{36,}' "$FILE_PATH" >/dev/null 2>&1; then
   FINDINGS="${FINDINGS}\n  - GitHub token detected"
 fi
 

--- a/.claude/hooks/task-complete-notify.sh
+++ b/.claude/hooks/task-complete-notify.sh
@@ -17,6 +17,7 @@ if command -v osascript &>/dev/null; then
 
   # Optional: play a sound
   afplay /System/Library/Sounds/Glass.aiff 2>/dev/null &
+  wait
 
 # Linux with notify-send
 elif command -v notify-send &>/dev/null; then
@@ -25,6 +26,7 @@ elif command -v notify-send &>/dev/null; then
   # Optional: play a sound
   if command -v paplay &>/dev/null; then
     paplay /usr/share/sounds/freedesktop/stereo/complete.oga 2>/dev/null &
+    wait
   fi
 fi
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -117,7 +117,7 @@ if [ -f ".claude/settings.json" ]; then
     for hook in .claude/hooks/*.sh; do
       [ -f "$hook" ] || continue
       basename=$(basename "$hook")
-      if echo "$SETTINGS_CONTENT" | grep -q "$basename"; then
+      if echo "$SETTINGS_CONTENT" | grep -qF "$basename"; then
         pass "$basename is referenced in settings.json"
       else
         warn "$basename exists but is NOT in settings.json (orphan hook)"

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -40,8 +40,10 @@ CTX="?"
 if [ -n "$CONTEXT_WINDOW" ] && [ "$CONTEXT_WINDOW" -gt 0 ] 2>/dev/null; then
   PCT=$(( CONTEXT_USED * 100 / CONTEXT_WINDOW ))
 
-  # Progress bar (10 chars)
+  # Progress bar (10 chars) — clamp to valid range
   FILLED=$(( PCT / 10 ))
+  [ "$FILLED" -lt 0 ] && FILLED=0
+  [ "$FILLED" -gt 10 ] && FILLED=10
   EMPTY=$(( 10 - FILLED ))
   BAR=""
   for ((i=0; i<FILLED; i++)); do BAR="${BAR}█"; done


### PR DESCRIPTION
## Summary
- Make all hook JSON parsing whitespace-tolerant (handles both minified and pretty-printed JSON)
- Guard `PROJECT_ROOT` against becoming `/` when no project marker is found
- Clamp statusline progress bar bounds, handle `$HOME` in rm detection, support `--message` flag
- Wait for background sound processes, use `grep -F` for literal matching in doctor

## Changes
| Script | Fix |
|--------|-----|
| All hooks (7 files) | Whitespace-tolerant JSON field extraction |
| `auto-lint.sh`, `auto-format.sh` | `PROJECT_ROOT="/"` fallback guard |
| `statusline.sh` | Progress bar bounds clamping (0–10) |
| `secret-scan.sh` | Redirect grep stdout to `/dev/null` |
| `block-dangerous-commands.sh` | Detect `$HOME`, simplified cwd regex |
| `branch-protect.sh` | Handle empty `CURRENT_BRANCH` on git failure |
| `conventional-commit.sh` | Support `--message` long form |
| `protect-files.sh` | Whitespace-tolerant `file_path` extraction |
| `task-complete-notify.sh` | `wait` for background sound processes |
| `doctor.sh` | `grep -F` for literal hook filename matching |

## Test plan
- [ ] Verify all scripts pass `bash -n` syntax check
- [ ] Verify hooks still trigger correctly with Claude Code
- [ ] Test JSON parsing with both minified and pretty-printed input

🤖 Generated with [Claude Code](https://claude.com/claude-code)