### PR TITLE
fix: remove editor-specific branding from wiki module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-* add optional Obsidian knowledge wiki module ([0392138](https://github.com/tansuasici/claude-code-kit/commit/0392138f380b992825a95452cf99c4dbcf8081cc))
-* add optional Obsidian knowledge wiki module (--obsidian) ([50d9feb](https://github.com/tansuasici/claude-code-kit/commit/50d9febc42e28171f760f4a6137f23839e58d4d5))
+* add optional knowledge wiki module (--wiki) ([0392138](https://github.com/tansuasici/claude-code-kit/commit/0392138f380b992825a95452cf99c4dbcf8081cc))
 
 
 ### Bug Fixes

--- a/WIKI.md
+++ b/WIKI.md
@@ -1,6 +1,6 @@
 # WIKI.md — Knowledge Wiki Schema
 
-This file configures Claude as a wiki maintainer for your Obsidian vault.
+This file configures Claude as a wiki maintainer for your knowledge vault.
 When this file exists, Claude follows the ingest, query, and lint workflows below.
 
 ---

--- a/install.sh
+++ b/install.sh
@@ -889,7 +889,7 @@ else
   warn "Skipped .claude/settings.json (already exists)"
 fi
 
-# --- Obsidian wiki module (optional) ---
+# --- Knowledge wiki module (optional) ---
 if [ "$WIKI" = true ] && [ "$PROFILE" != "minimal" ]; then
   # Copy WIKI.md schema
   manifest_add "WIKI.md"
@@ -1020,7 +1020,7 @@ else
     echo "  - Run /wiki-ingest to process them into the wiki"
     echo "  - Run /wiki-briefing for a daily summary"
     echo "  - Run /wiki-lint for periodic health checks"
-    echo "  - Open the project folder in Obsidian to browse the wiki"
+    echo "  - Open the project folder in your markdown editor to browse the wiki"
   fi
 fi
 echo ""

--- a/wiki-module/.claude/skills/wiki-ingest/SKILL.md
+++ b/wiki-module/.claude/skills/wiki-ingest/SKILL.md
@@ -13,7 +13,7 @@ Invoke with `/wiki-ingest` when:
 - A new file has been added to `raw-sources/`
 - You want to process an article, transcript, PDF, or notes into the wiki
 - You're batch-ingesting multiple sources
-- You've clipped a web article with Obsidian Web Clipper
+- You've clipped a web article or saved a source file
 
 ## Process
 


### PR DESCRIPTION
Remove all Obsidian references — wiki module is editor-agnostic.