### PR TITLE
feat: severity labels, anti-rationalization tables, error patterns, MCP integration

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -43,27 +43,60 @@ You are a thorough code reviewer focused on correctness, maintainability, and pe
 
 ## Output Format
 
-Organize findings by severity:
+Classify every finding with a severity label:
+
+| Label | When to Use | Example |
+|---|---|---|
+| **CRITICAL** | Security vulnerability, data loss, crash, merge blocker | SQL injection, unhandled null on critical path, auth bypass |
+| **MAJOR** | Bug, missing error handling, wrong behavior | Off-by-one, uncaught exception, race condition, missing validation |
+| **NIT** | Style, naming, minor improvement | Variable naming, import order, comment wording |
+| **FYI** | Context or observation, no action needed | "This pattern is also used in X", "Consider for future refactor" |
+
+Organize output by severity, most critical first:
 
 ```markdown
-## Must Fix
-- [file:line] Description of issue and how to fix
+## Critical
+| # | File | Issue | Suggested Fix |
+|---|------|-------|---------------|
+| 1 | file:line | Description | How to fix |
 
-## Should Fix
-- [file:line] Description of issue and suggestion
+## Major
+| # | File | Issue | Suggested Fix |
+|---|------|-------|---------------|
+| 1 | file:line | Description | How to fix |
 
-## Consider
-- [file:line] Optional improvement, not blocking
+## Nit
+| # | File | Issue | Suggested Fix |
+|---|------|-------|---------------|
 
 ## Good Stuff
 - Things done well worth calling out
 ```
 
+### Classification Rules
+
+- If unsure between Critical and Major → use Critical (err on the side of caution)
+- If unsure between Major and Nit → use Major
+- FYI items should be rare — don't pad the report with observations
+- A review with 0 Criticals and 0 Majors = approve
+- Omit empty severity sections
+
+## Enhanced Review (code-review-graph MCP)
+
+When code-review-graph MCP tools are available, use them for smarter reviews:
+
+1. Use `detect_changes_tool` to get risk-scored change analysis
+2. Use `get_impact_radius_tool` to identify blast radius (all affected files)
+3. Use `get_review_context_tool` for token-optimized context
+4. Focus review on high-risk changes and affected dependencies
+5. Flag changes that affect many callers/dependents as higher priority
+
+If code-review-graph is not available, proceed with standard file-based review.
+
 ## Rules
 
 - Be specific — point to exact files and lines
 - Suggest fixes, don't just criticize
-- Distinguish between "must fix" and "nice to have"
 - Acknowledge good patterns — review is not just about finding problems
 - Don't nitpick formatting if a formatter is configured
 - Focus on logic and behavior, not style preferences

--- a/.claude/skills/architecture-review/SKILL.md
+++ b/.claude/skills/architecture-review/SKILL.md
@@ -123,6 +123,16 @@ Evaluate growth readiness:
 - ...
 ```
 
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "It's just one exception to the architecture" | Exceptions accumulate. Each one makes the next one easier to justify. |
+| "We'll refactor when it becomes a problem" | By the time it's a problem, refactoring costs 10x more. Flag it now. |
+| "The project is too small for architecture" | Even small projects have structure. Bad habits set early persist at scale. |
+| "This coupling is temporary" | Temporary coupling becomes permanent coupling the moment a second feature depends on it. |
+| "SOLID is overkill here" | SOLID is a diagnostic tool, not a rulebook. Use it to identify risks, not enforce dogma. |
+
 ## Notes
 
 - This review focuses on structural architecture, not code-level quality (see `/code-quality-audit`)

--- a/.claude/skills/code-quality-audit/SKILL.md
+++ b/.claude/skills/code-quality-audit/SKILL.md
@@ -140,6 +140,16 @@ Evaluate:
 - End with actionable recommendations, not just observations
 - If no issues found in a category, state it explicitly — don't omit the section
 
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "It works, so it's fine" | Working code can still be unmaintainable, fragile, or a trap for future developers. |
+| "It's just a style issue" | Readability bugs compound. Confusing code leads to real bugs when someone modifies it. |
+| "Tests pass, so the code is correct" | Tests check behavior, not architecture, readability, or security. Passing tests are necessary, not sufficient. |
+| "We'll refactor this later" | Later never comes. If the smell is worth noting, it's worth flagging now. |
+| "This is how the framework does it" | Frameworks have their own tech debt. Validate patterns, don't cargo-cult them. |
+
 ## Notes
 
 - This audit focuses on code-level quality, not architecture (see `/architecture-review`)

--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -143,6 +143,58 @@ test("returns empty array when user has no orders instead of throwing NPE")
 - [Other places this pattern exists, if any]
 ```
 
+## Common Error Patterns
+
+Use these language-specific patterns to accelerate hypothesis formation. Focus on errors that are frequently misdiagnosed or waste investigation time.
+
+### Python
+
+| Error | Common Root Cause |
+|---|---|
+| `ImportError` / `ModuleNotFoundError` | Venv not activated, missing `pip install`, missing `__init__.py` |
+| `TypeError: X got an unexpected keyword argument` | Function signature changed, wrong overload |
+| `AttributeError: 'NoneType'` | Upstream query returned None, missing null check |
+| Django `OperationalError: no such table` | Missing migration — run `makemigrations` + `migrate` |
+| `RecursionError: maximum recursion depth` | Circular import or unintended self-call |
+
+### TypeScript / JavaScript
+
+| Error | Common Root Cause |
+|---|---|
+| `TS2322: Type X is not assignable to type Y` | Missing generic param, null not in union, async return type |
+| `Cannot find module` | tsconfig `paths` misconfigured, missing `package.json` exports field |
+| Next.js hydration mismatch | Server/client component boundary issue, browser-only API in SSR |
+| `TypeError: X is not a function` | Default vs named export mismatch, circular dependency |
+| `Unhandled Promise Rejection` | Missing `await`, swallowed catch, fire-and-forget async |
+
+### Go
+
+| Error | Common Root Cause |
+|---|---|
+| `undefined: X` | Unexported (lowercase) identifier, missing import, wrong build tag |
+| `cannot use X as type Y` | Interface not satisfied — check method signature and pointer receiver |
+| `fatal error: concurrent map writes` | Shared map without mutex — use `sync.Map` or add locking |
+| `context deadline exceeded` | Upstream timeout — check context propagation chain |
+
+### Rust
+
+| Error | Common Root Cause |
+|---|---|
+| `borrow of moved value` | Use `clone()`, pass reference, or restructure ownership |
+| `lifetime does not live long enough` | Add explicit lifetime annotations or restructure to avoid references |
+| `the trait X is not implemented for Y` | Missing `derive`, wrong generic bounds, need `impl` block |
+| `cannot borrow as mutable more than once` | Split borrows or use `RefCell` / `Cell` for interior mutability |
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I know what the bug is, I'll just fix it" | Reproduce first. Assumption-based fixes are wrong ~30% of the time and create new bugs. |
+| "The failing test is probably wrong" | Read the test. If it's wrong, fix it. If it's right, fix your code. Never skip. |
+| "It works locally, CI must be flaky" | Environments differ. Reproduce in CI conditions before dismissing. |
+| "I'll add logging later" | Intermittent bugs without logging become permanent mysteries. Add instrumentation now. |
+| "The stack trace points to X, so X is broken" | Stack traces show where the error surfaces, not where it originates. Trace upstream. |
+
 ## Notes
 
 - The #1 rule: **no fix without confirmed root cause** — guessing leads to patches that mask bugs

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -143,6 +143,16 @@ Create a clean pull request:
 - Base: main ← feat/user-search
 ```
 
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "Small change, no review needed" | Small changes cause production outages too. Every change gets the same pipeline. |
+| "I'll add tests after merging" | Post-merge tests never get written. Untested code stays untested. |
+| "CI will catch it" | CI catches what tests check. No tests = nothing to catch. CI is not magic. |
+| "It's just a config change" | Config changes can take down production faster than code changes. Verify. |
+| "The deadline is tight, skip coverage audit" | Shipping broken code creates more work than the time saved by skipping checks. |
+
 ## Notes
 
 - This skill automates the ship process but always asks for user confirmation on judgment calls (version bumps, untested paths, commit squashing)

--- a/.claude/skills/testing-audit/SKILL.md
+++ b/.claude/skills/testing-audit/SKILL.md
@@ -146,6 +146,16 @@ Assess the overall testing strategy:
 - End with actionable recommendations, not just observations
 - If no issues found in a category, state it explicitly — don't omit the section
 
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "100% coverage is overkill" | Nobody said 100%. But 0% on critical paths is negligent. Focus on risk, not percentages. |
+| "Mocking is good enough" | Mocks test your assumptions, not reality. Integration tests catch what mocks hide. |
+| "The code is too simple to test" | Simple code becomes complex code. Tests written now prevent regressions later. |
+| "E2E tests cover this" | E2E tests are slow and flaky. Unit tests give fast, precise feedback. You need both. |
+| "We'll add tests when we stabilize" | Code without tests never stabilizes. Tests are how you stabilize. |
+
 ## Notes
 
 - If no tests exist, the output should focus on a recommended testing strategy rather than auditing


### PR DESCRIPTION
## Summary
- Add severity classification (Critical/Major/Nit/FYI) to code-reviewer agent output (#51)
- Add code-review-graph MCP conditional integration to code-reviewer agent (#49)
- Add language-aware error patterns (Python, TypeScript, Go, Rust) to debug skill (#48)
- Add anti-rationalization tables to 5 skills: debug, code-quality-audit, ship, architecture-review, testing-audit (#50)

## Test plan
- [ ] Validate code-reviewer agent output format matches new severity labels
- [ ] Verify anti-rationalization tables render correctly in each skill
- [ ] Run `./scripts/validate-skills.sh` to ensure skill structure is valid
- [ ] Test debug skill error patterns are present and well-formatted

Closes #48, closes #49, closes #50, closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)