### PR TITLE
feat: add deepening-review and interface-design skills

### DIFF
--- a/.claude/skills/architecture-review/SKILL.md
+++ b/.claude/skills/architecture-review/SKILL.md
@@ -138,3 +138,11 @@ Evaluate growth readiness:
 - This review focuses on structural architecture, not code-level quality (see `/code-quality-audit`)
 - For small projects (&lt;5 files), a full architecture review may be overkill — suggest `/code-quality-audit` instead
 - Architectural recommendations should consider the team size and project phase
+
+## Related Skills
+
+This skill applies the **SOLID lens** in *report* mode. For complementary lenses:
+
+- **`/deepening-review`** — Depth/seam paradigm in *interactive* mode. Surfaces shallow modules and grills the chosen one with the user. Uses the vocabulary in `agent_docs/architecture-language.md`. Run this skill for breadth, `/deepening-review` for surgical depth.
+- **`/interface-design`** — Once a deepening candidate is picked (or any new module is being designed), spawns parallel sub-agents producing competing interfaces, then compares.
+- **`/refactoring-guide`** — Sequences the actual changes once a direction is agreed.

--- a/.claude/skills/deepening-review/SKILL.md
+++ b/.claude/skills/deepening-review/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: deepening-review
+description: Surface shallow modules as deepening candidates, then grill the chosen one interactively — depth/seam paradigm. Use for testability and AI-navigability when modules feel pass-through or fragmented.
+user-invocable: true
+---
+
+# Deepening Review
+
+## Kit Context
+
+Before starting this skill, ensure session boot is complete:
+
+1. Read `CODEBASE_MAP.md` for project understanding
+2. Read `CLAUDE.project.md` if it exists for project-specific rules
+3. Read `agent_docs/architecture-language.md` — **required**. This skill uses its vocabulary exactly.
+4. Read `tasks/decisions.md` if it exists — don't re-litigate ADR-resolved decisions.
+
+If `agent_docs/architecture-language.md` hasn't been read in this session, read it now before proceeding.
+
+## When to Use
+
+Invoke with `/deepening-review` when:
+
+- The user wants to improve architecture for testability or AI-navigability
+- A module cluster feels tightly coupled and hard to reason about
+- Tests exist but bugs keep escaping — suggesting tests sit past the wrong seam
+- Onboarding to a codebase and noticing pass-through modules that hide nothing
+- After `/architecture-review` flagged structural issues without suggesting concrete refactors
+
+## When NOT to Use
+
+- For SOLID violations / module health metrics → use `/architecture-review`
+- For specific code smells (long function, feature envy, etc.) → use `/code-quality-audit` then `/refactoring-guide`
+- For unused code → use `/dead-code-audit`
+- For projects under ~5 source files — depth analysis needs surface area
+
+## Paradigm vs `/architecture-review`
+
+| Lens | This skill (`deepening-review`) | `architecture-review` |
+|---|---|---|
+| Vocabulary | Module / Interface / Depth / Seam / Adapter / Leverage / Locality | SOLID, layers, coupling, cohesion |
+| Output mode | Interactive — candidates, grilling loop | Report — structured assessment |
+| Question | *"Where can a shallow module become deep?"* | *"Where are SOLID principles violated?"* |
+| Test angle | The interface is the test surface — replace tests, don't layer | Inject dependencies, abstract behind interfaces |
+
+Run them together for breadth + surgical depth. They don't overlap — they speak different languages on purpose.
+
+## Hard Rules
+
+- Use `architecture-language.md` vocabulary when *classifying* architecture. Don't reach for "service," "component," "API," or "boundary" as substitutes for **module**, **interface**, or **seam** in your reasoning. (Descriptive uses — "Stripe is a third-party service," "across a network boundary" — are fine; what matters is not classifying *your own* parts that way.)
+- Don't propose interfaces in step 2 (Present Candidates). Only candidates. Interfaces come in step 3 (Grilling) or `/interface-design`.
+- Don't flag ADR-resolved decisions as candidates unless the friction is severe enough to warrant reopening the ADR. Mark such candidates explicitly.
+- Apply the **deletion test** to every shallow-looking module before listing it.
+- One adapter = hypothetical seam. Don't propose ports without two real adapters.
+
+## Process
+
+### Phase 1: Explore
+
+Read existing context first:
+
+- `CODEBASE_MAP.md` — module map and conventions
+- `tasks/decisions.md` — past architectural ADRs (don't re-litigate)
+- Any project-specific domain glossary (e.g. `agent_docs/project/domain.md` if it exists)
+
+If domain context files don't exist, proceed silently — don't flag their absence or insist on creating them.
+
+Then walk the codebase. Use the `Agent` tool with `subagent_type=Explore` for organic exploration — don't follow rigid heuristics. Note where you experience friction:
+
+- Where does understanding one concept require bouncing between many small modules?
+- Where are modules **shallow** — interface nearly as complex as the implementation?
+- Where have pure functions been extracted just for testability, while the real bugs hide in how they're called (no **locality**)?
+- Where do tightly-coupled modules leak across their seams?
+- Which parts of the codebase are untested, or hard to test through their current interface?
+
+Apply the **deletion test** to anything you suspect is shallow. A "yes, deletion concentrates complexity meaningfully" is the signal.
+
+### Phase 2: Present Candidates
+
+Present a numbered list of deepening opportunities. For each candidate:
+
+```markdown
+### Candidate N: [Short name using domain language]
+
+**Files**: `path/to/a.ts`, `path/to/b.ts`, `path/to/c.ts`
+
+**Problem**: [Where the shallowness shows. What complexity leaks across the seams now.]
+
+**Solution**: [Plain English: what would be merged, where the new seam goes, what sits behind it.]
+
+**Benefits (locality)**: [What concentrates if we deepen — bug fixes, change surface, knowledge.]
+
+**Benefits (leverage)**: [What callers stop having to know.]
+
+**Test impact**: [What tests survive, what gets deleted, what gets written at the new interface.]
+
+**Dependency category**: [in-process / local-substitutable / remote-but-owned / true-external — see references/dependency-categories.md]
+```
+
+If a candidate contradicts an existing ADR, mark it: *"Contradicts ADR-NNN — but worth reopening because [load-bearing reason]."* Skip theoretical contradictions.
+
+End the list with: **"Which candidate would you like to explore? (or 'all' / 'none')"**
+
+Do **not** propose interfaces in this phase. Naming a deepened module is fine; specifying its method signatures is not.
+
+### Phase 3: Grilling Loop
+
+Once the user picks a candidate, drop into an interactive grilling conversation. Walk the design tree with them.
+
+Detail in [references/grilling-protocol.md](references/grilling-protocol.md). Key points:
+
+- Surface constraints first (what must hold true)
+- Map dependencies to a category (see [references/dependency-categories.md](references/dependency-categories.md))
+- Explore what sits behind the seam
+- Identify which existing tests survive, which get deleted, which get written
+- Side effects happen inline — update domain glossary if a new term emerges; offer ADR if user rejects with a load-bearing reason; invoke `/interface-design` if the user wants to explore alternative interfaces.
+
+### Phase 4: Hand-off
+
+When the grilling settles on a direction:
+
+- Summarize the agreed-upon shape (deepened module, seam location, adapter strategy, test strategy)
+- Write a refactoring task to `tasks/todo.md` using the kit's standard plan template (see `agent_docs/workflow.md`)
+- If the agreed shape requires interface design → suggest `/interface-design` next
+- If the user rejected the candidate with a reason future explorations should respect → write an ADR entry to `tasks/decisions.md`
+
+Do **not** start implementing. Deepening is a multi-file refactor; it goes through Plan First → confirmation → execution per the kit's workflow.
+
+## Output Format
+
+```markdown
+# Deepening Review
+
+## Summary
+[1-2 sentences: how many candidates, what kind of friction dominates.]
+
+## Candidates
+
+### Candidate 1: [name]
+[Files / Problem / Solution / Benefits (locality) / Benefits (leverage) / Test impact / Dependency category]
+
+### Candidate 2: [name]
+[...]
+
+## Out of scope (logged for later)
+- [Issues noticed but not pursued — to tasks/todo.md → ## Not Now]
+
+---
+
+**Which candidate would you like to explore? (or 'all' / 'none')**
+```
+
+After user picks → switch to grilling format (free-form Q&A, see references/grilling-protocol.md).
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "It's clean — every module does one thing" | Shallow modules each doing one thing produce **diffusion of complexity**. The user has to bounce between N tiny files to understand one operation. Locality lost. |
+| "We extracted these for testability" | The pure-function extraction is fine, but if the bugs hide in *how the pure functions are composed* — your test suite tests past the wrong seam. The interface is the test surface. |
+| "It's a port-and-adapters architecture" | Check: how many adapters? One adapter means a hypothetical seam — just indirection. Two means a real seam. |
+| "We can't deepen, the modules are owned by different teams" | Then the seam is correctly placed at a team boundary. Don't deepen across teams; do deepen within. |
+| "Refactoring is too risky" | Deepening that *removes* a shallow layer is one of the safest refactors — fewer abstractions to maintain. The risky one is **deepening the wrong module** by guessing where leverage lives. The grilling loop exists to prevent that. |
+| "The architecture is already documented" | Documentation describes; the deletion test asks if the documentation is *load-bearing*. A module no one would miss isn't deep just because it's named. |
+
+## Notes
+
+- This skill speaks a deliberately narrow vocabulary. If you find yourself reaching for "service," "boundary," or "component" — re-read `agent_docs/architecture-language.md`.
+- Inspired by John Ousterhout (deep modules), Michael Feathers (seams), and the [improve-codebase-architecture](https://github.com/mattpocock/skills/tree/main/improve-codebase-architecture) skill by Matt Pocock.
+- Pairs well with `/interface-design` for the chosen candidate's interface, and `/refactoring-guide` for the tactical execution sequence.

--- a/.claude/skills/deepening-review/references/dependency-categories.md
+++ b/.claude/skills/deepening-review/references/dependency-categories.md
@@ -1,0 +1,121 @@
+# Dependency Categories
+
+When a deepening candidate has external dependencies, the *category* of those dependencies determines how the deepened module gets tested across its seam, and whether a port-and-adapter pattern is justified.
+
+Vocabulary: **Module / Interface / Seam / Adapter**. See [`agent_docs/architecture-language.md`](../../../../agent_docs/architecture-language.md).
+
+---
+
+## Category 1 — In-Process
+
+**Definition**: Pure computation, in-memory state, no I/O, no clock, no randomness.
+
+**Examples**: parsing, validation, formatting, pure business rules, immutable data transformations.
+
+**Deepenable?** Always. Merge the modules, test through the new interface directly. No adapter needed.
+
+**Test strategy**: Direct calls at the deepened module's interface. No mocks, no fakes, no setup. If you find yourself wanting a mock here, the module probably has a hidden Category 2/3/4 dependency you missed.
+
+**Seam**: None at the module's external interface beyond the call signature itself.
+
+---
+
+## Category 2 — Local-Substitutable
+
+**Definition**: Dependencies that have realistic local stand-ins which can run inside the test process.
+
+**Examples**:
+- Postgres → PGLite or `pg-mem` (in-process Postgres)
+- Filesystem → `memfs` (in-memory FS)
+- Redis → `ioredis-mock` or in-memory map
+- Time → injectable clock with a fast-forward fake
+- HTTP server → supertest with the real handler
+
+**Deepenable?** Yes, **if the stand-in is good enough**. "Good enough" means: the stand-in fails for the same reasons the real thing fails. PGLite is good. A naive in-memory mock that doesn't enforce constraints is not.
+
+**Test strategy**: Spin up the stand-in in the test suite. Call the deepened module's interface. The stand-in is part of the test fixture, not part of the module's interface. The module doesn't know it's not talking to the real thing.
+
+**Seam**: **Internal** to the module. The module imports the substitutable resource directly. The seam is at the resource boundary — `pg.connect()` vs `pglite.connect()` — not at the module's external interface.
+
+**When *not* to deepen**: if the stand-in is so different from production that bugs only surface in production. At that point treat it like Category 4.
+
+---
+
+## Category 3 — Remote but Owned (Ports & Adapters)
+
+**Definition**: Your own services across a network boundary. You control both sides.
+
+**Examples**: another microservice you own, an internal HTTP API, a queue you publish to and consume from, a gRPC service in your monorepo.
+
+**Deepenable?** Yes, **with a port at the seam**. The deepened module owns the *logic*; the *transport* is an injected adapter.
+
+**Test strategy**:
+- Define a port (interface) at the seam
+- Production adapter: HTTP/gRPC/queue client
+- Test adapter: in-memory implementation that satisfies the same port
+- Tests use the in-memory adapter; integration tests verify the HTTP adapter against the real remote
+
+**Seam**: **External** — at the module's interface to the outside world.
+
+**Justification check**: at least two adapters (production HTTP + test in-memory) is the minimum. If you only have one, you have a hypothetical seam — just indirection. Don't introduce the port until two adapters are real.
+
+**Recommendation phrasing**: *"Define a port at the seam. Implement an HTTP adapter for production and an in-memory adapter for testing. The logic sits in one deep module even though it's deployed across a network."*
+
+---
+
+## Category 4 — True External (Mock)
+
+**Definition**: Third-party services you don't control. You can't run them locally with full fidelity, and you don't want to during unit tests.
+
+**Examples**: Stripe, Twilio, OpenAI, Auth0, S3 (sometimes), external partners' APIs.
+
+**Deepenable?** Yes, but with discipline. The deepened module takes the external dependency as an injected port; tests provide a mock adapter.
+
+**Test strategy**:
+- Define a port for the external capability you actually use (not the entire third-party API)
+- Production adapter: SDK or HTTP client wrapping the real service
+- Test adapter: hand-written mock with the behaviours your module relies on
+- **Contract test the production adapter** against the real service in a separate, slower test tier — this catches when the third party changes behaviour
+
+**Seam**: **External** — at the module's interface, ideally narrower than the third-party API. Your port should expose only the slice of behaviour you depend on.
+
+**Common mistake**: porting the entire third-party SDK shape. The port should reflect *your domain*, not theirs. "Charge a customer" is a port. `StripeChargeCreateParams` is not.
+
+---
+
+## Mixed Dependencies
+
+A real module often has a mix. Apply the category-by-category rule:
+
+- **Pure logic + Category 1 deps** → merge directly, test through interface
+- **Pure logic + Category 2 deps** → use the stand-in, test through interface
+- **Pure logic + Category 3 deps** → port at the seam, two adapters minimum
+- **Pure logic + Category 4 deps** → port for the *capability you use*, mock + contract test
+- **Multi-category** → categorize each dep, apply each rule. Don't unify everything behind one port "for consistency" — that hides the categorization that matters.
+
+---
+
+## Anti-Patterns
+
+| Anti-pattern | Why it's bad |
+|---|---|
+| **One adapter is enough** | A single adapter behind a port is just indirection. The port costs design effort + a level of redirection in every call. Pay it only when two adapters justify it. |
+| **Mock everything** | Category 1/2 deps don't need mocks. Mocking them produces tests that pass for the wrong reasons. |
+| **Mock nothing** | Category 4 deps in unit tests = slow, flaky, expensive tests. Use the port. |
+| **Port mirrors the third party** | The port should reflect *your* needs, not Stripe's API. A 50-method port is a sign the abstraction is at the wrong level. |
+| **Port at the wrong seam** | If the port sits inside your module's logic instead of at its edge, you've created an internal seam masquerading as an external one. The interface is the test surface — port at the interface, not three layers deep. |
+
+---
+
+## Quick Decision Table
+
+| Dependency | Category | Adapter? | Test strategy |
+|---|---|---|---|
+| Pure compute | 1 | No | Direct |
+| Postgres (with PGLite) | 2 | No (internal seam only) | Stand-in in test fixture |
+| Redis (with mock) | 2 | No | Stand-in |
+| Internal microservice | 3 | Yes — port + 2 adapters | In-memory adapter for unit, HTTP for integration |
+| Stripe / Twilio / OpenAI | 4 | Yes — capability port + mock | Mock for unit, contract test for production adapter |
+| Filesystem | 2 (with `memfs`) | No | Stand-in |
+| Time / clock | 1 or 2 (inject) | No | Fake clock |
+| Random | 1 (inject seed) | No | Deterministic seed |

--- a/.claude/skills/deepening-review/references/grilling-protocol.md
+++ b/.claude/skills/deepening-review/references/grilling-protocol.md
@@ -1,0 +1,162 @@
+# Grilling Protocol
+
+Once the user picks a candidate from the deepening review, drop into an interactive grilling conversation. The goal: walk the design tree together, surface every load-bearing constraint, and arrive at a shape both of you can defend.
+
+This is **not** a question-form-fill exercise. It's a real conversation. Some questions matter for one candidate and not another. Read the situation.
+
+Vocabulary: see [`agent_docs/architecture-language.md`](../../../../agent_docs/architecture-language.md). Keep the discipline.
+
+---
+
+## Stance
+
+- **You are not the architect** — the user is. You're a sparring partner who applies the deletion test and the depth/leverage lens, then yields to their domain knowledge when it's load-bearing.
+- **Press, don't push** — if the user's reason for a constraint is shallow ("we've always done it this way"), keep pressing. If it's deep ("this satisfies SOC 2 control X"), accept and move on.
+- **Stay in scope** — you're grilling *one* candidate. Other candidates' issues are not under discussion here.
+- **No code yet** — this phase ends with a design shape, not an implementation.
+
+---
+
+## The Tree
+
+Walk these branches in roughly this order. Skip branches that don't apply.
+
+### Branch 1: Constraints
+
+Surface what *must* hold true regardless of design choice.
+
+- What invariants must the deepened module preserve?
+- What ordering / consistency / atomicity requirements exist?
+- What latency or throughput floor is non-negotiable?
+- What error modes must be observable to callers? (Not "what errors might happen" — "what must callers be able to react to.")
+- Are there compliance / audit / multi-tenancy constraints that bind the seam location?
+
+If a constraint sounds load-bearing but the user can't articulate *why* — that's a signal to press. "Why this constraint?" → "What breaks if we relax it?" → "Is the breakage real or imagined?"
+
+### Branch 2: Dependencies
+
+Map every dependency to a category from [dependency-categories.md](dependency-categories.md):
+
+- In-process → no adapter needed
+- Local-substitutable → pick the stand-in
+- Remote-but-owned → confirm two adapters (production + test) are justified
+- True external → identify the *capability* you use, not the third-party API
+
+Common surprise: dependencies the user didn't think about. Things like clocks (`Date.now()`), randomness, environment variables, process exit codes, log sinks. These are dependencies even when they look like "just code."
+
+### Branch 3: Behind the Seam
+
+What sits inside the deepened module — and what stays outside?
+
+- Which currently-shallow modules merge into the deep one?
+- What new internal structure (private functions, internal seams) does the deepened module need?
+- What does the module *not* own? (Equally important — depth is not omnipresence.)
+- Is there state? Where does it live? When is it created and destroyed?
+
+The deletion test goes here too: "If we deepen this and call it X, would deleting X concentrate complexity meaningfully? Or is X still a pass-through under a new name?"
+
+### Branch 4: The Interface
+
+What is the smallest **interface** that gives callers maximum **leverage**?
+
+- What entry points does the module expose?
+- What does each entry point owe its callers in terms of invariants, errors, ordering?
+- What configuration does the module need at construction vs. per-call?
+- What does the interface *deliberately* not expose? (Internal seams, implementation choices, dependency identity.)
+
+If the interface starts looking large (5+ methods, complex parameter shapes), that's a signal to either:
+- Split — maybe two deep modules instead of one
+- Or invoke `/interface-design` to compare alternatives
+
+Don't try to converge on a single interface here. A *shape* is enough at this stage.
+
+### Branch 5: Tests
+
+Which tests survive, which get deleted, which get written?
+
+- What tests currently exist at the shallow modules' interfaces? Most will become waste.
+- What new tests get written at the deepened interface? List them in plain English.
+- What scenarios that were previously hard to test become easy at the new interface?
+- What scenarios become *harder* to test? (Honest answer — there's usually at least one.)
+
+The interface is the test surface. If you find a scenario only testable by reaching past the interface, the seam is in the wrong place.
+
+### Branch 6: Trade-offs
+
+Be explicit about what's lost.
+
+- What flexibility is given up? (Some shallow modules exist because they were extension points — losing them might be fine, might not.)
+- What knowledge concentrates in fewer hands? (Locality is good for maintenance, less good for bus factor.)
+- What dependencies between teams or modules does this rearrange?
+- What does this *not* solve? (Adjacent friction the user might mistakenly expect to vanish.)
+
+A direction without a clear trade-off statement is incomplete.
+
+---
+
+## Side Effects
+
+These happen **inline** as the conversation unfolds — don't batch them for the end.
+
+### Domain glossary update
+
+If you find yourself naming the deepened module after a concept that doesn't appear in `CODEBASE_MAP.md`, the project domain glossary, or `agent_docs/project/domain.md`:
+
+> *"This name — `OrderIntake` — isn't in the project's domain vocabulary yet. Should I add it to `[wherever the project keeps domain terms]` so future explorations find it?"*
+
+Add it there before continuing the grilling.
+
+### Term sharpening
+
+If a term comes up that the user uses one way and the codebase uses another way (e.g. "Order" means different things in two places):
+
+> *"You're using `Order` to mean the customer-facing record; the codebase has it pointing at the internal fulfilment row. Do we want to disambiguate before going further?"*
+
+Sharpen now or you'll bake the ambiguity into the deepened module.
+
+### ADR offer
+
+If the user **rejects** the candidate (or a load-bearing branch of it) with a reason that future explorers should respect:
+
+> *"You're rejecting this because [reason]. Want me to record this as an ADR in `tasks/decisions.md` so future architecture reviews don't re-suggest the same thing?"*
+
+Offer the ADR only when the reason is:
+- **Load-bearing** — actually constrains future decisions
+- **Non-obvious** — not something a fresh reader would re-derive
+- **Stable** — the constraint will outlast this sprint
+
+Skip the offer for "not worth it right now" (ephemeral) or "obviously bad idea" (self-evident).
+
+### Interface design hand-off
+
+If the user wants to compare alternative interfaces:
+
+> *"This feels like a `/interface-design` moment — let me spawn parallel sub-agents with different design constraints (minimize / maximize flexibility / common-case / ports & adapters) and bring back competing interfaces. Want me to?"*
+
+If yes → end the grilling, invoke `/interface-design` for the candidate.
+
+---
+
+## Closing the Grilling
+
+The grilling is done when:
+
+- The user can describe the deepened module's shape in 2-3 sentences
+- Dependencies are categorized
+- A test strategy is outlined
+- Trade-offs are explicit
+
+When you sense closure, summarize:
+
+> *"Let me restate the shape we've landed on: [deepened module name] absorbs [list]. Seam at [location], adapter strategy: [strategy]. Tests at [interface]. Trade-off accepted: [trade-off]. Did I get that right?"*
+
+Once the user confirms — write a refactoring task to `tasks/todo.md` using the kit's standard plan template (see `agent_docs/workflow.md`). Do not start implementing — that goes through the kit's normal Plan First → confirmation → execution flow.
+
+---
+
+## What to do when the conversation stalls
+
+- **User keeps deferring** ("let me think about it") → close out with: *"Let's park this. I'll write what we have to `tasks/todo.md` as a parked candidate. You can resume by saying `/deepening-review continue [name]`."*
+- **User pivots to a different candidate** → fine. End this grilling. Restart with the new pick.
+- **User wants to scrap the original candidate** → ask: *"Do you want to scrap entirely, or did we surface a different shape worth pursuing?"* Often grilling produces a *better* candidate than the one we started with.
+- **You realize the candidate was wrong** → say so. *"Pressing on this, I think the deepening is actually [different shape]. Want to pivot?"* Don't pretend the original was right.

--- a/.claude/skills/interface-design/SKILL.md
+++ b/.claude/skills/interface-design/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: interface-design
+description: Design It Twice — spawn 3-4 parallel sub-agents producing radically different interfaces for a module, then compare on depth, locality, and seam placement. Use before committing to a new interface.
+user-invocable: true
+---
+
+# Interface Design
+
+## Kit Context
+
+Before starting:
+
+1. Read `CODEBASE_MAP.md` for project understanding
+2. Read `CLAUDE.project.md` if it exists for project-specific rules
+3. Read `agent_docs/architecture-language.md` — **required**. This skill speaks its vocabulary.
+4. Read `tasks/decisions.md` — don't re-litigate ADR-resolved interface decisions.
+
+If `agent_docs/architecture-language.md` hasn't been read in this session, read it now.
+
+## When to Use
+
+Invoke with `/interface-design <module>` when:
+
+- After `/deepening-review` settles on a deepening candidate and the user wants to see alternative interface shapes before committing
+- A new module is about to be created and the first interface idea feels under-explored
+- An existing interface is being rewritten and "design it once" feels insufficient
+- You catch yourself converging on the first plausible interface — that's exactly when this skill earns its keep
+
+Based on Ousterhout's *"Design It Twice"*: **your first interface idea is unlikely to be the best.** Spawning parallel agents with different constraints produces designs you wouldn't have reached by iterating sequentially on one.
+
+## When NOT to Use
+
+- Trivial modules (a 3-line utility doesn't warrant 3 competing designs)
+- When the interface is dictated by an external contract (HTTP spec, protobuf, third-party SDK shape) — there's nothing to design
+- When the user has already committed to a shape and just wants implementation help
+
+## Hard Rules
+
+- Use `architecture-language.md` vocabulary when *classifying* the module being designed. Don't substitute "service / boundary / component" for **module / seam / interface** in your reasoning or in sub-agent briefs. (Descriptive uses — referring to Stripe as a "third-party service" — are fine.)
+- Spawn at least **3** sub-agents in parallel. Two designs collapse into a binary; three produce real contrast.
+- Each sub-agent must produce a **radically different** design. If two come back similar, re-spawn one with a sharper constraint.
+- The user reads while sub-agents work — don't block.
+- End with an **opinionated** recommendation. Not a menu.
+
+## Process
+
+### Phase 1: Frame the Problem Space
+
+Before spawning sub-agents, write a user-facing brief covering:
+
+- **The module being designed** — name, purpose in domain language
+- **Constraints** — invariants, ordering, error modes any interface must respect
+- **Dependencies** — categorized per [`deepening-review/references/dependency-categories.md`](../deepening-review/references/dependency-categories.md)
+- **Code sketch** — a rough illustrative shape (not a proposal — just enough to ground the constraints)
+- **What the deepened module hides** — the complexity behind the seam
+
+Show this to the user. Don't wait for them to read it — proceed to Phase 2 immediately. The user reads while sub-agents work in parallel.
+
+### Phase 2: Spawn Sub-Agents in Parallel
+
+Use the `Agent` tool. **One message, multiple tool calls** — they must run concurrently.
+
+Each sub-agent gets:
+1. The shared technical brief (file paths, dependency categories, what's behind the seam, vocabulary requirements)
+2. A **different design constraint** that forces radical divergence
+
+Standard four constraints (use 3 if the fourth doesn't apply):
+
+| Agent | Constraint |
+|---|---|
+| **Minimal** | Aim for 1-3 entry points maximum. Maximize leverage per entry point. Anything that can be expressed as a parameter rather than a method, must be. |
+| **Flexible** | Maximize flexibility and extension points. Optimise for use cases not yet imagined. Hooks, middleware, callbacks welcome. |
+| **Common-Case** | Optimise for the *most common* caller. The default case must be trivially callable; advanced cases can require more setup. |
+| **Ports & Adapters** | Design assuming Category 3/4 dependencies. Define ports at the seam. Production adapter and test adapter both real. |
+
+Drop "Ports & Adapters" if dependencies are all Category 1/2. Replace with **State-Machine** (model the module as explicit states + transitions) or **Functional-Core** (push as much as possible into pure functions; thin imperative shell) if either is a better fit for the problem.
+
+Each sub-agent must output:
+
+```markdown
+## Interface
+[Types, methods, parameters — plus invariants, ordering, error modes, configuration]
+
+## Usage Example
+[Realistic code showing how a caller uses it]
+
+## What's Behind the Seam
+[What the implementation hides — including internal seams not exposed by the interface]
+
+## Dependency Strategy
+[Per-dependency: category + adapter strategy if applicable]
+
+## Trade-offs
+[Where leverage is high. Where it's thin. What's deliberately hard.]
+```
+
+### Phase 3: Present and Compare
+
+Don't dump three designs at once. **Present them sequentially** so the user can absorb each one:
+
+```markdown
+## Design 1 — [Constraint name]
+[Sub-agent's output, lightly cleaned for formatting]
+
+## Design 2 — [Constraint name]
+[...]
+
+## Design 3 — [Constraint name]
+[...]
+```
+
+Then compare in prose along three axes:
+
+- **Depth** — leverage at the interface. Which design lets callers do the most per unit of interface they have to learn?
+- **Locality** — where change concentrates. Which design means a typical change touches the fewest files?
+- **Seam placement** — where the interface lives. Which design puts the seam where it actually needs to vary?
+
+The comparison is structured but the verdict is editorial. Don't hide behind "it depends."
+
+### Phase 4: Recommend
+
+Give your own pick. Be opinionated.
+
+```markdown
+## Recommendation
+
+**Pick: Design N**
+
+Reasoning:
+- [Why this design wins on the axis that matters most for *this* module]
+- [What you accept losing by not picking the others]
+- [What hybrid elements (if any) are worth borrowing from rejected designs]
+
+If the user disagrees with the choice of axis, the verdict can flip — call that out:
+*"If [different priority] is actually the most important constraint, Design M wins instead."*
+```
+
+If two designs combine well, **propose a hybrid explicitly** — don't just say "could be combined." Sketch the merge.
+
+### Phase 5: Hand-off
+
+Once the user picks (your recommendation or otherwise):
+
+- Write the chosen interface to `tasks/todo.md` as the planned shape
+- If this came from `/deepening-review` — update the deepening task with the chosen interface
+- If the rejected designs surface load-bearing reasons not to take them — offer ADRs in `tasks/decisions.md`
+
+Implementation goes through the kit's normal Plan First → confirmation → execution flow. This skill ends at "we know the interface."
+
+## Output Format
+
+```markdown
+# Interface Design — [Module Name]
+
+## Problem Space
+[Frame: constraints, dependencies, sketch, what's behind the seam]
+
+[Sub-agents working in parallel...]
+
+## Design 1 — Minimal
+[Output]
+
+## Design 2 — Flexible
+[Output]
+
+## Design 3 — Common-Case
+[Output]
+
+## Comparison
+[Prose comparison: depth / locality / seam placement]
+
+## Recommendation
+[Opinionated pick + reasoning + optional hybrid]
+```
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I already know what the interface should be" | Then `Design It Twice` is exactly when you should run this skill. The cost of three sub-agents is small; the cost of an interface that locks in a worse design is large. |
+| "All three designs converged on the same thing" | Then either the constraints were too narrow or the sub-agent briefs weren't divergent enough. Re-spawn with sharper constraints. |
+| "Let the user pick — they know best" | The user wants a *strong read*, not a menu. They can override your pick, but they need an opinion to push against. |
+| "The interface doesn't matter — implementation does" | The interface is what callers see, what tests exercise, what survives implementation rewrites. It matters more than the implementation. |
+| "I'll just iterate after shipping v1" | Interfaces calcify the moment a second caller depends on them. The cost of changing an interface scales with caller count. Get it right before shipping. |
+
+## Notes
+
+- This skill leans heavily on parallel sub-agent execution. Verify all three are spawned in **one message** with multiple `Agent` tool calls — sequential spawning loses the parallelism that makes this useful.
+- Inspired by John Ousterhout's *A Philosophy of Software Design* (Design It Twice principle) and the [improve-codebase-architecture](https://github.com/mattpocock/skills/tree/main/improve-codebase-architecture) skill by Matt Pocock.
+- Pairs with `/deepening-review` (which finds the candidate) and `/refactoring-guide` (which sequences the implementation).

--- a/.claude/skills/refactoring-guide/SKILL.md
+++ b/.claude/skills/refactoring-guide/SKILL.md
@@ -117,3 +117,11 @@ For each approved refactoring, provide:
 - Always ensure test coverage before refactoring; if tests are missing, write them first
 - Prefer small, incremental refactorings over big-bang rewrites
 - Each refactoring step should be committable and deployable on its own
+
+## Related Skills
+
+This skill is **tactical** — it applies Fowler's catalog to specific code smells. For complementary work at the architectural level:
+
+- **`/deepening-review`** — *Topological* refactoring: identify shallow modules and turn them into deep ones. Different paradigm (depth/seams instead of smell/refactoring), different vocabulary (`agent_docs/architecture-language.md`). Use it before this skill when the friction is module-level rather than code-level.
+- **`/interface-design`** — When a refactoring will reshape an interface significantly, run this skill to compare alternative interface designs in parallel before committing.
+- **`/architecture-review`** — Structural SOLID assessment that often produces inputs for this skill.

--- a/.kit-manifest
+++ b/.kit-manifest
@@ -22,9 +22,11 @@
 .claude/skills/code-quality-audit
 .claude/skills/dead-code-audit
 .claude/skills/debug
+.claude/skills/deepening-review
 .claude/skills/dependency-audit
 .claude/skills/design-review
 .claude/skills/documentation-audit
+.claude/skills/interface-design
 .claude/skills/office-hours
 .claude/skills/performance-audit
 .claude/skills/project-health-report
@@ -40,6 +42,7 @@ CLAUDE.md
 CODEBASE_MAP.md
 DESIGN.md
 VERSION
+agent_docs/architecture-language.md
 agent_docs/conventions.md
 agent_docs/contracts.md
 agent_docs/debugging.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ Read only what's relevant to the current task:
 - Skills guide → `agent_docs/skills.md`
 - Task contracts (completion criteria) → `agent_docs/contracts.md`
 - Prompting & bias awareness → `agent_docs/prompting.md`
+- Architecture language (vocabulary for `/deepening-review` and `/interface-design`) → `agent_docs/architecture-language.md`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ User-invocable audit and guide skills — run with `/skill-name`:
 | `/code-quality-audit` | Audits code smells, error handling, and maintainability |
 | `/performance-audit` | Identifies bottlenecks in startup, rendering, memory, and I/O |
 | `/architecture-review` | Reviews SOLID compliance, module boundaries, and dependencies |
+| `/deepening-review` | Depth/seam paradigm — surfaces shallow modules and grills the chosen one interactively |
+| `/interface-design` | Design It Twice — parallel sub-agents produce competing interfaces, then compare |
 | `/testing-audit` | Audits test coverage, quality, and testing strategy |
 | `/dead-code-audit` | Detects unused functions, dead imports, and orphan files |
 | `/refactoring-guide` | Fowler-based refactoring recommendations with execution plans |
@@ -318,6 +320,7 @@ claude-code-kit/
     skills.md                      #   Skill extraction guide
     contracts.md                   #   Task contract system
     prompting.md                   #   Bias awareness & neutral prompting
+    architecture-language.md       #   Vocabulary for /deepening-review and /interface-design
     project/                       #   Project-specific docs (yours)
   tasks/                           # Session state & tracking
     todo.md, lessons.md, decisions.md, handoff.md
@@ -342,6 +345,8 @@ claude-code-kit/
       code-quality-audit/          # Code smells & error handling audit
       performance-audit/           # Bottleneck & rendering analysis
       architecture-review/         # SOLID & module boundary review
+      deepening-review/            # Depth/seam paradigm — interactive candidate grilling
+      interface-design/            # Design It Twice — parallel competing interfaces
       testing-audit/               # Test coverage & quality audit
       dead-code-audit/             # Unused code detection
       refactoring-guide/           # Fowler-based refactoring plans

--- a/agent_docs/architecture-language.md
+++ b/agent_docs/architecture-language.md
@@ -19,12 +19,12 @@ When discussing *should this module be deeper, where should the seam go, what do
 ### Module
 Anything with an interface and an implementation. Deliberately scale-agnostic — applies equally to a function, class, package, or tier-spanning slice.
 
-_Avoid_: "unit," "component," "service" (each carries paradigm-specific baggage that derails the conversation).
+*Avoid*: "unit," "component," "service" (each carries paradigm-specific baggage that derails the conversation).
 
 ### Interface
 Everything a caller must know to use the module correctly. Includes the type signature, but also invariants, ordering constraints, error modes, required configuration, and performance characteristics.
 
-_Avoid_: "API," "signature" (too narrow — those refer only to the type-level surface).
+*Avoid*: "API," "signature" (too narrow — those refer only to the type-level surface).
 
 ### Implementation
 The code inside a module — its body. Distinct from **Adapter**: a thing can be a small adapter with a large implementation (a Postgres repo) or a large adapter with a small implementation (an in-memory fake). Reach for "adapter" when the seam is the topic; "implementation" otherwise.
@@ -35,7 +35,7 @@ Leverage at the interface — the amount of behaviour a caller (or test) can exe
 ### Seam *(from Michael Feathers)*
 A place where you can alter behaviour without editing in that place. The *location* at which a module's interface lives. Choosing where to put the seam is its own design decision, distinct from what goes behind it.
 
-_Avoid_: "boundary" (overloaded with DDD's bounded context).
+*Avoid*: "boundary" (overloaded with DDD's bounded context).
 
 ### Adapter
 A concrete thing that satisfies an interface at a seam. Describes *role* (what slot it fills), not substance (what's inside).

--- a/agent_docs/architecture-language.md
+++ b/agent_docs/architecture-language.md
@@ -1,0 +1,103 @@
+# Architecture Language
+
+Shared vocabulary for architectural discussions. Used by `deepening-review` and `interface-design`. The point is **terminology discipline** — substituting "service," "API," "boundary," or "component" produces vague suggestions and re-litigates the same ground.
+
+## Scope
+
+This vocabulary governs **module topology** discussions — depth, seams, adapters. It is **not** a replacement for paradigm-specific vocabularies:
+
+- `architecture-review` uses **SOLID** vocabulary (responsibilities, dependencies, layers) — that's a different lens.
+- `code-quality-audit` uses **smell** vocabulary (Fowler) — also different.
+- `refactoring-guide` uses **Fowler's catalog** (Extract Function, Move Method, etc.) — also different.
+
+When discussing *should this module be deeper, where should the seam go, what does the interface owe its callers* — use this vocabulary. When discussing *which SOLID principle is violated* or *which refactoring technique applies* — use the paradigm appropriate to the lens.
+
+---
+
+## Terms
+
+### Module
+Anything with an interface and an implementation. Deliberately scale-agnostic — applies equally to a function, class, package, or tier-spanning slice.
+
+_Avoid_: "unit," "component," "service" (each carries paradigm-specific baggage that derails the conversation).
+
+### Interface
+Everything a caller must know to use the module correctly. Includes the type signature, but also invariants, ordering constraints, error modes, required configuration, and performance characteristics.
+
+_Avoid_: "API," "signature" (too narrow — those refer only to the type-level surface).
+
+### Implementation
+The code inside a module — its body. Distinct from **Adapter**: a thing can be a small adapter with a large implementation (a Postgres repo) or a large adapter with a small implementation (an in-memory fake). Reach for "adapter" when the seam is the topic; "implementation" otherwise.
+
+### Depth
+Leverage at the interface — the amount of behaviour a caller (or test) can exercise per unit of interface they have to learn. A module is **deep** when a large amount of behaviour sits behind a small interface. A module is **shallow** when the interface is nearly as complex as the implementation.
+
+### Seam *(from Michael Feathers)*
+A place where you can alter behaviour without editing in that place. The *location* at which a module's interface lives. Choosing where to put the seam is its own design decision, distinct from what goes behind it.
+
+_Avoid_: "boundary" (overloaded with DDD's bounded context).
+
+### Adapter
+A concrete thing that satisfies an interface at a seam. Describes *role* (what slot it fills), not substance (what's inside).
+
+### Leverage
+What callers get from depth. More capability per unit of interface they have to learn. One implementation pays back across N call sites and M tests.
+
+### Locality
+What maintainers get from depth. Change, bugs, knowledge, and verification concentrate at one place rather than spreading across callers. Fix once, fixed everywhere.
+
+---
+
+## Principles
+
+### Depth is a property of the interface, not the implementation
+A deep module can be internally composed of small, mockable, swappable parts — they just aren't part of the interface. A module can have **internal seams** (private to its implementation, used by its own tests) as well as the **external seam** at its interface.
+
+### The deletion test
+Imagine deleting the module. If complexity vanishes, the module wasn't hiding anything (it was a pass-through). If complexity reappears across N callers, the module was earning its keep. Apply this to anything that looks shallow.
+
+### The interface is the test surface
+Callers and tests cross the same seam. If you want to test *past* the interface, the module is probably the wrong shape. Tests at the interface survive internal refactors; tests past the interface break on every implementation change.
+
+### One adapter means a hypothetical seam. Two adapters means a real one
+Don't introduce a port unless something actually varies across it. A single-adapter seam is just indirection. The typical justification for a real seam: production adapter + test adapter.
+
+### Replace, don't layer (testing)
+When a shallow module is folded into a deep one, the old unit tests on the shallow piece become waste — delete them. Write new tests at the deepened interface. Don't keep both layers of tests "to be safe" — they pull in opposite directions on the next refactor.
+
+---
+
+## Relationships
+
+- A **Module** has exactly one **Interface** (the surface it presents to callers and tests).
+- **Depth** is a property of a **Module**, measured against its **Interface**.
+- A **Seam** is where a **Module**'s **Interface** lives.
+- An **Adapter** sits at a **Seam** and satisfies the **Interface**.
+- **Depth** produces **Leverage** for callers and **Locality** for maintainers.
+
+---
+
+## Rejected framings
+
+These come up often and weaken the conversation. Reject them when they appear:
+
+| Framing | Why it's rejected |
+|---|---|
+| **Depth as ratio of impl-lines to interface-lines** (Ousterhout's original) | Rewards padding the implementation. We use depth-as-leverage instead. |
+| **"Interface" = the TypeScript `interface` keyword** | Too narrow. Interface here includes every fact a caller must know — invariants, ordering, error modes, config. |
+| **"Boundary"** | Overloaded with DDD's bounded context. Say **seam** or **interface**. |
+| **"Service"** | Carries SOA / microservice connotations. Say **module**. |
+| **"Component"** | Carries UI-framework connotations. Say **module**. |
+| **Every interface needs a port and adapter** | One adapter = hypothetical seam. Don't add a port until two adapters are justified. |
+
+---
+
+## Quick reference card
+
+When proposing an architectural change, every sentence should be expressible in these terms:
+
+- "This **module** is **shallow** — its **interface** is nearly as complex as its **implementation**. Apply the **deletion test**: would deleting it concentrate complexity, or just push it onto the N callers?"
+- "Put the **seam** at the **module**'s external **interface**. Two **adapters**: production (HTTP) and test (in-memory). The **deep module** owns the logic; transport is injected."
+- "These tests sit *past* the **interface** — they assert on internal state. Replace them with tests at the **interface** so they survive refactors."
+
+If a sentence is *classifying* parts of the system as "services," "components," or "boundaries" — rewrite it. (Mentioning a third party as "the Stripe service" or referring to "across the network boundary" descriptively is fine. The discipline is about classifying *your own* parts in this skill's vocabulary, not policing every word you use.)


### PR DESCRIPTION
## Summary

Adds two new architecture skills + a shared vocabulary doc, inspired by [Matt Pocock's improve-codebase-architecture](https://github.com/mattpocock/skills/tree/main/improve-codebase-architecture):

- **`/deepening-review`** — depth/seam paradigm in interactive mode. Surfaces shallow modules as candidates, then drops into a grilling loop on the chosen one. Applies the deletion test and the 4-category dependency classification.
- **`/interface-design`** — *Design It Twice*. Spawns 3-4 parallel sub-agents producing competing interfaces (minimal / flexible / common-case / ports-and-adapters), compares on depth/locality/seam placement, ends with an opinionated recommendation.
- **`agent_docs/architecture-language.md`** — shared vocabulary (Module / Interface / Depth / Seam / Adapter / Leverage / Locality) with rejected framings to keep terminology disciplined.

The new skills use a different paradigm from the existing `/architecture-review` (SOLID) and `/refactoring-guide` (Fowler) — depth-as-leverage instead of structural rules. They are cross-linked as complementary lenses, not replacements.

## Files changed

**New:**
- agent_docs/architecture-language.md
- .claude/skills/deepening-review/SKILL.md
- .claude/skills/deepening-review/references/dependency-categories.md
- .claude/skills/deepening-review/references/grilling-protocol.md
- .claude/skills/interface-design/SKILL.md

**Updated:**
- .claude/skills/architecture-review/SKILL.md (cross-link)
- .claude/skills/refactoring-guide/SKILL.md (cross-link)
- CLAUDE.md (Agent Docs list)
- README.md (Skills table + directory tree)
- .kit-manifest

## Test plan

- validate-skills.sh: 162 passed, 0 failed, 0 warnings
- gen-skill-docs.sh: MDX files generated cleanly
- Manual review: vocabulary discipline, internal link paths, cross-links
- CI will run: markdown-lint, link-check, template-validation
- release-please should bump 1.6.3 to 1.7.0 (minor — feat:)

## Companion PR

Web docs sync (meta.json + docsync.config.ts) will follow in a separate PR after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)