### PR TITLE
fix: add --repo flag to gh workflow dispatch in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,4 +31,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_BRANCH=$(echo '${{ steps.release.outputs.pr }}' | jq -r '.headBranchName')
-          gh workflow run validate.yml --ref "${PR_BRANCH}"
+          gh workflow run validate.yml --ref "${PR_BRANCH}" --repo "${{ github.repository }}"


### PR DESCRIPTION
## Summary
- Release workflow's `gh workflow run` failed with "not a git repository" because the job doesn't checkout the repo
- Add `--repo` flag so `gh` CLI knows which repository to dispatch on

## Test plan
- [ ] Merge this PR → release workflow triggers → validate workflow dispatched on release-please branch → checks pass on release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)