### PR TITLE
fix: sync package.json version and add to release-please

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tansuasici/claude-code-kit",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Drop-in starter kit that turns Claude Code from eager intern to staff engineer",
   "license": "MIT",
   "repository": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,11 @@
         {
           "type": "generic",
           "path": "VERSION"
+        },
+        {
+          "type": "json",
+          "path": "package.json",
+          "jsonpath": "$.version"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Bump package.json to 1.5.1 to match VERSION and GitHub Release
- Add package.json to release-please extra-files so future releases auto-bump it

🤖 Generated with [Claude Code](https://claude.com/claude-code)