### PR TITLE
fix: include WIKI.md in npm package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "CLAUDE.project.md",
     "CODEBASE_MAP.md",
     "DESIGN.md",
+    "WIKI.md",
     "install.sh",
     "uninstall.sh",
     "VERSION",


### PR DESCRIPTION
## Summary
- Add `WIKI.md` to `files` array in package.json so it's included in the npm tarball
- Without this, `--obsidian` flag fails because WIKI.md is missing from the published package

## Test plan
- [x] `npm pack --dry-run` confirms WIKI.md is in tarball