### PR TITLE
fix: switch repos to squash-only merge to stop CHANGELOG duplicates

### DIFF
--- a/agent_docs/conventions.md
+++ b/agent_docs/conventions.md
@@ -100,6 +100,14 @@ chore/short-description
 - Don't commit: `.env`, `node_modules`, build artifacts, IDE configs, OS files
 - Don't commit broken code to main (even as WIP)
 
+### Merging Pull Requests
+
+- **Use squash merge only** (`gh pr merge --squash`).
+- Merge commits with `--merge` produce a synthesized merge commit whose body inherits the feature branch's HEAD subject. release-please then sees both the original commit AND the merge commit as separate `feat:`/`fix:` entries — every PR shows up twice in the changelog.
+- Squash merging produces one commit on `main` with the PR title as subject. release-please records one entry. Linear history.
+- Rebase merge avoids the duplicate problem too but pollutes `main` with the branch's intermediate commits.
+- Both `claude-code-kit` and `claude-code-kit-web` are configured GitHub-side to accept squash only — the other strategies are disabled at repo level.
+
 ---
 
 ## Code Review Expectations

--- a/tasks/decisions.md
+++ b/tasks/decisions.md
@@ -36,3 +36,18 @@ Track important technical decisions here so they don't get lost between sessions
 ---
 
 <!-- Add new decisions below this line -->
+
+### ADR-002: Squash-only merge for kit and web repos
+- **Date**: 2026-04-26
+- **Status**: accepted
+- **Context**: Past CHANGELOGs (v1.6.0–v1.7.2) showed every PR's bug-fix line *twice*. Each entry came from (1) the original `fix:`/`feat:` commit on the feature branch and (2) the merge commit GitHub creates on `--merge`, whose body auto-inherits the feature branch's HEAD commit subject. release-please's conventional-commits parser saw both and emitted two entries per PR.
+- **Options**:
+  - A) **Squash merge only** — single commit on `main` with PR title as subject. One changelog entry per PR. Loses intermediate branch commits (acceptable for this repo size).
+  - B) **Rebase merge only** — replays each commit on `main` linearly. No merge commit pollution. But every "fix lint" / "address review" commit ends up in changelog separately.
+  - C) **Keep merge + filter release-please** — config a regex to drop merge commits. Brittle, depends on release-please internals.
+- **Decision**: A (squash only). Disabled `--enable-merge-commit` and `--enable-rebase-merge` at GitHub repo level for both `claude-code-kit` and `claude-code-kit-web` so the wrong strategy can't be selected by mistake.
+- **Consequences**:
+  - Future PRs must be merged with `gh pr merge --squash` (the only option GitHub now exposes).
+  - release-please will produce one changelog entry per PR.
+  - Past v1.6.x / 1.7.x duplicate entries remain — git history is immutable, fixing them isn't worth a force-push.
+  - Documented in `agent_docs/conventions.md` under "Merging Pull Requests".


### PR DESCRIPTION
## Why every release shows duplicate fix lines

Look at v1.7.2's changelog entry on GitHub Releases:

> **Bug Fixes**
> - remove exports/ phantom dir, sync data flow with tiered boot, complete manifest (\`451bfde\`)
> - remove exports/ phantom dir, sync data flow with tiered boot, complete manifest (\`375d1fc\`)

Same line, twice. This pattern repeats for every release since at least v1.6.0.

**Root cause:**
- \`375d1fc\` = the actual \`fix:\` commit on the feature branch
- \`451bfde\` = the merge commit GitHub creates on \`gh pr merge --merge\`. Its body auto-inherits the feature branch HEAD's subject (\`fix: remove exports/ phantom dir...\`).

release-please's conventional-commits parser scans both, finds \`fix:\` in both, emits both.

## Fix

**At repo level** (already applied):

\`\`\`bash
gh repo edit tansuasici/claude-code-kit --enable-merge-commit=false --enable-rebase-merge=false
gh repo edit tansuasici/claude-code-kit-web --enable-merge-commit=false --enable-rebase-merge=false
\`\`\`

Squash is now the only option in the merge UI. The wrong strategy can't be selected by mistake.

**Documented** in this PR:
- \`agent_docs/conventions.md\` — new "Merging Pull Requests" subsection explaining what to use and why
- \`tasks/decisions.md\` — ADR-002 recording options A/B/C considered and why squash won

## Past entries

v1.6.0 through v1.7.2 will keep their duplicate entries. Git history is immutable; force-pushing CHANGELOG to clean cosmetic noise isn't worth it.

## Self-test for this PR

This PR is a \`fix:\` commit. When merged via squash (the only option now), it should appear **once** in v1.7.3's changelog — not twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)