### PR TITLE
feat: auto-publish to npm on release-please tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,3 +135,39 @@ jobs:
           report_status "Markdown Lint" "$ML_RESULT"
           report_status "Link Check" "$LC_RESULT"
           report_status "Template Validation" "$TV_RESULT"
+
+  # Auto-publish to npm whenever release-please cuts a new release.
+  # Requires NPM_TOKEN secret (https://www.npmjs.com/settings/<user>/tokens
+  # → Granular Access Token, scope to @tansuasici/claude-code-kit, write).
+  publish-npm:
+    name: Publish to npm
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # for npm provenance
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Verify version matches tag
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG="${{ needs.release-please.outputs.version }}"
+          if [ "$PKG_VERSION" != "$TAG" ]; then
+            echo "ERROR: package.json version ($PKG_VERSION) does not match release tag ($TAG)"
+            exit 1
+          fi
+          echo "Publishing $PKG_VERSION..."
+
+      - name: Publish
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Closes the gap where npm version (1.6.3) trails local kit (1.7.3) by four releases. After this lands, every release-please tag auto-publishes.

## Workflow change

New job \`publish-npm\` in \`.github/workflows/release.yml\`:
- Triggers on \`needs.release-please.outputs.release_created == 'true'\`
- Checks out the tagged commit
- Verifies package.json version matches the tag (sanity check)
- \`npm publish --access public --provenance\`

## One-time manual steps

1. Generate npm Granular Access Token scoped to \`@tansuasici/claude-code-kit\` (write)
2. Add as \`NPM_TOKEN\` repo secret
3. Run \`cd kit && npm publish --access public\` once locally to catch 1.7.3 up

After that, every future feat/fix release auto-publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)