### PR TITLE
feat: DESIGN.md, spec folders, product context, loop detection, why-loop

### DIFF
--- a/.claude/hooks/loop-detect.sh
+++ b/.claude/hooks/loop-detect.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# loop-detect.sh — PostToolUse hook
+# Detects agent edit loops: same file edited 4+ times without progress
+#
+# Tracks recent Edit/Write actions in a temp file and warns or blocks
+# when the same file is being repeatedly edited.
+#
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+parse_json_field() {
+  local field="$1"
+  if command -v jq &>/dev/null; then
+    echo "$INPUT" | jq -r "(.tool_input.${field} // .${field}) // empty" 2>/dev/null || true
+  elif command -v python3 &>/dev/null; then
+    echo "$INPUT" | python3 -c "import sys,json;d=json.load(sys.stdin);v=d.get('tool_input',d);print(v.get('${field}',d.get('${field}','')))" 2>/dev/null || true
+  else
+    echo "$INPUT" | grep -oE "\"${field}\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | head -1 | sed 's/.*:[[:space:]]*"//;s/"$//' || true
+  fi
+}
+
+TOOL_NAME=$(parse_json_field "tool_name")
+
+# Only track file-editing tools
+case "$TOOL_NAME" in
+  Edit|Write|NotebookEdit) ;;
+  *) exit 0 ;;
+esac
+
+FILE_PATH=$(parse_json_field "file_path")
+[ -z "$FILE_PATH" ] && exit 0
+
+# Track file in a session-scoped temp file
+TRACK_FILE="/tmp/claude-loop-detect-$$"
+# Use parent PID for session scope (agent runs hooks as child processes)
+TRACK_FILE="/tmp/claude-loop-detect-${PPID:-$$}"
+
+# Append current edit
+echo "$FILE_PATH" >> "$TRACK_FILE"
+
+# Count recent edits to this file (last 10 entries)
+RECENT_EDITS=$(tail -10 "$TRACK_FILE" 2>/dev/null | grep -cF "$FILE_PATH" || echo "0")
+
+if [ "$RECENT_EDITS" -ge 6 ]; then
+  # Second warning: block the action
+  echo "BLOCKED: $FILE_PATH has been edited $RECENT_EDITS times in recent actions."
+  echo ""
+  echo "This looks like an edit loop. Stop and:"
+  echo "  1. Re-read the original goal"
+  echo "  2. Re-read the file to understand current state"
+  echo "  3. Ask the user for guidance if stuck"
+  echo ""
+  echo "Do NOT continue editing the same file repeatedly."
+  exit 2
+elif [ "$RECENT_EDITS" -ge 4 ]; then
+  # First warning: let it through but warn
+  echo "WARNING: $FILE_PATH has been edited $RECENT_EDITS times in recent actions."
+  echo ""
+  echo "You may be in an edit loop. Consider:"
+  echo "  - Re-reading the file to check current state"
+  echo "  - Re-reading the original goal"
+  echo "  - Trying a different approach"
+  exit 0
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -81,6 +81,10 @@
           {
             "type": "command",
             "command": ".claude/hooks/unicode-scan.sh"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/loop-detect.sh"
           }
         ]
       }

--- a/.claude/skills/design-review/SKILL.md
+++ b/.claude/skills/design-review/SKILL.md
@@ -22,10 +22,12 @@ Invoke with `/design-review` when:
 
 Identify the project's design foundations:
 
-1. **Read style config** — Tailwind config, CSS variables, theme files, design tokens
-2. **Identify patterns** — component library in use (shadcn, MUI, Chakra, custom)
-3. **Check for design tokens** — colors, spacing, typography, border-radius, shadows
-4. **Note inconsistencies** — multiple sources of truth, conflicting tokens
+1. **Check for DESIGN.md** — if it exists, use it as the single source of truth for design tokens, colors, typography, spacing, and component styles
+2. **Read style config** — Tailwind config, CSS variables, theme files, design tokens
+3. **Identify patterns** — component library in use (shadcn, MUI, Chakra, custom)
+4. **Check for design tokens** — colors, spacing, typography, border-radius, shadows
+5. **Cross-reference** — compare style config against DESIGN.md (if present) and flag any deviations
+6. **Note inconsistencies** — multiple sources of truth, conflicting tokens
 
 ### Phase 2: Visual Consistency Audit
 
@@ -145,6 +147,7 @@ Review interactive elements:
 
 - This review focuses on implementation quality, not design direction — it won't redesign your UI
 - AI slop detection is about identifying patterns that look unintentionally generic, not banning specific styles
+- If the project has a `DESIGN.md`, compare implementation against its defined tokens, colors, and component styles
 - If the project has a Figma/design spec, compare implementation against it
 - For accessibility-specific review, use `/accessibility-audit` which covers WCAG compliance in depth
 - Requires reading the actual component/template code — not just CSS

--- a/.claude/skills/shape-spec/SKILL.md
+++ b/.claude/skills/shape-spec/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: shape-spec
+description: Creates a timestamped feature spec folder with structured plan, decisions, and references for multi-session features
+user-invocable: true
+---
+
+# Shape Spec
+
+## When to Use
+
+Invoke with `/shape-spec` when:
+
+- Planning a feature that will span multiple sessions
+- Decisions and context should be preserved beyond the current session
+- The feature requires significant research or tradeoff analysis
+- You want structured handoff context for another session or developer
+
+## Process
+
+### Phase 1: Name and Scope
+
+1. Ask: "What feature are we speccing?" — get a short name
+2. Create the spec folder: `tasks/specs/<date>-<name>/`
+3. Confirm scope boundaries — what's in, what's out
+
+### Phase 2: Shape the Plan
+
+Gather structured information through conversation:
+
+1. **Goal** — What does "done" look like?
+2. **Context** — Why is this needed now? What triggered it?
+3. **Approach** — What's the implementation strategy?
+4. **Files to touch** — Which files need changes?
+5. **Open questions** — What needs clarification?
+6. **Risks** — What could go wrong?
+
+Write findings to `plan.md` in the spec folder.
+
+### Phase 3: Capture Decisions
+
+For each decision made during planning:
+
+1. What was decided?
+2. What alternatives were considered?
+3. Why was this option chosen?
+
+Write to `shape.md` in the spec folder.
+
+### Phase 4: Gather References
+
+Collect pointers to relevant context:
+
+- Similar code in the codebase
+- Related documentation
+- Relevant skills that apply
+- External references (docs, issues, examples)
+
+Write to `references.md` in the spec folder.
+
+## Output Format
+
+```text
+tasks/specs/<date>-<feature-name>/
+  plan.md          # Implementation plan
+  shape.md         # Decisions and context
+  references.md    # Pointers to relevant code, docs, skills
+```
+
+### plan.md template
+
+```markdown
+# Feature: <name>
+
+## Goal
+<what does "done" look like>
+
+## Context
+<why this is needed>
+
+## Approach
+1. ...
+2. ...
+
+## Files to Touch
+- `path/to/file` — what changes
+
+## Open Questions
+- ...
+
+## Risks
+- ...
+```
+
+### shape.md template
+
+```markdown
+# Decisions: <feature name>
+
+## Decision 1: <title>
+**Chosen**: <what was decided>
+**Alternatives**: <what else was considered>
+**Rationale**: <why this option>
+
+## Decision 2: <title>
+...
+```
+
+### references.md template
+
+```markdown
+# References: <feature name>
+
+## Codebase
+- `path/to/similar/code` — <why it's relevant>
+
+## Skills
+- `/skill-name` — <what it checks>
+
+## External
+- <link or reference> — <what it covers>
+```
+
+## Notes
+
+- Spec folders are optional — simple tasks should use `tasks/todo.md` directly
+- Keep spec folders lightweight — they're planning artifacts, not documentation
+- Spec folders survive sessions — new sessions read them for context
+- Reference active spec folders from `tasks/todo.md` instead of duplicating the plan

--- a/.claude/skills/skill-extractor/SKILL.md
+++ b/.claude/skills/skill-extractor/SKILL.md
@@ -50,9 +50,21 @@ Do NOT extract if:
 1. **Identify**: During your session, notice when you discover something non-obvious
 2. **Verify**: Confirm the discovery actually works/is true
 3. **Check duplicates**: Read existing skills in `.claude/skills/` to avoid duplication
-4. **Draft**: Use the template at `.claude/skills/skill-extractor/resources/skill-template.md`
-5. **Save**: Write to `.claude/skills/<skill-name>/SKILL.md`
-6. **Report**: Tell the user what you extracted and why
+4. **Why Loop**: For each pattern to be extracted, clarify the reasoning (see below)
+5. **Draft**: Use the template at `.claude/skills/skill-extractor/resources/skill-template.md`
+6. **Save**: Write to `.claude/skills/<skill-name>/SKILL.md`
+7. **Report**: Tell the user what you extracted and why
+
+### Why Loop (Step 4)
+
+For each pattern to be extracted, ask the user:
+
+1. "What problem does this solve? What happens without it?"
+2. "What's the most common mistake related to this?"
+
+Incorporate the answers into the skill's rationale. If the user can't articulate why the pattern matters, reconsider whether it's worth extracting — a pattern without a clear rationale is likely low-value.
+
+The goal: every extracted skill should explain not just **what** to do but **why** it matters. Skills without strong rationale get ignored or misapplied in future sessions.
 
 ## Quality Gates
 
@@ -63,6 +75,9 @@ Before saving a skill, verify:
 - [ ] The skill doesn't duplicate existing knowledge in `CLAUDE.md` or `tasks/lessons.md`
 - [ ] The YAML frontmatter has accurate `name` and `description`
 - [ ] The description is specific enough for semantic matching to work
+- [ ] The skill includes a concrete "Why" with the problem it solves
+- [ ] At least one "what goes wrong without this" example is included
+- [ ] The rationale was confirmed by the user, not inferred by the agent
 
 ## Manual Invocation
 

--- a/.claude/skills/skill-extractor/resources/skill-template.md
+++ b/.claude/skills/skill-extractor/resources/skill-template.md
@@ -10,6 +10,11 @@ user-invocable: false
 
 <!-- What goes wrong or is confusing? Be specific. -->
 
+## Why This Matters
+
+<!-- What happens without this knowledge? What's the cost of getting it wrong? -->
+<!-- This section must be filled before extraction is complete. -->
+
 ## Context
 
 <!-- When does this happen? What stack/version/config triggers it? -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,18 @@ Ask yourself: *"Would a staff engineer approve this?"*
 
 ---
 
+## Design System
+If `DESIGN.md` exists, read it before any UI work. Treat it as the design source of truth — compare implementation against it during design reviews and UI generation.
+
+---
+
+## Product Context
+If `agent_docs/project/mission.md` exists, read it for product context before feature work.
+If `agent_docs/project/tech-stack.md` exists, read it before technology choices.
+If `agent_docs/project/roadmap.md` exists, read it before scoping or prioritization discussions.
+
+---
+
 ## Agent Docs
 Read only what's relevant to the current task:
 - Full workflow & plan template → `agent_docs/workflow.md`

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -34,6 +34,7 @@ Developers using Claude Code and similar agents often get inconsistent results �
 ├── CLAUDE.md                      # Core agent instructions (kit-managed)
 ├── CLAUDE.project.md              # Project-specific overlay (never touched by kit)
 ├── CODEBASE_MAP.md                # Project documentation template
+├── DESIGN.md                      # Design system template (optional, for UI projects)
 ├── .kit-manifest                  # Tracks kit-managed files (auto-generated)
 ├── install.sh                     # One-line installer
 ├── uninstall.sh                   # Clean removal of all kit files
@@ -49,6 +50,9 @@ Developers using Claude Code and similar agents often get inconsistent results �
 │   ├── contracts.md               # Task contract system
 │   ├── prompting.md               # Bias awareness & neutral prompting
 │   └── project/                   # Project-specific docs (never touched by kit)
+│       ├── mission.md             # Product mission and audience (optional template)
+│       ├── tech-stack.md          # Technology choices with rationale (optional template)
+│       └── roadmap.md             # Current priorities and milestones (optional template)
 │
 ├── tasks/                         # Session state & tracking
 │   ├── todo.md                    # Current task board
@@ -68,6 +72,7 @@ Developers using Claude Code and similar agents often get inconsistent results �
 │   │   ├── protect-files.sh       # Block edits to sensitive files
 │   │   ├── branch-protect.sh      # Block push to main/force push
 │   │   ├── block-dangerous-commands.sh  # Block destructive commands
+│   │   ├── loop-detect.sh         # Edit loop detection and prevention
 │   │   ├── conventional-commit.sh # Enforce commit message format
 │   │   ├── secret-scan.sh         # Detect secrets in code
 │   │   ├── unicode-scan.sh        # Detect invisible Unicode (Glassworm defense)
@@ -97,7 +102,8 @@ Developers using Claude Code and similar agents often get inconsistent results �
 │       ├── retro/                 # Sprint retrospective & analytics
 │       ├── office-hours/          # Pre-coding product validation
 │       ├── debug/                 # Root-cause debugging
-│       └── design-review/         # UI design consistency review
+│       ├── design-review/         # UI design consistency review
+│       └── shape-spec/            # Feature spec folder creation
 │
 ├── scripts/                       # Utility scripts
 │   ├── validate.sh                # Validates CODEBASE_MAP completeness

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,118 @@
+# DESIGN.md
+
+<!-- This file captures your project's design system in a format AI agents can read natively.
+     It is the single source of truth for how the project should look and feel.
+     Fill in the sections relevant to your project, delete the rest.
+     See: https://github.com/VoltAgent/awesome-design-md -->
+
+## Visual Theme & Atmosphere
+
+<!-- What emotional impression should the UI create? (e.g., "Professional and calm", "Bold and energetic") -->
+
+## Color Palette & Roles
+
+<!-- Define colors and their semantic roles -->
+
+| Role | Value | Usage |
+|---|---|---|
+| Primary | | Buttons, links, active states |
+| Secondary | | Supporting UI elements |
+| Background | | Page and card backgrounds |
+| Surface | | Elevated containers |
+| Text | | Body text |
+| Text Muted | | Secondary text, placeholders |
+| Error | | Error states, destructive actions |
+| Warning | | Warning states, caution |
+| Success | | Success states, confirmations |
+| Border | | Dividers, input borders |
+
+<!-- Dark mode overrides, if applicable -->
+
+## Typography Rules
+
+| Element | Font | Size | Weight | Line Height |
+|---|---|---|---|---|
+| H1 | | | | |
+| H2 | | | | |
+| H3 | | | | |
+| Body | | | | |
+| Small | | | | |
+| Code | | | | |
+
+<!-- Max 2-3 font families. State them here. -->
+
+## Component Stylings
+
+<!-- Define the visual treatment for core UI elements -->
+
+### Buttons
+
+| Variant | Background | Text | Border | Radius | Padding |
+|---|---|---|---|---|---|
+| Primary | | | | | |
+| Secondary | | | | | |
+| Ghost | | | | | |
+| Destructive | | | | | |
+
+### Cards
+
+<!-- Background, shadow, border, radius, padding -->
+
+### Inputs
+
+<!-- Border, radius, padding, focus ring, error state -->
+
+### Modals / Dialogs
+
+<!-- Overlay, width, padding, animation -->
+
+## Layout Principles
+
+<!-- Grid system, max content width, spacing scale, page structure -->
+
+- Spacing scale:
+- Max content width:
+- Grid columns:
+- Gutter:
+
+## Depth & Elevation
+
+<!-- Shadow scale for layering UI elements -->
+
+| Level | Shadow | Usage |
+|---|---|---|
+| 0 | none | Flat elements |
+| 1 | | Cards, dropdowns |
+| 2 | | Modals, popovers |
+| 3 | | Toasts, tooltips |
+
+## Do's and Don'ts
+
+### Do
+
+-
+
+### Don't
+
+-
+
+## Responsive Behavior
+
+| Breakpoint | Width | Layout Changes |
+|---|---|---|
+| Mobile | | |
+| Tablet | | |
+| Desktop | | |
+| Wide | | |
+
+## Agent Prompt Guide
+
+<!-- Instructions for AI agents generating UI for this project -->
+
+When generating UI for this project:
+
+1. Always use the color tokens defined above — never hardcode hex values
+2. Follow the spacing scale — no arbitrary pixel values
+3. Match the component stylings for buttons, cards, inputs
+4. Check the Do's and Don'ts before creating new patterns
+5. Test responsive behavior at all breakpoints listed above

--- a/agent_docs/hooks.md
+++ b/agent_docs/hooks.md
@@ -21,6 +21,7 @@ Hooks are shell scripts that run automatically at specific points in Claude Code
 |------|------|-------------|
 | **secret-scan** | `.claude/hooks/secret-scan.sh` | Scans for API keys, tokens, passwords, private keys in edited files |
 | **unicode-scan** | `.claude/hooks/unicode-scan.sh` | Detects invisible Unicode characters (Glassworm attack vector, zero-width chars, variation selectors) |
+| **loop-detect** | `.claude/hooks/loop-detect.sh` | Detects edit loops — warns at 4 edits, blocks at 6 edits to the same file |
 
 ### Stop (runs when Claude finishes)
 

--- a/agent_docs/project/mission.md
+++ b/agent_docs/project/mission.md
@@ -1,0 +1,19 @@
+# Mission
+
+<!-- Fill in to give the agent product context. This is optional — delete if not needed. -->
+
+## Problem
+
+<!-- What problem does this project solve? Who has this problem? -->
+
+## Audience
+
+<!-- Who are the target users? What do they care about? -->
+
+## Approach
+
+<!-- What's the core approach or differentiator? Why this solution over alternatives? -->
+
+## Non-Goals
+
+<!-- What is explicitly out of scope? This helps the agent avoid scope creep. -->

--- a/agent_docs/project/roadmap.md
+++ b/agent_docs/project/roadmap.md
@@ -1,0 +1,19 @@
+# Roadmap
+
+<!-- Fill in to help the agent align feature work with project priorities. This is optional — delete if not needed. -->
+
+## Current Priority
+
+<!-- What's being worked on right now? What's the immediate goal? -->
+
+## Next Up
+
+<!-- What comes after the current priority? What's on deck? -->
+
+## Future Considerations
+
+<!-- Longer-term goals that should inform current decisions but aren't being built yet -->
+
+## Constraints
+
+<!-- Deadlines, budget, team size, or other factors that affect what's realistic -->

--- a/agent_docs/project/tech-stack.md
+++ b/agent_docs/project/tech-stack.md
@@ -1,0 +1,38 @@
+# Tech Stack
+
+<!-- Fill in to help the agent make consistent technology choices. This is optional — delete if not needed. -->
+
+## Frontend
+
+<!-- Framework, UI library, state management, styling approach -->
+
+| Layer | Choice | Rationale |
+|---|---|---|
+| Framework | | |
+| Styling | | |
+| State | | |
+
+## Backend
+
+<!-- Language, framework, ORM, API style -->
+
+| Layer | Choice | Rationale |
+|---|---|---|
+| Language | | |
+| Framework | | |
+| Database | | |
+| ORM | | |
+
+## Infrastructure
+
+<!-- Hosting, CI/CD, monitoring, deployment strategy -->
+
+| Layer | Choice | Rationale |
+|---|---|---|
+| Hosting | | |
+| CI/CD | | |
+| Monitoring | | |
+
+## Key Decisions
+
+<!-- Document stack choices that have tradeoffs or might surprise someone new to the project -->

--- a/agent_docs/workflow.md
+++ b/agent_docs/workflow.md
@@ -104,6 +104,34 @@ Copy this into `tasks/todo.md`:
 
 ---
 
+## Feature Spec Folders (Optional)
+
+For multi-file tasks or features that require significant planning, create a timestamped spec folder instead of (or alongside) `tasks/todo.md`:
+
+```text
+tasks/specs/
+  2026-04-05-user-auth/
+    plan.md          # Implementation plan (what we build)
+    shape.md         # Decisions and context from planning
+    references.md    # Pointers to similar code, docs, examples
+```
+
+### When to use spec folders
+
+- Multi-session features that need persistent context
+- Tasks where planning decisions should be preserved for future reference
+- Features with significant research or tradeoff analysis
+
+### When NOT to use spec folders
+
+- Simple tasks that fit in `tasks/todo.md`
+- Bug fixes or single-file changes
+- Tasks that will be completed in one session
+
+Spec folders survive sessions and serve as handoff context. A new session can read the spec folder to understand what was planned and why.
+
+---
+
 ## Mid-Task Recovery
 
 If something goes sideways:

--- a/install.sh
+++ b/install.sh
@@ -399,7 +399,7 @@ generate_strict_settings() {
     ],
     "PostToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|NotebookEdit",
         "hooks": [
           {
             "type": "command",
@@ -408,6 +408,10 @@ generate_strict_settings() {
           {
             "type": "command",
             "command": ".claude/hooks/unicode-scan.sh"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/loop-detect.sh"
           },
           {
             "type": "command",


### PR DESCRIPTION
## Summary
- Add DESIGN.md template for frontend design systems with CLAUDE.md integration (#42)
- Add timestamped feature spec folders and `/shape-spec` skill (#43)
- Add why-loop to skill extraction workflow for richer skill documentation (#44)
- Add structured product context templates: mission.md, tech-stack.md, roadmap.md (#45)
- Update hook profiles — fix strict matcher to include NotebookEdit (#46)
- Add loop-detect.sh PostToolUse hook for edit loop detection and prevention (#47)

## Test plan
- [ ] Run `./scripts/validate-skills.sh` to validate shape-spec skill
- [ ] Verify DESIGN.md template has all 9 sections
- [ ] Test loop-detect.sh with: `echo '{"tool_name":"Edit","tool_input":{"file_path":"test.ts"}}' | .claude/hooks/loop-detect.sh`
- [ ] Verify CLAUDE.md conditional pointers are correctly formatted
- [ ] Check install.sh strict profile includes loop-detect.sh and NotebookEdit matcher

Closes #42, closes #43, closes #44, closes #45, closes #46, closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)