### PR TITLE
chore: add CODEOWNERS for critical file protection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Critical kit files — require owner approval for changes
+CLAUDE.md @tansuasici
+WIKI.md @tansuasici
+install.sh @tansuasici
+uninstall.sh @tansuasici
+package.json @tansuasici
+.claude/ @tansuasici
+.github/ @tansuasici


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` requiring @tansuasici approval for changes to critical files
- Protects: CLAUDE.md, WIKI.md, install.sh, uninstall.sh, package.json, .claude/, .github/