### PR TITLE
feat: add optional Obsidian knowledge wiki module

### DIFF
--- a/.claude/agents/wiki-maintainer.md
+++ b/.claude/agents/wiki-maintainer.md
@@ -1,0 +1,80 @@
+---
+name: wiki-maintainer
+description: Knowledge wiki maintenance agent for ingest, cross-referencing, and health checks
+---
+
+# Wiki Maintainer
+
+You are a knowledge wiki maintainer. Your job is to keep a structured, interlinked wiki healthy and current based on raw source documents.
+
+## Core Responsibilities
+
+1. **Ingest sources** — read raw documents, extract key information, write summary pages, update entity and concept pages, maintain cross-references
+2. **Maintain consistency** — ensure wikilinks are valid, index is current, no contradictions go unflagged
+3. **Preserve immutability** — never modify files in `raw-sources/`
+
+## Before Any Operation
+
+1. Read `WIKI.md` for vault conventions and directory structure
+2. Read `wiki/index.md` for current wiki state
+3. Check `wiki/log.md` for recent activity
+
+## Ingest Process
+
+When processing a new source:
+
+1. Read the source completely
+2. Create summary page in `wiki/summaries/`
+3. For each entity mentioned:
+   - Existing page → update with new info, cite source
+   - New entity (appears in 2+ sources) → create page
+4. For each concept:
+   - Existing page → update, note agreements/contradictions
+   - New significant concept → create page
+5. Update `wiki/index.md`
+6. Append to `wiki/log.md`
+7. Report all files touched
+
+## Page Format
+
+Every page gets YAML frontmatter:
+
+```yaml
+---
+title: Page Title
+type: summary | entity | concept | comparison | analysis
+sources: [source-files]
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+tags: [tags]
+---
+```
+
+Use `[[wikilinks]]` for all internal references. File names in kebab-case.
+
+## Lint Process
+
+When health-checking the wiki:
+
+1. Scan all wiki pages
+2. Check for: contradictions, orphan pages, missing link targets, stale content, hub gaps
+3. Write report to `wiki/lint-report.md`
+4. Log the check
+
+## Rules
+
+1. **Never modify raw sources** — they are immutable ground truth
+2. **Always update index.md** after changes
+3. **Always append to log.md** after operations
+4. **Cite sources** — every claim traces back to a raw source
+5. **Flag contradictions** — note both claims, don't silently resolve
+6. **Prefer updates over creation** — enrich existing pages first
+7. **Be thorough but concise** — the wiki is a synthesis, not a duplicate
+
+## Output Format
+
+After any operation, report:
+- Files created (with paths)
+- Files updated (with what changed)
+- Connections found (new cross-references)
+- Issues flagged (contradictions, gaps)

--- a/.claude/skills/wiki-briefing/SKILL.md
+++ b/.claude/skills/wiki-briefing/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: wiki-briefing
+description: Morning briefing from the knowledge wiki — recent activity, new sources, open actions, and key updates
+user-invocable: true
+---
+
+# Wiki Briefing
+
+## When to Use
+
+Invoke with `/wiki-briefing` when:
+
+- Starting a new session and want to know what changed
+- Morning routine — quick overview of wiki state
+- After a break — catch up on recent ingests and changes
+- Want a summary of open items and recent activity
+
+## Process
+
+### Phase 1: Recent Activity
+
+1. Read `wiki/log.md` — extract the last 5-10 entries
+2. Summarize: what was ingested, queried, or linted recently
+3. Note the date of last activity — flag if wiki has been idle
+
+### Phase 2: New Sources
+
+1. List files in `raw-sources/` with modification dates
+2. Identify any files added since the last log entry
+3. If unprocessed sources exist, flag them for ingest
+
+### Phase 3: Wiki State
+
+1. Read `wiki/index.md` — count total sources and wiki pages
+2. Check if `wiki/lint-report.md` exists and has unresolved issues
+3. Note any pages updated in the last 7 days
+
+### Phase 4: Open Actions (if applicable)
+
+1. Search wiki pages for action items, TODOs, or open questions
+2. Check for pages marked with `status: draft` or `status: review` in frontmatter
+3. Surface any items tagged with today's date or past-due dates
+
+## Output Format
+
+```markdown
+### Wiki Briefing — YYYY-MM-DD
+
+**Wiki size**: {N} sources ingested, {N} wiki pages
+
+**Recent activity** (last 7 days):
+- [date] Ingested: "Article Title" → wiki/summaries/article.md
+- [date] Query: "Question asked" → wiki/analyses/answer.md
+- [date] Lint: 3 issues found (2 resolved)
+
+**Unprocessed sources** ({N}):
+- raw-sources/new-article.md (added YYYY-MM-DD)
+- raw-sources/transcript.md (added YYYY-MM-DD)
+→ Run `/wiki-ingest` to process these
+
+**Open items**:
+- Draft page: wiki/concepts/draft-concept.md
+- Open question in wiki/entities/some-entity.md: "Need to verify X"
+
+**Health**:
+- Last lint: YYYY-MM-DD ({N} days ago)
+- Unresolved issues: {N}
+→ Run `/wiki-lint` for a fresh check
+```
+
+If the wiki is empty or not yet initialized:
+```markdown
+### Wiki Briefing — YYYY-MM-DD
+
+Your wiki is empty. To get started:
+1. Add source files to `raw-sources/` (articles, notes, transcripts)
+2. Run `/wiki-ingest` to process them into the wiki
+3. Ask questions — Claude will search the wiki and save valuable answers
+```
+
+## Rules
+
+1. Keep the briefing concise — this is a morning glance, not a deep report
+2. Always check for unprocessed sources — this is the most actionable item
+3. If last lint was > 7 days ago, suggest running `/wiki-lint`
+4. Don't read every wiki page — use index.md and log.md for the overview
+5. If wiki doesn't exist yet, guide the user to get started

--- a/.claude/skills/wiki-ingest/SKILL.md
+++ b/.claude/skills/wiki-ingest/SKILL.md
@@ -66,7 +66,7 @@ For each new source:
 
 1. Add entry to `wiki/index.md` under the appropriate section
 2. Append to `wiki/log.md`:
-   ```
+   ```markdown
    ## [YYYY-MM-DD] ingest | Source Title
    - Summary: wiki/summaries/source-name.md
    - Updated: [list of modified pages]

--- a/.claude/skills/wiki-ingest/SKILL.md
+++ b/.claude/skills/wiki-ingest/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: wiki-ingest
+description: Ingest a new source into the knowledge wiki — read, summarize, cross-reference, and update index
+user-invocable: true
+---
+
+# Wiki Ingest
+
+## When to Use
+
+Invoke with `/wiki-ingest` when:
+
+- A new file has been added to `raw-sources/`
+- You want to process an article, transcript, PDF, or notes into the wiki
+- You're batch-ingesting multiple sources
+- You've clipped a web article with Obsidian Web Clipper
+
+## Process
+
+### Phase 1: Discover
+
+1. Read `WIKI.md` for vault conventions and directory structure
+2. Read `wiki/index.md` for current wiki state
+3. Identify the new source(s) in `raw-sources/`
+   - If user specifies a file, use that
+   - If user says "process new sources", find files not yet listed in index.md
+
+### Phase 2: Read & Extract
+
+For each new source:
+
+1. Read the source file completely
+2. Identify:
+   - Key takeaways (3-5 bullets)
+   - Entities mentioned (people, tools, organizations, projects)
+   - Concepts discussed (ideas, frameworks, patterns)
+   - Claims that might contradict or reinforce existing wiki content
+   - Metadata: author, date, URL, type
+
+### Phase 3: Write Summary
+
+1. Create `wiki/summaries/{source-name}.md` with frontmatter:
+   ```yaml
+   ---
+   title: Source Title
+   type: summary
+   sources: [original-filename.md]
+   created: YYYY-MM-DD
+   updated: YYYY-MM-DD
+   tags: [relevant, tags]
+   ---
+   ```
+2. Include: key takeaways, detailed summary, notable quotes (attributed), source metadata
+
+### Phase 4: Cross-Reference
+
+1. **Entities**: For each entity mentioned:
+   - If `wiki/entities/{name}.md` exists → update with new information, cite the source
+   - If entity appears in 2+ sources but has no page → create one
+2. **Concepts**: For each concept:
+   - If `wiki/concepts/{name}.md` exists → update, note agreements/contradictions
+   - If concept is significant and new → create a page
+3. Use `[[wikilinks]]` in all pages for cross-references
+
+### Phase 5: Update Index & Log
+
+1. Add entry to `wiki/index.md` under the appropriate section
+2. Append to `wiki/log.md`:
+   ```
+   ## [YYYY-MM-DD] ingest | Source Title
+   - Summary: wiki/summaries/source-name.md
+   - Updated: [list of modified pages]
+   - New pages: [list of created pages]
+   ```
+
+## Output Format
+
+Report to user:
+
+```markdown
+### Ingest Complete: {Source Title}
+
+**Summary**: wiki/summaries/{name}.md
+**Key takeaways**:
+- Bullet 1
+- Bullet 2
+- Bullet 3
+
+**Files touched** ({N} total):
+- Created: wiki/summaries/source-name.md
+- Updated: wiki/entities/entity-a.md, wiki/concepts/concept-b.md
+- Created: wiki/entities/new-entity.md
+
+**Connections found**:
+- Links to [[existing-concept]] — reinforces claim about X
+- Contradicts [[other-page]] on Y — flagged in both pages
+```
+
+## Rules
+
+1. Never modify files in `raw-sources/` — they are immutable
+2. Always update `wiki/index.md` after any change
+3. Always append to `wiki/log.md`
+4. Every wiki claim must cite its source
+5. Flag contradictions explicitly — do not silently resolve
+6. Prefer updating existing pages over creating new ones
+7. Ask the user before creating pages for minor/ambiguous entities
+8. If ingesting multiple sources, process one at a time and report each

--- a/.claude/skills/wiki-lint/SKILL.md
+++ b/.claude/skills/wiki-lint/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: wiki-lint
+description: Health-check the knowledge wiki — find contradictions, orphans, missing pages, and stale content
+user-invocable: true
+---
+
+# Wiki Lint
+
+## When to Use
+
+Invoke with `/wiki-lint` when:
+
+- Wiki has grown and you want a health check
+- You suspect stale or contradictory content
+- Running a periodic (weekly) maintenance pass
+- Preparing the wiki for a new research phase
+
+## Process
+
+### Phase 1: Inventory
+
+1. Read `WIKI.md` for vault conventions
+2. Read `wiki/index.md` for the catalog
+3. Glob all files in `wiki/` recursively
+4. Compare: files on disk vs. entries in index.md
+
+### Phase 2: Structural Checks
+
+1. **Orphan pages** — wiki pages with zero inbound `[[wikilinks]]` from other pages
+2. **Missing pages** — `[[wikilinks]]` that point to files that don't exist
+3. **Broken links** — wikilinks to pages that were renamed or removed
+4. **Index drift** — pages that exist on disk but aren't listed in index.md (or vice versa)
+5. **Empty pages** — pages with frontmatter but no meaningful content
+
+### Phase 3: Content Checks
+
+1. **Contradictions** — pages that make conflicting claims about the same topic
+   - Compare entity pages against each other and against summaries
+   - Flag with exact quotes and source citations
+2. **Stale claims** — check if newer sources in `raw-sources/` supersede claims in the wiki
+   - Compare file dates: source newer than wiki page that references it
+3. **Hub gaps** — concepts or entities mentioned in 3+ pages but lacking a dedicated page
+4. **Thin pages** — pages with less than 3 sentences of actual content (excluding frontmatter)
+
+### Phase 4: Report
+
+Write `wiki/lint-report.md`:
+
+```markdown
+---
+title: Wiki Lint Report
+type: analysis
+created: YYYY-MM-DD
+---
+
+# Wiki Lint Report — YYYY-MM-DD
+
+## Summary
+- Pages scanned: N
+- Issues found: N
+- Critical: N | Warning: N | Info: N
+
+## Critical Issues
+
+### Contradictions
+| Page A | Page B | Conflict | Sources |
+|--------|--------|----------|---------|
+| [[page-a]] | [[page-b]] | Disagree on X | source1.md vs source2.md |
+
+### Missing Pages
+- [[missing-page]] — referenced by: page-a.md, page-b.md
+
+## Warnings
+
+### Orphan Pages
+- [[orphan-page]] — no inbound links, consider linking or removing
+
+### Stale Content
+- [[stale-page]] — last updated YYYY-MM-DD, newer source exists
+
+## Suggestions
+
+### Hub Gaps
+- "concept-name" mentioned in N pages but has no dedicated page
+  - Referenced in: [[page-a]], [[page-b]], [[page-c]]
+
+### Index Drift
+- Files not in index: page-x.md, page-y.md
+- Index entries without files: old-page.md
+```
+
+### Phase 5: Log
+
+Append to `wiki/log.md`:
+```
+## [YYYY-MM-DD] lint | Health check
+- Report: wiki/lint-report.md
+- Issues: N critical, N warnings, N suggestions
+```
+
+## Output Format
+
+Print a summary to the user:
+
+```markdown
+### Wiki Health Report
+
+**Scanned**: {N} pages across {N} directories
+**Issues**: {N} critical, {N} warnings, {N} suggestions
+
+**Critical**:
+- 2 contradictions found (see lint-report.md)
+- 3 missing pages (wikilinks to non-existent files)
+
+**Top suggestions**:
+- Create page for "concept-x" (mentioned in 5 pages)
+- Update "entity-y" (newer source available)
+
+Full report: wiki/lint-report.md
+```
+
+## Rules
+
+1. Never modify wiki pages during lint — report only
+2. Always write the full report to `wiki/lint-report.md`
+3. Always append to `wiki/log.md`
+4. Distinguish severity: critical (contradictions, broken links) > warning (stale, orphan) > info (suggestions)
+5. Include actionable fixes — don't just list problems
+6. If the wiki is small (< 10 pages), skip structural checks and focus on content

--- a/.claude/skills/wiki-lint/SKILL.md
+++ b/.claude/skills/wiki-lint/SKILL.md
@@ -92,7 +92,7 @@ created: YYYY-MM-DD
 ### Phase 5: Log
 
 Append to `wiki/log.md`:
-```
+```markdown
 ## [YYYY-MM-DD] lint | Health check
 - Report: wiki/lint-report.md
 - Issues: N critical, N warnings, N suggestions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,11 @@ If `DESIGN.md` exists, read it before any UI work. Treat it as the design source
 
 ---
 
+## Knowledge Wiki
+If `WIKI.md` exists, read it before knowledge work. Follow its ingest, query, and lint workflows when working with the wiki vault. Never modify files in `raw-sources/` — they are immutable. Always update `wiki/index.md` and append to `wiki/log.md` after any wiki operation.
+
+---
+
 ## Product Context
 If `agent_docs/project/mission.md` exists, read it for product context before feature work.
 If `agent_docs/project/tech-stack.md` exists, read it before technology choices.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Then fill in `CODEBASE_MAP.md` with your project's details and start a Claude Co
 | `--upgrade` | Add new files without overwriting your customizations |
 | `--diff` | Compare local installation against latest kit (read-only) |
 | `--gitignore` | Add kit files to `.gitignore` (keep kit local, don't push to repo) |
+| `--obsidian` | Add knowledge wiki module (Obsidian second brain) |
 | `--version v1.0.0` | Install a specific version instead of latest |
 
 ### Uninstall
@@ -66,6 +67,7 @@ Examples:
 # Install with npx
 npx @tansuasici/claude-code-kit init --template nextjs
 npx @tansuasici/claude-code-kit init --profile strict
+npx @tansuasici/claude-code-kit init --obsidian
 npx @tansuasici/claude-code-kit init --upgrade
 
 # Or with curl
@@ -196,6 +198,7 @@ Built-in agents for code review, planning, and maintenance:
 | `qa-reviewer` | Evidence-based QA verification |
 | `planner` | Creates implementation plans with 3-lens review and failure modes |
 | `dead-code-remover` | Removes verified unused code through static reference analysis |
+| `wiki-maintainer` | Knowledge wiki maintenance — ingest, cross-reference, health checks *(requires `--obsidian`)* |
 
 ## Skills
 
@@ -221,6 +224,9 @@ User-invocable audit and guide skills — run with `/skill-name`:
 | `/skill-extractor` | Extracts non-obvious knowledge into reusable skills |
 | `/skill-generator` | Generates project-specific coding skills from tech stack analysis |
 | `/shape-spec` | Creates timestamped feature spec folders for multi-session planning |
+| `/wiki-ingest` | Ingest source into knowledge wiki — summarize, cross-reference, update index *(requires `--obsidian`)* |
+| `/wiki-lint` | Health-check the knowledge wiki — contradictions, orphans, stale content *(requires `--obsidian`)* |
+| `/wiki-briefing` | Morning briefing from the wiki — recent activity, new sources, open items *(requires `--obsidian`)* |
 
 ## Stack Templates
 
@@ -277,6 +283,8 @@ sonnet-4.5 | feat/search | ████████░░ 78% | $1.24
 
 **DESIGN.md** — Optional design system template for UI projects. Captures colors, typography, spacing, component styles in a format agents read natively. The `/design-review` skill checks implementation against it.
 
+**Knowledge Wiki** — Optional Obsidian second brain module (install with `--obsidian`). Based on Andrej Karpathy's LLM Wiki pattern: Claude incrementally builds and maintains a persistent, interlinked wiki from raw sources. Three operations: `/wiki-ingest` processes new sources into the wiki, `/wiki-lint` health-checks for contradictions and orphans, `/wiki-briefing` gives you a daily summary. The wiki compounds — every source you add makes it smarter.
+
 **Product Context** — Optional templates in `agent_docs/project/` (mission.md, tech-stack.md, roadmap.md) give agents product awareness beyond code conventions.
 
 **Permissions** — `.claude/settings.json` includes curated allow/deny lists. Allowed: test runners, linters, git reads. Denied: `curl`, `wget`, `.env` reads, `npm publish`. Review and customize for your project.
@@ -315,9 +323,15 @@ claude-code-kit/
     todo.md, lessons.md, decisions.md, handoff.md
   scripts/                         # Utility scripts
     doctor.sh, validate.sh, statusline.sh, convert.sh, validate-skills.sh, build-skills.sh, gen-agents-md.sh
+  # --- Optional: Knowledge Wiki (--obsidian) ---
+  WIKI.md                          # Wiki schema & conventions
+  raw-sources/                     # Immutable source documents (yours)
+  wiki/                            # Claude-maintained knowledge base
+    index.md, log.md               # Navigation & activity log
+    summaries/, entities/, concepts/ # Wiki page directories
   .claude/
     settings.json                  # Hook configs & permissions
-    agents/                        # code-reviewer, security-reviewer, planner, qa-reviewer, dead-code-remover
+    agents/                        # code-reviewer, security-reviewer, planner, qa-reviewer, dead-code-remover, wiki-maintainer
     hooks/                         # 12 deterministic hook scripts
       project/                     # Project-specific hooks (yours)
     skills/                        # Reusable knowledge & audit skills
@@ -341,6 +355,9 @@ claude-code-kit/
       debug/                       # Root-cause debugging
       design-review/               # UI design consistency review
       shape-spec/                  # Feature spec folder creation
+      wiki-ingest/                 # Wiki source ingestion (--obsidian)
+      wiki-lint/                   # Wiki health checks (--obsidian)
+      wiki-briefing/               # Wiki daily briefing (--obsidian)
   examples/
     nextjs/                        # Next.js 16 + App Router template
     node-api/                      # Express + TypeScript template

--- a/WIKI.md
+++ b/WIKI.md
@@ -1,0 +1,170 @@
+# WIKI.md — Knowledge Wiki Schema
+
+This file configures Claude as a wiki maintainer for your Obsidian vault.
+When this file exists, Claude follows the ingest, query, and lint workflows below.
+
+---
+
+## Architecture
+
+Three layers, strict separation:
+
+| Layer | Path | Owner | Mutability |
+|-------|------|-------|------------|
+| Raw sources | `raw-sources/` | Human | Immutable — Claude reads, never modifies |
+| Wiki | `wiki/` | Claude | Claude creates, updates, maintains |
+| Schema | `WIKI.md` (this file) | Both | Co-evolved over time |
+
+---
+
+## Directory Structure
+
+```
+raw-sources/              # Drop articles, PDFs, transcripts, notes here
+  assets/                 # Downloaded images and attachments
+
+wiki/                     # Claude-maintained knowledge base
+  index.md                # Content catalog — Claude reads first on every query
+  log.md                  # Chronological activity log (append-only)
+  summaries/              # One page per ingested source
+  entities/               # People, tools, organizations, projects
+  concepts/               # Ideas, patterns, frameworks, topics
+```
+
+---
+
+## Page Conventions
+
+Every wiki page uses YAML frontmatter:
+
+```yaml
+---
+title: Page Title
+type: summary | entity | concept | comparison | analysis
+sources: [filename1.md, filename2.md]
+created: 2026-04-14
+updated: 2026-04-14
+tags: [tag1, tag2]
+---
+```
+
+- Use `[[wikilinks]]` for internal cross-references
+- File names: kebab-case (`machine-learning.md`, `openai.md`)
+- One concept per page — split if a page covers multiple distinct ideas
+- Link liberally — every mention of a known entity or concept should be a wikilink
+
+---
+
+## Operations
+
+### Ingest
+
+When a new source appears in `raw-sources/`:
+
+1. Read the source completely
+2. Create `wiki/summaries/{source-name}.md` with:
+   - Key takeaways (3-5 bullets)
+   - Detailed summary
+   - Source metadata (author, date, URL if available)
+3. Update `wiki/index.md` — add entry with link and one-line description
+4. For each entity mentioned:
+   - If entity page exists → update with new information, note the source
+   - If entity is mentioned 2+ times across sources but has no page → create one
+5. For each concept mentioned:
+   - If concept page exists → update, note agreements/contradictions with existing content
+   - If concept is new and significant → create a page
+6. Append to `wiki/log.md`:
+   ```
+   ## [YYYY-MM-DD] ingest | Source Title
+   - Summary: wiki/summaries/source-name.md
+   - Updated: list of touched pages
+   - New pages: list of created pages
+   ```
+7. Report every file touched
+
+### Query
+
+When answering a question from the wiki:
+
+1. Read `wiki/index.md` to find relevant pages
+2. Read the relevant wiki pages (not raw sources — the wiki is pre-synthesized)
+3. Synthesize an answer with `[[wikilink]]` citations
+4. If the answer produces a valuable artifact (comparison table, analysis, timeline):
+   - Save it as a new wiki page (type: comparison | analysis)
+   - Update index.md
+   - Append to log.md
+
+### Lint
+
+Periodic health check of the wiki:
+
+1. Read every file in `wiki/`
+2. Check for:
+   - **Contradictions** — pages that disagree on facts
+   - **Orphan pages** — no inbound wikilinks from other pages
+   - **Missing pages** — wikilinks that point to non-existent pages
+   - **Stale claims** — information superseded by newer sources
+   - **Hub gaps** — concepts mentioned 3+ times but lacking a dedicated page
+   - **Broken links** — wikilinks to pages that were renamed or removed
+3. Write report to `wiki/lint-report.md`
+4. Suggest specific fixes for each issue found
+5. Append to `wiki/log.md`
+
+---
+
+## Index Format
+
+`wiki/index.md` structure:
+
+```markdown
+# Wiki Index
+
+Last updated: YYYY-MM-DD
+Sources: N | Wiki pages: N
+
+## Summaries
+- [[source-name]] — One-line description (YYYY-MM-DD)
+
+## Entities
+- [[entity-name]] — Type, brief description
+
+## Concepts
+- [[concept-name]] — Brief description
+
+## Analyses
+- [[analysis-name]] — What it compares/analyzes
+```
+
+---
+
+## Log Format
+
+`wiki/log.md` — append-only, newest at bottom:
+
+```markdown
+# Wiki Log
+
+## [YYYY-MM-DD] ingest | Article Title
+- Summary: wiki/summaries/article-title.md
+- Updated: wiki/entities/some-entity.md, wiki/concepts/some-concept.md
+- New pages: wiki/entities/new-entity.md
+
+## [YYYY-MM-DD] query | Question asked
+- Answer saved: wiki/analyses/comparison-name.md
+
+## [YYYY-MM-DD] lint | Health check
+- Report: wiki/lint-report.md
+- Issues found: 3 contradictions, 2 orphans, 5 missing pages
+```
+
+---
+
+## Rules
+
+1. **Never modify raw sources** — they are immutable ground truth
+2. **Always update index.md** after any wiki change
+3. **Always append to log.md** after any operation
+4. **Cite sources** — every claim in the wiki should trace back to a raw source
+5. **Flag contradictions** — don't silently resolve them, note both claims and their sources
+6. **Prefer updating over creating** — enrich existing pages before making new ones
+7. **Keep summaries concise** — the wiki is a synthesis, not a copy of the source

--- a/WIKI.md
+++ b/WIKI.md
@@ -19,7 +19,7 @@ Three layers, strict separation:
 
 ## Directory Structure
 
-```
+```text
 raw-sources/              # Drop articles, PDFs, transcripts, notes here
   assets/                 # Downloaded images and attachments
 
@@ -74,7 +74,7 @@ When a new source appears in `raw-sources/`:
    - If concept page exists → update, note agreements/contradictions with existing content
    - If concept is new and significant → create a page
 6. Append to `wiki/log.md`:
-   ```
+   ```markdown
    ## [YYYY-MM-DD] ingest | Source Title
    - Summary: wiki/summaries/source-name.md
    - Updated: list of touched pages

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,9 @@ PROFILE="standard"
 UPGRADE=false
 DIFF_MODE=false
 GITIGNORE=false
+OBSIDIAN=false
 TARGET_VERSION=""
+LOCAL_SOURCE=false
 DEST="$(pwd)"
 CLONE_DIR=""
 MANIFEST_FILE=".kit-manifest"
@@ -34,6 +36,31 @@ manifest_write() {
   if [ ${#MANIFEST_ENTRIES[@]} -gt 0 ]; then
     printf '%s\n' "${MANIFEST_ENTRIES[@]}" | sort -u > "$dest/$MANIFEST_FILE"
   fi
+}
+
+# Create wiki index.md template
+create_wiki_index() {
+  cat > "$1" << 'WIKIEOF'
+# Wiki Index
+
+Last updated: —
+Sources: 0 | Wiki pages: 0
+
+## Summaries
+
+## Entities
+
+## Concepts
+
+## Analyses
+WIKIEOF
+}
+
+# Create wiki log.md template
+create_wiki_log() {
+  cat > "$1" << 'WIKIEOF'
+# Wiki Log
+WIKIEOF
 }
 
 # Check if a path is a project overlay (never touched by kit)
@@ -454,7 +481,8 @@ SETTINGS_EOF
 }
 
 cleanup() {
-  if [ -n "$CLONE_DIR" ] && [ -d "$CLONE_DIR" ]; then
+  # Only clean up if we cloned to a temp directory (not --local mode)
+  if [ "$LOCAL_SOURCE" = false ] && [ -n "$CLONE_DIR" ] && [ -d "$CLONE_DIR" ]; then
     rm -rf "$CLONE_DIR"
   fi
 }
@@ -485,6 +513,10 @@ while [[ $# -gt 0 ]]; do
       GITIGNORE=true
       shift
       ;;
+    --obsidian)
+      OBSIDIAN=true
+      shift
+      ;;
     --version|-v)
       [ $# -ge 2 ] || error "--version requires an argument"
       TARGET_VERSION="$2"
@@ -502,6 +534,7 @@ while [[ $# -gt 0 ]]; do
       echo "  --upgrade, -u    Update kit-managed files (skips project overlay files)"
       echo "  --diff, -d       Compare local installation against latest kit (read-only)"
       echo "  --gitignore, -g  Add kit files to .gitignore (keep kit local, don't push to repo)"
+      echo "  --obsidian       Add knowledge wiki module (Obsidian second brain)"
       echo "  --version, -v    Install a specific version (e.g., --version v1.0.0)"
       echo "  --help, -h       Show this help"
       echo ""
@@ -511,6 +544,7 @@ while [[ $# -gt 0 ]]; do
     --local)
       [ $# -ge 2 ] || error "--local requires a path argument"
       CLONE_DIR="$2"
+      LOCAL_SOURCE=true
       shift 2
       ;;
     *)
@@ -855,6 +889,39 @@ else
   warn "Skipped .claude/settings.json (already exists)"
 fi
 
+# --- Obsidian wiki module (optional) ---
+if [ "$OBSIDIAN" = true ] && [ "$PROFILE" != "minimal" ]; then
+  # Copy WIKI.md schema
+  manifest_add "WIKI.md"
+  if [ ! -f "$DEST/WIKI.md" ]; then
+    cp "$CLONE_DIR/WIKI.md" "$DEST/WIKI.md"
+    ok "Created WIKI.md (knowledge wiki schema)"
+  elif [ "$UPGRADE" = true ]; then
+    cp "$CLONE_DIR/WIKI.md" "$DEST/WIKI.md"
+    ok "Updated WIKI.md"
+  else
+    warn "Skipped WIKI.md (already exists)"
+  fi
+
+  # Scaffold vault directories
+  if [ ! -d "$DEST/raw-sources" ]; then
+    mkdir -p "$DEST/raw-sources"
+    ok "Created raw-sources/ (drop articles, PDFs, transcripts here)"
+  fi
+
+  if [ ! -d "$DEST/wiki" ]; then
+    mkdir -p "$DEST/wiki/summaries" "$DEST/wiki/entities" "$DEST/wiki/concepts"
+    create_wiki_index "$DEST/wiki/index.md"
+    create_wiki_log "$DEST/wiki/log.md"
+    ok "Created wiki/ (Claude-maintained knowledge base)"
+  else
+    # Ensure subdirectories exist
+    mkdir -p "$DEST/wiki/summaries" "$DEST/wiki/entities" "$DEST/wiki/concepts"
+    [ -f "$DEST/wiki/index.md" ] || create_wiki_index "$DEST/wiki/index.md"
+    [ -f "$DEST/wiki/log.md" ] || create_wiki_log "$DEST/wiki/log.md"
+  fi
+fi
+
 # Write manifest
 manifest_add "$MANIFEST_FILE"
 manifest_write "$DEST"
@@ -886,6 +953,11 @@ if [ "$GITIGNORE" = true ]; then
       echo "scripts/build-skills.sh"
       echo "scripts/gen-skill-docs.sh"
       echo ".claude/"
+      if [ "$OBSIDIAN" = true ]; then
+        echo "WIKI.md"
+        echo "raw-sources/"
+        echo "wiki/"
+      fi
     } >> "$GITIGNORE_FILE"
     ok "Added kit files to .gitignore (kit stays local, won't be pushed)"
   fi
@@ -914,5 +986,14 @@ else
   echo "  3. Run ./scripts/validate.sh to check for unfilled placeholders"
   echo "  4. Review .claude/settings.json to enable/disable hooks"
   echo "  5. Start a Claude Code session"
+  if [ "$OBSIDIAN" = true ]; then
+    echo ""
+    echo "  Wiki module:"
+    echo "  - Add source files to raw-sources/ (articles, PDFs, transcripts)"
+    echo "  - Run /wiki-ingest to process them into the wiki"
+    echo "  - Run /wiki-briefing for a daily summary"
+    echo "  - Run /wiki-lint for periodic health checks"
+    echo "  - Open the project folder in Obsidian to browse the wiki"
+  fi
 fi
 echo ""


### PR DESCRIPTION
## Summary

- Adds `--obsidian` installer flag for optional knowledge wiki module based on Andrej Karpathy's LLM Wiki pattern
- Creates `WIKI.md` schema template, `wiki/` directory scaffold, `raw-sources/` for immutable sources
- Adds 3 new skills: `/wiki-ingest`, `/wiki-lint`, `/wiki-briefing`
- Adds `wiki-maintainer` agent for subagent-based wiki operations
- Fixes cleanup bug in `install.sh` that deleted source directory in `--local` mode

## New Files
- `WIKI.md` — wiki schema with ingest/query/lint workflows
- `.claude/agents/wiki-maintainer.md` — dedicated wiki maintenance agent
- `.claude/skills/wiki-ingest/SKILL.md` — source ingestion skill
- `.claude/skills/wiki-lint/SKILL.md` — wiki health check skill
- `.claude/skills/wiki-briefing/SKILL.md` — daily briefing skill

## Modified Files
- `CLAUDE.md` — conditional "Knowledge Wiki" section (same pattern as DESIGN.md)
- `install.sh` — `--obsidian` flag, scaffold helpers, gitignore support, cleanup fix
- `README.md` — docs for flag, skills, agent, feature description, directory structure

## Test plan
- [x] Fresh install with `--obsidian`: all wiki files created
- [x] Fresh install without `--obsidian`: no wiki files created
- [x] Kit source directory preserved after `--local` install (cleanup bug fix)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)