### PR TITLE
fix: auto-trigger CI checks on release-please PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   release-please:
@@ -17,6 +18,17 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
+      pr: ${{ steps.release.outputs.pr }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
+
+      # GITHUB_TOKEN can trigger workflow_dispatch (unlike push/pull_request).
+      # This makes required status checks pass on the release PR.
+      - name: Trigger CI on release PR
+        if: steps.release.outputs.pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_BRANCH=$(echo '${{ steps.release.outputs.pr }}' | jq -r '.headBranchName')
+          gh workflow run validate.yml --ref "${PR_BRANCH}"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   markdown-lint:


### PR DESCRIPTION
## Summary
- Release-please uses GITHUB_TOKEN to create PRs, which doesn't trigger other workflows (GitHub limitation)
- Required status checks (Markdown Lint, Link Check, Template Validation) were stuck as "pending"
- Fix: use `workflow_dispatch` (exempt from the GITHUB_TOKEN limitation) to trigger the validate workflow on the release PR branch
- Add `workflow_dispatch` trigger to validate.yml

## Test plan
- [ ] Next release-please PR should auto-pass required checks without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)