### PR TITLE
fix: remove exports/ phantom dir, sync data flow with tiered boot, complete manifest

### DIFF
--- a/.kit-manifest
+++ b/.kit-manifest
@@ -55,6 +55,7 @@ agent_docs/workflow.md
 scripts/build-skills.sh
 scripts/convert.sh
 scripts/doctor.sh
+scripts/gen-agents-md.sh
 scripts/gen-skill-docs.sh
 scripts/statusline.sh
 scripts/validate-skills.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,16 +161,11 @@ Key design principle: CLAUDE.md acts as a **logical directory** — it contains 
 │   ├── validate.sh                # Validates CODEBASE_MAP completeness
 │   ├── statusline.sh              # Terminal status line
 │   ├── doctor.sh                  # Installation health checker
-│   ├── convert.sh                 # Export agents to Cursor/Windsurf/Aider formats
+│   ├── convert.sh                 # Export agents to Cursor/Windsurf/Aider formats (writes to chosen output dir)
 │   ├── validate-skills.sh         # Validates skill directory structure
 │   ├── gen-skill-docs.sh          # Generates web MDX docs from SKILL.md files
 │   ├── gen-agents-md.sh           # Generates cross-tool AGENTS.md from kit sources
 │   └── build-skills.sh            # Builds SKILL.md from .tmpl templates + shared blocks
-│
-├── exports/                       # Agent format exports
-│   ├── cursor/                    # Cursor editor format
-│   ├── windsurf/                  # Windsurf editor format
-│   └── aider/                     # Aider format
 │
 └── examples/                      # Stack-specific templates
     ├── nextjs/                    # Next.js 16 + App Router

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -118,16 +118,11 @@ Developers using Claude Code and similar agents often get inconsistent results �
 │   ├── validate.sh                # Validates CODEBASE_MAP completeness
 │   ├── statusline.sh              # Terminal status line
 │   ├── doctor.sh                  # Installation health checker
-│   ├── convert.sh                 # Export agents to Cursor/Windsurf/Aider formats
+│   ├── convert.sh                 # Export agents to Cursor/Windsurf/Aider formats (writes to chosen output dir)
 │   ├── validate-skills.sh         # Validates skill directory structure
 │   ├── gen-skill-docs.sh          # Generates web MDX docs from SKILL.md files
 │   ├── gen-agents-md.sh           # Generates cross-tool AGENTS.md from kit sources
 │   └── build-skills.sh            # Builds SKILL.md from .tmpl templates + shared blocks
-│
-├── exports/                       # Agent format exports
-│   ├── cursor/                    # Cursor editor format
-│   ├── windsurf/                  # Windsurf editor format
-│   └── aider/                     # Aider format
 │
 └── examples/                      # Stack-specific templates
     ├── nextjs/                    # Next.js 16 + App Router
@@ -144,6 +139,7 @@ Developers using Claude Code and similar agents often get inconsistent results �
 | `agent_docs/workflow.md` | Task lifecycle, research/implementation split, session strategy |
 | `agent_docs/contracts.md` | Task contract system for deterministic completion |
 | `agent_docs/prompting.md` | Sycophancy awareness and neutral prompting |
+| `agent_docs/architecture-language.md` | Shared vocabulary for `/deepening-review` and `/interface-design` |
 | `tasks/lessons.md` | Accumulated corrections — reviewed every session |
 | `CLAUDE.project.md` | Project overlay — project-specific rules that survive kit upgrades |
 | `.kit-manifest` | Tracks which files are kit-managed vs. project-owned |
@@ -170,28 +166,40 @@ Key design principle: CLAUDE.md acts as a **logical directory** — it contains 
 ## Data Flow
 
 ```text
-Session Start
-  → CLAUDE.md (read always, kit base rules)
-  → CLAUDE.project.md (read always if exists, project-specific overrides)
-  → CODEBASE_MAP.md (read always)
-  → tasks/lessons.md (read always)
-  → tasks/decisions.md (read always if exists)
-  → tasks/handoff-*.md (read latest if exists)
-  → agent_docs/{relevant}.md (read conditionally per task type)
-  → agent_docs/project/{relevant}.md (read conditionally, project-specific)
-  → .claude/skills/ (loaded automatically via semantic matching)
+Session Start (Tiered — see CLAUDE.md "Session Boot")
+  Tier 1 — Always:
+    → CLAUDE.md (kit base rules; read implicitly by Claude Code)
+    → CODEBASE_MAP.md
+    → CLAUDE.project.md (if exists, project-specific overrides)
+
+  Tier 2 — If continuing interrupted work:
+    → tasks/handoff-*.md (latest, only if one exists)
+    → tasks/todo.md (only if active tasks)
+
+  Tier 3 — On demand:
+    → tasks/lessons.md "## Top Rules" section (first 15 lines) when relevant
+    → tasks/lessons.md (full) only when decisions could repeat past mistakes
+    → tasks/decisions.md only when facing architectural choices
+    → agent_docs/{relevant}.md per task type (workflow, debugging, testing, etc.)
+    → agent_docs/project/{relevant}.md project-specific
+    → .claude/skills/ loaded automatically via semantic matching
 
 During Work
-  → .claude/hooks/ (execute deterministically on every tool call)
-  → .claude/hooks/project/ (project-specific hooks, same lifecycle)
-  → tasks/todo.md (updated as tasks progress)
+  → .claude/hooks/ execute deterministically on every tool call
+  → .claude/hooks/project/ project-specific hooks (same lifecycle)
+  → tasks/todo.md updated as tasks progress
+
+After Compaction (mid-session context loss)
+  → Re-read tasks/todo.md
+  → Re-read files actively being edited
+  → Re-read tasks/lessons.md "## Top Rules" only
 
 Session End
-  → tasks/handoff-{date}.md (generated if mid-work)
-  → tasks/lessons.md (updated if user corrected agent)
+  → tasks/handoff-{date}.md generated if mid-work
+  → tasks/lessons.md updated if user corrected agent
 
 Upgrade (install.sh --upgrade)
-  → .kit-manifest (read to identify kit-managed files)
+  → .kit-manifest read to identify kit-managed files
   → Kit files updated, project overlay files skipped
 ```
 


### PR DESCRIPTION
## Summary

Three drift fixes the v1.7.1 audit caught.

### 1. Remove `exports/` phantom directory

\`CODEBASE_MAP.md\` and \`AGENTS.md\` (auto-generated from CODEBASE_MAP) both listed an \`exports/\` directory with \`cursor/\`, \`windsurf/\`, and \`aider/\` subdirs. The directory **does not exist on disk** — \`convert.sh\` writes exports to a chosen output dir at call time, not to a permanent repo directory.

Removed the phantom block and clarified \`convert.sh\`'s description so AGENTS.md (Linux Foundation cross-tool standard) stops emitting misleading info.

### 2. Update Data Flow to reflect tiered session boot

\`CODEBASE_MAP\`'s Data Flow described the pre-1.5.0 boot model (read everything at session start). \`CLAUDE.md\` migrated to a tiered boot earlier (Tier 1 project awareness, Tier 2 continuing work, Tier 3 on-demand).

Two docs were describing two different boot models — confusing for a fresh agent. Rewrote Data Flow to mirror \`CLAUDE.md\`'s tiered scheme exactly, plus the After-Compaction recovery path.

### 3. Add \`gen-agents-md.sh\` to \`.kit-manifest\`

Script existed in \`scripts/\` since 1.5.0 but was never tracked by \`.kit-manifest\`, so \`install.sh --upgrade\` silently skipped it. Added alphabetically between \`gen-skill-docs.sh\` and \`statusline.sh\`.

### 4. Add \`agent_docs/architecture-language.md\` to Critical Files

Vocabulary doc shipped in 1.7.0 was not in CODEBASE_MAP's Critical Files table even though \`/deepening-review\` and \`/interface-design\` both list it as required reading.

## Files

- \`CODEBASE_MAP.md\` — exports/ block removed, Data Flow rewritten, Critical Files row added
- \`AGENTS.md\` — regenerated via \`gen-agents-md.sh\`
- \`.kit-manifest\` — gen-agents-md.sh added

## Release impact

\`fix:\` prefix → release-please opens 1.7.1 → 1.7.2 patch release PR after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)