### PR TITLE
docs: fix bin/ and scripts/ entries in README directory tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,8 @@ claude-code-kit/
   install.sh                       # One-line setup script
   uninstall.sh                     # Clean removal script
   bin/
-    cli.sh                         # npx CLI entry point
+    claude-code-kit.js             # Node.js entry point for npx
+    cli.sh                         # Shell CLI implementation
   agent_docs/                      # Agent behavior guides
     workflow.md                    #   Planning templates & task lifecycle
     debugging.md                   #   4-step debugging protocol
@@ -325,7 +326,7 @@ claude-code-kit/
   tasks/                           # Session state & tracking
     todo.md, lessons.md, decisions.md, handoff.md
   scripts/                         # Utility scripts
-    doctor.sh, validate.sh, statusline.sh, convert.sh, validate-skills.sh, build-skills.sh, gen-agents-md.sh
+    doctor.sh, validate.sh, statusline.sh, convert.sh, validate-skills.sh, build-skills.sh, gen-skill-docs.sh, gen-agents-md.sh
   # --- Optional: Knowledge Wiki (--wiki) ---
   WIKI.md                          # Wiki schema & conventions
   raw-sources/                     # Immutable source documents (yours)


### PR DESCRIPTION
## Summary

Audit caught two filesystem-vs-tree drifts in `README.md`:

1. **`bin/`** listed only `cli.sh`, but `bin/claude-code-kit.js` (the Node entry point used by npx) has been in the repo for several releases without ever appearing in the tree. AGENTS.md regen flagged this on PR #85; README missed the same fix.
2. **`scripts/`** inline summary listed 7 of 8 scripts — `gen-skill-docs.sh` was missing. The full Scripts table further down already had it, so this was a pure copy-paste drift.

## Cross-check (everything else accurate)

| Section | Filesystem | README | Status |
|---|---|---|---|
| Hooks | 12 `.sh` files | 12 in table | ✓ |
| Agents | 5 `.md` files | 6 (5 base + wiki-maintainer) | ✓ |
| Skills | 20 dirs (excl. \_shared/_templates) | 23 (20 + 3 wiki-*) | ✓ |
| Scripts table | 8 files | 8 in table | ✓ |
| Scripts inline | 8 files | 7 → **fixed to 8** | now ✓ |
| bin/ | 2 files | 1 → **fixed to 2** | now ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)