### PR TITLE
chore: sync CODEBASE_MAP and AGENTS.md with v1.7.0 skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ Key design principle: CLAUDE.md acts as a **logical directory** — it contains 
 │   ├── skills.md                  # Skill extraction & cleanup
 │   ├── contracts.md               # Task contract system
 │   ├── prompting.md               # Bias awareness & neutral prompting
+│   ├── architecture-language.md   # Vocabulary for /deepening-review and /interface-design
 │   └── project/                   # Project-specific docs (never touched by kit)
 │       ├── mission.md             # Product mission and audience (optional template)
 │       ├── tech-stack.md          # Technology choices with rationale (optional template)
@@ -135,6 +136,8 @@ Key design principle: CLAUDE.md acts as a **logical directory** — it contains 
 │       ├── code-quality-audit/    # Code smells & error handling audit
 │       ├── performance-audit/     # Bottleneck & rendering analysis
 │       ├── architecture-review/   # SOLID & module boundary review
+│       ├── deepening-review/      # Depth/seam paradigm — interactive candidate grilling
+│       ├── interface-design/      # Design It Twice — parallel competing interfaces
 │       ├── testing-audit/         # Test coverage & quality audit
 │       ├── dead-code-audit/       # Unused code detection
 │       ├── refactoring-guide/     # Fowler-based refactoring plans
@@ -150,7 +153,8 @@ Key design principle: CLAUDE.md acts as a **logical directory** — it contains 
 │       └── shape-spec/            # Feature spec folder creation
 │
 ├── bin/                           # npm distribution entry point
-│   └── cli.sh                     # CLI wrapper for npx claude-code-kit
+│   ├── claude-code-kit.js         # Node.js entry point for npx
+│   └── cli.sh                     # Shell CLI implementation
 ├── package.json                   # npm package definition
 │
 ├── scripts/                       # Utility scripts

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -49,6 +49,7 @@ Developers using Claude Code and similar agents often get inconsistent results �
 │   ├── skills.md                  # Skill extraction & cleanup
 │   ├── contracts.md               # Task contract system
 │   ├── prompting.md               # Bias awareness & neutral prompting
+│   ├── architecture-language.md   # Vocabulary for /deepening-review and /interface-design
 │   └── project/                   # Project-specific docs (never touched by kit)
 │       ├── mission.md             # Product mission and audience (optional template)
 │       ├── tech-stack.md          # Technology choices with rationale (optional template)
@@ -92,6 +93,8 @@ Developers using Claude Code and similar agents often get inconsistent results �
 │       ├── code-quality-audit/    # Code smells & error handling audit
 │       ├── performance-audit/     # Bottleneck & rendering analysis
 │       ├── architecture-review/   # SOLID & module boundary review
+│       ├── deepening-review/      # Depth/seam paradigm — interactive candidate grilling
+│       ├── interface-design/      # Design It Twice — parallel competing interfaces
 │       ├── testing-audit/         # Test coverage & quality audit
 │       ├── dead-code-audit/       # Unused code detection
 │       ├── refactoring-guide/     # Fowler-based refactoring plans


### PR DESCRIPTION
## Summary

Follow-up to [#83](https://github.com/tansuasici/claude-code-kit/pull/83) — the directory tree in `CODEBASE_MAP.md` was missing the new pieces shipped in v1.7.0:

- `agent_docs/architecture-language.md` — vocabulary for `/deepening-review` and `/interface-design`
- `.claude/skills/deepening-review/`
- `.claude/skills/interface-design/`

`AGENTS.md` is regenerated from `CODEBASE_MAP.md` via `gen-agents-md.sh`, so refresh both.

## Bonus drift fix

`gen-agents-md.sh` also caught an unrelated stale entry: `bin/claude-code-kit.js` exists in the repo but was never reflected in the directory tree. Picked up automatically.

## Files changed

- `CODEBASE_MAP.md` — manual edit (added 2 skill entries + architecture-language.md)
- `AGENTS.md` — regenerated by `gen-agents-md.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)