### PR TITLE
chore: update template version references to latest

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -80,7 +80,7 @@ Developers using Claude Code and similar agents often get inconsistent results �
 │   └── convert.sh                 # Export agents to Cursor/Windsurf/Aider formats
 │
 └── examples/                      # Stack-specific templates
-    ├── nextjs/                    # Next.js 15 + App Router
+    ├── nextjs/                    # Next.js 16 + App Router
     ├── node-api/                  # Express + TypeScript
     └── python-fastapi/            # FastAPI + SQLAlchemy
 ```

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Each template includes a customized `CLAUDE.md` with stack-specific rules and a 
 
 | Template | Stack | Includes |
 |----------|-------|----------|
-| `nextjs` | Next.js 15, App Router, Prisma, Tailwind | Server/Client Component rules, build verification |
+| `nextjs` | Next.js 16, App Router, Prisma, Tailwind | Server/Client Component rules, build verification |
 | `node-api` | Express, TypeScript, Knex.js | Layered architecture, API design conventions |
 | `python-fastapi` | FastAPI, SQLAlchemy 2.0, Pydantic v2 | Async patterns, dependency injection, Alembic |
 
@@ -255,7 +255,7 @@ claude-code-kit/
     hooks/                         # 9 deterministic hook scripts
     skills/skill-extractor/        # Meta-skill for knowledge extraction
   examples/
-    nextjs/                        # Next.js 15 + App Router template
+    nextjs/                        # Next.js 16 + App Router template
     node-api/                      # Express + TypeScript template
     python-fastapi/                # FastAPI + SQLAlchemy template
 ```

--- a/examples/nextjs/CODEBASE_MAP.md
+++ b/examples/nextjs/CODEBASE_MAP.md
@@ -1,13 +1,13 @@
 # CODEBASE_MAP.md — Next.js Example
 
 ## What
-A full-stack web application built with Next.js 15 and App Router. Handles [product/service] for [users/audience].
+A full-stack web application built with Next.js 16 and App Router. Handles [product/service] for [users/audience].
 
 ## Why
 [Business context — why this project exists, who uses it]
 
 ## Tech Stack
-- **Framework**: Next.js 15 (App Router)
+- **Framework**: Next.js 16 (App Router)
 - **Language**: TypeScript
 - **Styling**: Tailwind CSS
 - **Database**: PostgreSQL via Prisma ORM

--- a/examples/node-api/CODEBASE_MAP.md
+++ b/examples/node-api/CODEBASE_MAP.md
@@ -7,7 +7,7 @@ A REST API service built with Express.js and TypeScript. Handles [domain] operat
 [Business context — why this API exists, who consumes it]
 
 ## Tech Stack
-- **Runtime**: Node.js 20
+- **Runtime**: Node.js 22
 - **Framework**: Express.js
 - **Language**: TypeScript
 - **Database**: PostgreSQL via Knex.js (query builder)

--- a/examples/python-fastapi/CODEBASE_MAP.md
+++ b/examples/python-fastapi/CODEBASE_MAP.md
@@ -7,7 +7,7 @@ A REST API built with FastAPI and Python. Handles [domain] operations for [consu
 [Business context — why this API exists, who consumes it]
 
 ## Tech Stack
-- **Runtime**: Python 3.12
+- **Runtime**: Python 3.13
 - **Framework**: FastAPI
 - **ORM**: SQLAlchemy 2.0 (async)
 - **Migrations**: Alembic


### PR DESCRIPTION
## Summary
- Next.js 15 → 16 (examples, README, CODEBASE_MAP)
- Node.js 20 → 22 LTS (node-api example)
- Python 3.12 → 3.13 (python-fastapi example)

🤖 Generated with [Claude Code](https://claude.com/claude-code)