### PR TITLE
fix: align Three-Agent Pattern ASCII art

### DIFF
--- a/agent_docs/prompting.md
+++ b/agent_docs/prompting.md
@@ -42,12 +42,12 @@ For high-stakes reviews (security, data integrity, production bugs), use multipl
 ### The Three-Agent Pattern
 
 ```text
-┌─────────────┐    ┌──────────────────┐    ┌─────────────┐
-│  Finder      │    │  Adversary       │    │  Referee     │
-│              │    │                  │    │              │
-│  Goal: Find  │───>│  Goal: Disprove  │───>│  Goal: Judge │
-│  all issues  │    │  false positives │    │  accurately  │
-└─────────────┘    └──────────────────┘    └─────────────┘
+┌────────────────┐   ┌────────────────┐   ┌────────────────┐
+│    Finder      │   │   Adversary    │   │    Referee     │
+│                │   │                │   │                │
+│  Goal: Find    │──>│ Goal: Disprove │──>│  Goal: Judge   │
+│  all issues    │   │ false positives│   │  accurately    │
+└────────────────┘   └────────────────┘   └────────────────┘
 ```
 
 **Agent 1 — Finder**: Incentivized to find issues aggressively.


### PR DESCRIPTION
## Summary
- Equalized box widths in the Three-Agent Pattern diagram in `agent_docs/prompting.md`
- Boxes were different widths causing misaligned lines on the docs website

🤖 Generated with [Claude Code](https://claude.com/claude-code)