### PR TITLE
fix: resolve review findings (#36, #37, #38, #39)

### DIFF
--- a/.claude/hooks/unicode-scan.sh
+++ b/.claude/hooks/unicode-scan.sh
@@ -66,42 +66,42 @@ FINDINGS=""
 if command -v perl &>/dev/null; then
 
   # Zero Width Space (U+200B)
-  if perl -CSD -ne 'exit 1 if /\x{200B}/' "$FILE_PATH" 2>/dev/null; then :; else
+  if ! perl -CSD -ne 'exit 1 if /\x{200B}/' "$FILE_PATH" 2>/dev/null; then
     FINDINGS="${FINDINGS}\n  - Zero Width Space (U+200B) detected"
   fi
 
   # Zero Width Non-Joiner (U+200C)
-  if perl -CSD -ne 'exit 1 if /\x{200C}/' "$FILE_PATH" 2>/dev/null; then :; else
+  if ! perl -CSD -ne 'exit 1 if /\x{200C}/' "$FILE_PATH" 2>/dev/null; then
     FINDINGS="${FINDINGS}\n  - Zero Width Non-Joiner (U+200C) detected"
   fi
 
   # Zero Width Joiner (U+200D)
-  if perl -CSD -ne 'exit 1 if /\x{200D}/' "$FILE_PATH" 2>/dev/null; then :; else
+  if ! perl -CSD -ne 'exit 1 if /\x{200D}/' "$FILE_PATH" 2>/dev/null; then
     FINDINGS="${FINDINGS}\n  - Zero Width Joiner (U+200D) detected"
   fi
 
   # Word Joiner (U+2060)
-  if perl -CSD -ne 'exit 1 if /\x{2060}/' "$FILE_PATH" 2>/dev/null; then :; else
+  if ! perl -CSD -ne 'exit 1 if /\x{2060}/' "$FILE_PATH" 2>/dev/null; then
     FINDINGS="${FINDINGS}\n  - Word Joiner (U+2060) detected"
   fi
 
   # BOM mid-file (U+FEFF) — skip first line (legitimate BOM position)
-  if tail -n +2 "$FILE_PATH" | perl -CSD -ne 'exit 1 if /\x{FEFF}/' 2>/dev/null; then :; else
+  if ! tail -n +2 "$FILE_PATH" | perl -CSD -ne 'exit 1 if /\x{FEFF}/' 2>/dev/null; then
     FINDINGS="${FINDINGS}\n  - Zero Width No-Break Space / BOM mid-file (U+FEFF) detected"
   fi
 
   # Variation Selectors (U+FE00–FE0F) — primary Glassworm vector
-  if perl -CSD -ne 'exit 1 if /[\x{FE00}-\x{FE0F}]/' "$FILE_PATH" 2>/dev/null; then :; else
+  if ! perl -CSD -ne 'exit 1 if /[\x{FE00}-\x{FE0F}]/' "$FILE_PATH" 2>/dev/null; then
     FINDINGS="${FINDINGS}\n  - Variation Selectors (U+FE00-FE0F) detected — GLASSWORM ATTACK VECTOR"
   fi
 
   # Variation Selectors Supplement (U+E0100–E01EF) — primary Glassworm vector
-  if perl -CSD -ne 'exit 1 if /[\x{E0100}-\x{E01EF}]/' "$FILE_PATH" 2>/dev/null; then :; else
+  if ! perl -CSD -ne 'exit 1 if /[\x{E0100}-\x{E01EF}]/' "$FILE_PATH" 2>/dev/null; then
     FINDINGS="${FINDINGS}\n  - Variation Selectors Supplement (U+E0100-E01EF) detected — GLASSWORM ATTACK VECTOR"
   fi
 
   # Tags block (U+E0000–E007F) — hidden text encoding
-  if perl -CSD -ne 'exit 1 if /[\x{E0000}-\x{E007F}]/' "$FILE_PATH" 2>/dev/null; then :; else
+  if ! perl -CSD -ne 'exit 1 if /[\x{E0000}-\x{E007F}]/' "$FILE_PATH" 2>/dev/null; then
     FINDINGS="${FINDINGS}\n  - Tags block (U+E0000-E007F) detected — hidden text encoding"
   fi
 

--- a/agent_docs/hooks.md
+++ b/agent_docs/hooks.md
@@ -50,7 +50,7 @@ Hooks are configured in `.claude/settings.json`:
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|NotebookEdit",
         "hooks": [
           { "type": "command", "command": ".claude/hooks/protect-files.sh" }
         ]

--- a/agent_docs/skills.md
+++ b/agent_docs/skills.md
@@ -122,6 +122,44 @@ Templates for all files are in `.claude/skills/skill-extractor/resources/`.
 
 ---
 
+## Template-Based Skill Generation
+
+For skills that share common kit rules (preamble, scope discipline, verification order), the kit provides a template system that prevents doc drift across skills.
+
+### How It Works
+
+1. **Shared blocks** in `.claude/skills/_shared/blocks/` contain reusable content (e.g., `preamble.md`, `scope-rules.md`)
+2. **Templates** in `.claude/skills/_templates/*.tmpl` reference blocks via `{{PLACEHOLDER}}` tags
+3. **Build script** (`./scripts/build-skills.sh`) assembles templates into final SKILL.md files
+
+### Available Blocks
+
+| Placeholder | File | Content |
+|---|---|---|
+| `{{PREAMBLE}}` | `preamble.md` | Session boot context check |
+| `{{SCOPE_RULES}}` | `scope-rules.md` | Read-only analysis, scope discipline |
+| `{{VERIFICATION_ORDER}}` | `verification-order.md` | Typecheck > lint > test > smoke |
+| `{{PLAN_FIRST}}` | `plan-first.md` | Plan-first methodology for multi-file changes |
+| `{{CONTEXT_GATHERING}}` | `context-gathering.md` | Project config and structure analysis |
+| `{{REPORT_FOOTER}}` | `report-footer.md` | Report formatting guidelines |
+
+### Usage
+
+```bash
+# List available blocks and templates
+./scripts/build-skills.sh --list
+
+# Build all templated skills
+./scripts/build-skills.sh
+
+# Preview without writing
+./scripts/build-skills.sh --dry-run
+```
+
+When a shared block changes (e.g., verification order gets a new step), run `build-skills.sh` once and all templated skills update automatically.
+
+---
+
 ## Skill Lifecycle
 
 1. **Discovery** — Claude encounters something non-obvious during a session

--- a/install.sh
+++ b/install.sh
@@ -766,7 +766,8 @@ if [ "$PROFILE" != "minimal" ]; then
       cp "$f" "$DEST/.claude/agents/"
       manifest_add ".claude/agents/$(basename "$f")"
     done
-    ok "Created .claude/agents/ (code-reviewer, security-reviewer, planner, qa-reviewer)"
+    AGENT_COUNT=$(ls -1 "$DEST/.claude/agents/"*.md 2>/dev/null | wc -l | tr -d ' ')
+    ok "Created .claude/agents/ ($AGENT_COUNT agents)"
   elif [ "$UPGRADE" = true ]; then
     upgrade_dir "$CLONE_DIR/.claude/agents" "$DEST/.claude/agents" "*.md" ".claude/agents"
   else
@@ -853,6 +854,7 @@ if [ "$GITIGNORE" = true ]; then
       echo "scripts/convert.sh"
       echo "scripts/validate-skills.sh"
       echo "scripts/build-skills.sh"
+      echo "scripts/gen-skill-docs.sh"
       echo ".claude/"
     } >> "$GITIGNORE_FILE"
     ok "Added kit files to .gitignore (kit stays local, won't be pushed)"

--- a/scripts/build-skills.sh
+++ b/scripts/build-skills.sh
@@ -84,9 +84,15 @@ if [ "$BLOCK_COUNT" -eq 0 ]; then
   exit 1
 fi
 
+if ! command -v python3 &>/dev/null; then
+  err "python3 is required but not found"
+  exit 1
+fi
+
 info "Loaded $BLOCK_COUNT shared blocks"
 
-# Replace placeholders in content using python3 (reliable, cross-platform)
+# Replace placeholders using python3.
+# Outputs content to stdout and unreplaced placeholder names (one per line) to stderr.
 replace_placeholders() {
   local tmpl_file="$1"
   local blocks_dir="$2"
@@ -97,29 +103,24 @@ import sys, os, re
 tmpl_file = sys.argv[1]
 blocks_dir = sys.argv[2]
 
-# Read template
 with open(tmpl_file, 'r') as f:
     content = f.read()
 
-# Load blocks
 blocks = {}
 for fname in os.listdir(blocks_dir):
     if not fname.endswith('.md'):
         continue
-    name = fname[:-3]  # remove .md
+    name = fname[:-3]
     placeholder = name.upper().replace('-', '_')
     with open(os.path.join(blocks_dir, fname), 'r') as f:
         blocks[placeholder] = f.read()
 
-# Replace placeholders
 for name, block_content in blocks.items():
     tag = '{{' + name + '}}'
     content = content.replace(tag, block_content)
 
-# Check for unreplaced
 remaining = re.findall(r'\{\{[A-Z_]+\}\}', content)
 if remaining:
-    # Print warnings to stderr
     for tag in set(remaining):
         print(f'UNREPLACED:{tag}', file=sys.stderr)
 
@@ -141,16 +142,11 @@ for tmpl_file in "$TEMPLATES_DIR"/*.tmpl; do
     continue
   fi
 
-  # Build
-  WARNINGS=""
-  content=$(replace_placeholders "$tmpl_file" "$BLOCKS_DIR" 2> >(while read -r line; do
-    if [[ "$line" == UNREPLACED:* ]]; then
-      WARNINGS="${WARNINGS} ${line#UNREPLACED:}"
-    fi
-  done; [ -n "$WARNINGS" ] && echo "$WARNINGS" > /tmp/build-skills-warnings || true))
-
-  MISSING=$(cat /tmp/build-skills-warnings 2>/dev/null || true)
-  rm -f /tmp/build-skills-warnings
+  # Build — capture stderr to a temp file for reliable warning detection
+  TMPWARN=$(mktemp)
+  content=$(replace_placeholders "$tmpl_file" "$BLOCKS_DIR" 2>"$TMPWARN")
+  MISSING=$(grep '^UNREPLACED:' "$TMPWARN" 2>/dev/null | sed 's/^UNREPLACED://' | tr '\n' ' ' || true)
+  rm -f "$TMPWARN"
 
   # Determine output path
   output_dir="$SKILLS_DIR/$tmpl_name"
@@ -162,7 +158,7 @@ for tmpl_file in "$TEMPLATES_DIR"/*.tmpl; do
     echo "Source: $tmpl_file"
     echo "Output: $output_file"
     if [ -n "$MISSING" ]; then
-      warn "Unreplaced placeholders:$MISSING"
+      warn "Unreplaced placeholders: $MISSING"
     fi
     echo "Content preview (first 10 lines):"
     echo "$content" | head -10
@@ -173,10 +169,10 @@ for tmpl_file in "$TEMPLATES_DIR"/*.tmpl; do
 
   # Write output
   mkdir -p "$output_dir"
-  echo "$content" > "$output_file"
+  printf '%s\n' "$content" > "$output_file"
 
   if [ -n "$MISSING" ]; then
-    warn "$tmpl_name — built with unreplaced:$MISSING"
+    warn "$tmpl_name — built with unreplaced: $MISSING"
     ERRORS=$((ERRORS + 1))
   else
     ok "$tmpl_name → $output_file"

--- a/scripts/gen-skill-docs.sh
+++ b/scripts/gen-skill-docs.sh
@@ -126,6 +126,12 @@ if [ -d "$SKILLS_DIR" ]; then
   for skill_dir in "$SKILLS_DIR"/*/; do
     [ -d "$skill_dir" ] || continue
     skill_name=$(basename "$skill_dir")
+
+    # Skip infrastructure directories
+    case "$skill_name" in
+      _*) continue ;;
+    esac
+
     skill_file="$skill_dir/SKILL.md"
 
     if [ ! -f "$skill_file" ]; then

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -45,6 +45,11 @@ for skill_dir in "$SKILLS_DIR"/*/; do
   [ -d "$skill_dir" ] || continue
 
   skill_name=$(basename "$skill_dir")
+
+  # Skip infrastructure directories
+  case "$skill_name" in
+    _*) continue ;;
+  esac
   SKILL_FILE="$skill_dir/SKILL.md"
 
   echo "  $skill_name/"


### PR DESCRIPTION
## Summary
- Fix build-skills.sh race condition with mktemp (#36)
- Skip `_shared/` and `_templates/` in validate-skills.sh and gen-skill-docs.sh (#37)
- Fix install.sh agent count, add missing gitignore entry, fix hooks.md matcher (#38)
- Add python3 pre-flight check, improve unicode-scan.sh readability (#39)
- Add template-based skill generation docs to agent_docs/skills.md (for docsync)

Closes #36, #37, #38, #39

## Test plan
- [x] `build-skills.sh --dry-run` works with mktemp
- [x] `validate-skills.sh` reports 0 failures (no false positives from _shared/_templates)
- [x] `unicode-scan.sh` still detects ZWSP and Glassworm vectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)