### PR TITLE
feat: add HTML artifacts module (--html flag)

### DIFF
--- a/ARTIFACTS.md
+++ b/ARTIFACTS.md
@@ -1,0 +1,131 @@
+---
+title: HTML Artifact Conventions
+type: schema
+---
+
+# ARTIFACTS.md — HTML Artifact Conventions
+
+This file configures Claude to produce HTML artifacts — not markdown — for specs,
+reports, PR explainers, design prototypes, and custom editors. When this file
+exists, Claude follows the directory layout, naming, and patterns below.
+
+Background: HTML carries far more signal than markdown (tables, CSS, SVG,
+interactions, copy-as-prompt buttons) and is easier to share. With 1MB context
+windows the extra tokens are noise. Markdown stays for files you edit by hand;
+HTML takes over for files you only read.
+
+---
+
+## When HTML, when Markdown
+
+Prefer **HTML** when one or more is true:
+
+- Output will exceed ~100 lines (nobody reads a long markdown plan)
+- The reader is someone other than you (sharing matters)
+- The content benefits from layout, color, diagrams, side-by-side comparison
+- Two-way interaction would help (sliders, knobs, "copy filled prompt" buttons)
+- You want SVG flowcharts, not ASCII
+
+Keep **markdown** for: `tasks/lessons.md`, `tasks/decisions.md`, `tasks/todo.md`,
+`tasks/handoff-*.md`, ADRs, short notes — anything edited by hand or grepped.
+
+---
+
+## Directory
+
+```text
+artifacts/
+  index.html            # Catalog — links to every artifact, kept current
+  design-system.html    # Reference tokens (colors, type, spacing) — Claude mirrors this
+  YYYY-MM-DD-<slug>.html  # Generated artifacts
+```
+
+---
+
+## Conventions
+
+- File names: date prefix + kebab-case slug → `2026-05-11-onboarding-spec.html`
+- Every artifact mirrors `design-system.html`'s tokens (read it before generating)
+- After creating an artifact, append a row to `index.html` with title, date, type, link
+- **Standalone files** — embed CSS and JS inline. No external deps, no build step.
+  An artifact must work when uploaded to S3 and opened by a colleague.
+- Use inline SVG for diagrams, never ASCII
+
+---
+
+## Artifact Types
+
+| Type          | Use for                                       | Key elements                                       |
+|---------------|-----------------------------------------------|----------------------------------------------------|
+| `spec`        | Implementation plan, design exploration       | Mockups, code snippets, tradeoff tables, N-up grid |
+| `pr-explain`  | PR or code review writeup                     | Diff blocks, inline annotations, severity colors   |
+| `report`      | Research, weekly recap, incident, deep-dive   | SVG diagrams, sections, summary box                |
+| `design`      | Component prototype, animation tuning         | Sliders/knobs, live preview, copy-params button    |
+| `editor`      | Throwaway data editor (triage, config, prompt)| Copy-as-JSON / Copy-as-prompt export button        |
+
+---
+
+## Two-way Interaction
+
+When an artifact accepts input, it **must** include an export button so the
+user's work returns to Claude Code as paste-able text:
+
+| Artifact          | Required button                                |
+|-------------------|------------------------------------------------|
+| Editor (any kind) | `Copy as JSON` or `Copy as markdown`           |
+| Design tuner      | `Copy params` (JSON blob of slider values)     |
+| Prompt playground | `Copy filled prompt`                           |
+| Triage/reorder    | `Copy as ordered list`                         |
+
+Implementation: a single button → `navigator.clipboard.writeText(JSON.stringify(state))`.
+No frameworks needed.
+
+---
+
+## Sharing
+
+To share externally: upload the file to S3/CDN and send the link. Since every
+artifact is standalone, no build pipeline is required.
+
+For local viewing: `open artifacts/<file>.html` (macOS) opens it in the default
+browser. Claude can run this for you.
+
+---
+
+## Anti-patterns
+
+- **No generic `/html` skill** — let the prompt's intent drive the artifact type
+- **No multi-file artifacts** — one file, one purpose, one open-in-browser action
+- **No build tooling** — no React, no bundlers, no npm install
+- **No reusing a 500-line boilerplate** — start from the prompt, not a template
+- **No omitting `design-system.html`** — artifacts will drift in style otherwise
+- **No mixing tasks/ into artifacts/** — tasks/ stays markdown (edited by hand)
+
+---
+
+## Index Maintenance
+
+After creating any artifact, update `artifacts/index.html`:
+
+1. Add a row to the catalog table: date | type | title | link | one-line purpose
+2. Keep newest entries at the top
+3. If an artifact is superseded by a newer version, mark the old row as
+   superseded (don't delete — history matters)
+
+If `index.html` is missing or stale, regenerate it from the `artifacts/*.html`
+files on disk (read each file's `<title>` and `<meta name="artifact-*">` tags).
+
+---
+
+## Artifact Metadata
+
+Every artifact should declare itself in `<head>`:
+
+```html
+<title>Onboarding Screen Spec — 2026-05-11</title>
+<meta name="artifact-type" content="spec">
+<meta name="artifact-date" content="2026-05-11">
+<meta name="artifact-purpose" content="Compare 6 onboarding layouts">
+```
+
+This makes `index.html` regeneration trivial.

--- a/ARTIFACTS.md
+++ b/ARTIFACTS.md
@@ -1,8 +1,3 @@
----
-title: HTML Artifact Conventions
-type: schema
----
-
 # ARTIFACTS.md — HTML Artifact Conventions
 
 This file configures Claude to produce HTML artifacts — not markdown — for specs,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,11 @@ If `WIKI.md` exists, read it before knowledge work. Follow its ingest, query, an
 
 ---
 
+## HTML Artifacts
+If `ARTIFACTS.md` exists, read it before producing any spec, plan, report, PR writeup, design prototype, or custom editor. Default to HTML output (not markdown) for those use cases — store under `artifacts/`, mirror tokens from `artifacts/design-system.html`, and append a row to `artifacts/index.html` after creating any artifact. Markdown stays for `tasks/` and other hand-edited files.
+
+---
+
 ## Product Context
 If `agent_docs/project/mission.md` exists, read it for product context before feature work.
 If `agent_docs/project/tech-stack.md` exists, read it before technology choices.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Then fill in `CODEBASE_MAP.md` with your project's details and start a Claude Co
 | `--diff` | Compare local installation against latest kit (read-only) |
 | `--gitignore` | Add kit files to `.gitignore` (keep kit local, don't push to repo) |
 | `--wiki` | Add knowledge wiki module (personal knowledge base) |
+| `--html` | Add HTML artifacts module (specs, reports, PR writeups as HTML — see `ARTIFACTS.md`) |
 | `--version v1.0.0` | Install a specific version instead of latest |
 
 ### Uninstall
@@ -68,6 +69,7 @@ Examples:
 npx @tansuasici/claude-code-kit init --template nextjs
 npx @tansuasici/claude-code-kit init --profile strict
 npx @tansuasici/claude-code-kit init --wiki
+npx @tansuasici/claude-code-kit init --html
 npx @tansuasici/claude-code-kit init --upgrade
 
 # Or with curl
@@ -287,6 +289,8 @@ sonnet-4.5 | feat/search | ████████░░ 78% | $1.24
 
 **Knowledge Wiki** — Optional knowledge wiki module (install with `--wiki`). Based on Andrej Karpathy's LLM Wiki pattern: Claude incrementally builds and maintains a persistent, interlinked wiki from raw sources. Three operations: `/wiki-ingest` processes new sources into the wiki, `/wiki-lint` health-checks for contradictions and orphans, `/wiki-briefing` gives you a daily summary. The wiki compounds — every source you add makes it smarter.
 
+**HTML Artifacts** — Optional module (install with `--html`). Based on the Claude Code team's pattern of preferring HTML output over markdown for specs, plans, PR writeups, reports, and design prototypes — richer information (SVG, tables, code, interactions), easier to share (upload + link), and easier to read for anyone outside your terminal. The kit ships `ARTIFACTS.md` (conventions) and a `design-system.html` reference so every generated artifact stays on-brand. Deliberately ships *without* a `/html` skill — the original recommendation is to just prompt for HTML, not to over-structure it.
+
 **Product Context** — Optional templates in `agent_docs/project/` (mission.md, tech-stack.md, roadmap.md) give agents product awareness beyond code conventions.
 
 **Permissions** — `.claude/settings.json` includes curated allow/deny lists. Allowed: test runners, linters, git reads. Denied: `curl`, `wget`, `.env` reads, `npm publish`. Review and customize for your project.
@@ -333,6 +337,11 @@ claude-code-kit/
   wiki/                            # Claude-maintained knowledge base
     index.md, log.md               # Navigation & activity log
     summaries/, entities/, concepts/ # Wiki page directories
+  # --- Optional: HTML Artifacts (--html) ---
+  ARTIFACTS.md                     # HTML artifact conventions & schema
+  artifacts/                       # Generated HTML artifacts
+    design-system.html             # Reference tokens — every artifact mirrors these
+    index.html                     # Catalog of all artifacts
   .claude/
     settings.json                  # Hook configs & permissions
     agents/                        # code-reviewer, security-reviewer, planner, qa-reviewer, dead-code-remover, wiki-maintainer

--- a/html-module/templates/design-system.html
+++ b/html-module/templates/design-system.html
@@ -1,0 +1,353 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Design System Reference — Claude Code Kit Artifacts</title>
+<meta name="artifact-type" content="reference">
+<meta name="artifact-purpose" content="Token + component reference. Every other artifact should mirror these tokens.">
+<!--
+  This file is the visual contract for every HTML artifact in artifacts/.
+
+  Claude: when generating any new artifact, read this file first and reuse:
+    - The :root CSS custom properties (colors, type scale, spacing, radius, shadow)
+    - The component patterns below (buttons, cards, tables, code blocks, SVG style)
+
+  Replace the tokens below with your project's actual taste — this file is meant
+  to be edited. Keep the shape stable; change the values.
+-->
+<style>
+  :root {
+    /* Color tokens — replace with your brand */
+    --bg:           #fbfaf7;
+    --surface:      #ffffff;
+    --surface-alt:  #f4f1eb;
+    --text:         #18181b;
+    --text-muted:   #6b6b73;
+    --border:       #e4e0d8;
+    --accent:       #0f766e;
+    --accent-soft:  #ccfbf1;
+    --success:      #15803d;
+    --warning:      #b45309;
+    --error:        #b91c1c;
+
+    /* Type scale */
+    --font-sans: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, system-ui, sans-serif;
+    --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    --font-serif: ui-serif, "Iowan Old Style", "Apple Garamond", Georgia, serif;
+
+    --text-xs:  0.75rem;
+    --text-sm:  0.875rem;
+    --text-base:1rem;
+    --text-lg:  1.125rem;
+    --text-xl:  1.375rem;
+    --text-2xl: 1.75rem;
+    --text-3xl: 2.5rem;
+
+    --leading-tight: 1.2;
+    --leading-body:  1.6;
+
+    /* Spacing */
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 0.75rem;
+    --space-4: 1rem;
+    --space-6: 1.5rem;
+    --space-8: 2rem;
+    --space-12: 3rem;
+
+    /* Radius / elevation */
+    --radius-sm: 4px;
+    --radius:    8px;
+    --radius-lg: 14px;
+    --shadow-1:  0 1px 2px rgba(0,0,0,0.04), 0 1px 3px rgba(0,0,0,0.06);
+    --shadow-2:  0 4px 12px rgba(0,0,0,0.08);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg:          #0f1115;
+      --surface:     #161922;
+      --surface-alt: #1f2330;
+      --text:        #e8e6e0;
+      --text-muted:  #9a9ba3;
+      --border:      #2a2f3d;
+      --accent:      #5eead4;
+      --accent-soft: #134e4a;
+      --success:     #4ade80;
+      --warning:     #fbbf24;
+      --error:       #f87171;
+    }
+  }
+
+  * { box-sizing: border-box; }
+  html { font-size: 16px; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--font-sans);
+    font-size: var(--text-base);
+    line-height: var(--leading-body);
+    -webkit-font-smoothing: antialiased;
+  }
+
+  main {
+    max-width: 880px;
+    margin: 0 auto;
+    padding: var(--space-12) var(--space-6);
+  }
+
+  h1, h2, h3, h4 {
+    font-family: var(--font-serif);
+    line-height: var(--leading-tight);
+    color: var(--text);
+    margin: var(--space-8) 0 var(--space-3);
+    letter-spacing: -0.01em;
+  }
+  h1 { font-size: var(--text-3xl); margin-top: 0; }
+  h2 { font-size: var(--text-2xl); border-bottom: 1px solid var(--border); padding-bottom: var(--space-2); }
+  h3 { font-size: var(--text-xl); }
+  h4 { font-size: var(--text-lg); }
+  p  { margin: 0 0 var(--space-4); }
+  small { color: var(--text-muted); font-size: var(--text-sm); }
+
+  a { color: var(--accent); text-decoration: none; border-bottom: 1px solid currentColor; }
+  a:hover { opacity: 0.7; }
+
+  /* Cards */
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: var(--space-6);
+    box-shadow: var(--shadow-1);
+    margin-bottom: var(--space-4);
+  }
+
+  /* Buttons */
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    font: inherit;
+    font-weight: 500;
+    padding: var(--space-2) var(--space-4);
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    transition: transform 0.05s ease, background 0.15s ease;
+  }
+  .btn:hover { background: var(--surface-alt); }
+  .btn:active { transform: translateY(1px); }
+  .btn--primary { background: var(--accent); color: var(--bg); border-color: var(--accent); }
+  .btn--primary:hover { opacity: 0.9; background: var(--accent); }
+  .btn--ghost { background: transparent; border-color: transparent; color: var(--text-muted); }
+
+  /* Tables */
+  table { width: 100%; border-collapse: collapse; margin: var(--space-4) 0; font-size: var(--text-sm); }
+  th, td { text-align: left; padding: var(--space-3); border-bottom: 1px solid var(--border); }
+  th { font-weight: 600; color: var(--text-muted); text-transform: uppercase; font-size: var(--text-xs); letter-spacing: 0.04em; }
+  tr:hover td { background: var(--surface-alt); }
+
+  /* Code */
+  code, pre {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+  }
+  code:not(pre code) {
+    background: var(--surface-alt);
+    padding: 2px 6px;
+    border-radius: var(--radius-sm);
+  }
+  pre {
+    background: var(--surface-alt);
+    padding: var(--space-4);
+    border-radius: var(--radius);
+    overflow-x: auto;
+    border: 1px solid var(--border);
+    line-height: 1.5;
+  }
+
+  /* Badges */
+  .badge {
+    display: inline-block;
+    padding: 2px 10px;
+    border-radius: 999px;
+    font-size: var(--text-xs);
+    font-weight: 500;
+    background: var(--accent-soft);
+    color: var(--accent);
+  }
+  .badge--warn { background: color-mix(in oklab, var(--warning) 18%, transparent); color: var(--warning); }
+  .badge--err  { background: color-mix(in oklab, var(--error) 18%, transparent); color: var(--error); }
+  .badge--ok   { background: color-mix(in oklab, var(--success) 18%, transparent); color: var(--success); }
+
+  /* Swatches */
+  .swatch-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: var(--space-3); }
+  .swatch { padding: var(--space-3); border-radius: var(--radius-sm); border: 1px solid var(--border); }
+  .swatch .chip { width: 100%; height: 56px; border-radius: var(--radius-sm); margin-bottom: var(--space-2); border: 1px solid var(--border); }
+  .swatch code { display: block; font-size: var(--text-xs); color: var(--text-muted); background: none; padding: 0; }
+
+  /* SVG diagram defaults */
+  svg.diagram { display: block; max-width: 100%; height: auto; }
+  svg.diagram .node    { fill: var(--surface); stroke: var(--text); stroke-width: 1.5; }
+  svg.diagram .label   { fill: var(--text); font: 500 14px var(--font-sans); }
+  svg.diagram .edge    { stroke: var(--text-muted); stroke-width: 1.5; fill: none; }
+  svg.diagram .accent  { fill: var(--accent); stroke: var(--accent); }
+
+  /* Layout helpers */
+  .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-4); }
+  @media (max-width: 640px) { .grid-2 { grid-template-columns: 1fr; } }
+
+  /* Sticky footer toolbar (pattern for two-way artifacts) */
+  .toolbar {
+    position: sticky;
+    bottom: var(--space-4);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow-2);
+    padding: var(--space-3) var(--space-4);
+    border-radius: var(--radius);
+    display: flex;
+    gap: var(--space-2);
+    align-items: center;
+    margin-top: var(--space-8);
+  }
+  .toolbar .spacer { flex: 1; }
+  .toolbar .toast { color: var(--success); font-size: var(--text-sm); opacity: 0; transition: opacity 0.2s; }
+  .toolbar .toast.show { opacity: 1; }
+</style>
+</head>
+<body>
+<main>
+
+  <header>
+    <span class="badge">Reference</span>
+    <h1>Design System</h1>
+    <p>Tokens, components, and patterns every artifact in <code>artifacts/</code> should reuse.
+       Edit the <code>:root</code> variables in the <code>&lt;style&gt;</code> block to match your project's taste —
+       the structure below stays the same.</p>
+  </header>
+
+  <h2>Colors</h2>
+  <div class="card">
+    <div class="swatch-grid" id="swatches"></div>
+  </div>
+
+  <h2>Typography</h2>
+  <div class="card">
+    <h1 style="margin-top:0">Display heading</h1>
+    <h2>Section heading</h2>
+    <h3>Subsection heading</h3>
+    <h4>Detail heading</h4>
+    <p>Body copy uses the sans stack at <code>--text-base</code> with <code>--leading-body</code> line height.
+       Reading is more important than density. <a href="#">Inline link</a>, <code>inline code</code>, and
+       <strong>strong</strong> emphasis follow.</p>
+    <small>Muted small text uses <code>--text-muted</code> for secondary information.</small>
+  </div>
+
+  <h2>Buttons</h2>
+  <div class="card">
+    <button class="btn btn--primary">Primary action</button>
+    <button class="btn">Secondary</button>
+    <button class="btn btn--ghost">Ghost</button>
+  </div>
+
+  <h2>Status badges</h2>
+  <div class="card">
+    <span class="badge">default</span>
+    <span class="badge badge--ok">success</span>
+    <span class="badge badge--warn">warning</span>
+    <span class="badge badge--err">error</span>
+  </div>
+
+  <h2>Tables</h2>
+  <div class="card">
+    <table>
+      <thead><tr><th>Type</th><th>Use for</th><th>Status</th></tr></thead>
+      <tbody>
+        <tr><td>spec</td><td>Implementation plan</td><td><span class="badge badge--ok">stable</span></td></tr>
+        <tr><td>pr-explain</td><td>PR review writeup</td><td><span class="badge badge--ok">stable</span></td></tr>
+        <tr><td>design</td><td>Component prototype</td><td><span class="badge badge--warn">draft</span></td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h2>Code</h2>
+  <div class="card">
+<pre><code>function tokens() {
+  return { bg: 'var(--bg)', text: 'var(--text)' };
+}</code></pre>
+  </div>
+
+  <h2>SVG diagrams</h2>
+  <div class="card">
+    <svg class="diagram" viewBox="0 0 480 160" role="img" aria-label="Source to wiki pipeline">
+      <rect class="node" x="20"  y="50" width="120" height="60" rx="8"/>
+      <text class="label" x="80"  y="85" text-anchor="middle">Source</text>
+
+      <path class="edge" d="M140 80 L200 80" marker-end="url(#arrow)"/>
+      <rect class="node accent" x="200" y="50" width="120" height="60" rx="8"/>
+      <text class="label" x="260" y="85" text-anchor="middle" style="fill:var(--bg)">Synthesize</text>
+
+      <path class="edge" d="M320 80 L380 80" marker-end="url(#arrow)"/>
+      <rect class="node" x="380" y="50" width="80" height="60" rx="8"/>
+      <text class="label" x="420" y="85" text-anchor="middle">Artifact</text>
+
+      <defs>
+        <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+          <path d="M0 0 L10 5 L0 10 z" fill="var(--text-muted)"/>
+        </marker>
+      </defs>
+    </svg>
+  </div>
+
+  <h2>Two-way interaction</h2>
+  <div class="card">
+    <p>Artifacts that accept input must include an export button. Pattern:</p>
+<pre><code>btn.addEventListener('click', () =&gt; {
+  navigator.clipboard.writeText(JSON.stringify(state, null, 2));
+  toast('Copied');
+});</code></pre>
+  </div>
+
+  <div class="toolbar">
+    <span>Token snapshot</span>
+    <span class="spacer"></span>
+    <span class="toast" id="toast">Copied</span>
+    <button class="btn btn--primary" id="copyTokens">Copy tokens as JSON</button>
+  </div>
+
+</main>
+
+<script>
+  // Render color swatches from the live :root tokens
+  const tokens = ['bg','surface','surface-alt','text','text-muted','border','accent','accent-soft','success','warning','error'];
+  const root = getComputedStyle(document.documentElement);
+  const grid = document.getElementById('swatches');
+  for (const t of tokens) {
+    const value = root.getPropertyValue('--' + t).trim();
+    const el = document.createElement('div');
+    el.className = 'swatch';
+    el.innerHTML = `
+      <div class="chip" style="background:var(--${t})"></div>
+      <strong>--${t}</strong>
+      <code>${value}</code>
+    `;
+    grid.appendChild(el);
+  }
+
+  // Copy-to-clipboard pattern for two-way artifacts
+  const toast = document.getElementById('toast');
+  document.getElementById('copyTokens').addEventListener('click', async () => {
+    const payload = Object.fromEntries(tokens.map(t => [t, root.getPropertyValue('--' + t).trim()]));
+    await navigator.clipboard.writeText(JSON.stringify(payload, null, 2));
+    toast.classList.add('show');
+    setTimeout(() => toast.classList.remove('show'), 1400);
+  });
+</script>
+</body>
+</html>

--- a/html-module/templates/index.html
+++ b/html-module/templates/index.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Artifact Catalog</title>
+<meta name="artifact-type" content="index">
+<meta name="artifact-purpose" content="Catalog of every HTML artifact in this project.">
+<!--
+  Claude: after creating any artifact in artifacts/, append a row to the table
+  below with date, type, title, link, and a one-line purpose. Keep newest at top.
+  Mirror tokens from design-system.html if you edit them there.
+-->
+<style>
+  :root {
+    --bg:           #fbfaf7;
+    --surface:      #ffffff;
+    --surface-alt:  #f4f1eb;
+    --text:         #18181b;
+    --text-muted:   #6b6b73;
+    --border:       #e4e0d8;
+    --accent:       #0f766e;
+    --accent-soft:  #ccfbf1;
+    --font-sans:  ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, system-ui, sans-serif;
+    --font-mono:  ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    --font-serif: ui-serif, "Iowan Old Style", "Apple Garamond", Georgia, serif;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg:#0f1115; --surface:#161922; --surface-alt:#1f2330;
+      --text:#e8e6e0; --text-muted:#9a9ba3; --border:#2a2f3d;
+      --accent:#5eead4; --accent-soft:#134e4a;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--text);
+    font-family: var(--font-sans); line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+  }
+  main { max-width: 960px; margin: 0 auto; padding: 3rem 1.5rem; }
+  h1 { font-family: var(--font-serif); font-size: 2.5rem; margin: 0 0 0.5rem; letter-spacing: -0.01em; }
+  p.lead { color: var(--text-muted); margin: 0 0 2.5rem; font-size: 1.125rem; }
+  table { width: 100%; border-collapse: collapse; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+  th, td { text-align: left; padding: 0.75rem 1rem; border-bottom: 1px solid var(--border); font-size: 0.95rem; vertical-align: top; }
+  th { background: var(--surface-alt); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted); font-weight: 600; }
+  tr:last-child td { border-bottom: none; }
+  tr:hover td { background: var(--surface-alt); }
+  a { color: var(--accent); text-decoration: none; border-bottom: 1px solid currentColor; }
+  a:hover { opacity: 0.7; }
+  .badge {
+    display: inline-block; padding: 2px 8px; border-radius: 999px;
+    font-size: 0.7rem; font-weight: 500; letter-spacing: 0.02em;
+    background: var(--accent-soft); color: var(--accent);
+  }
+  .empty {
+    border: 1px dashed var(--border); border-radius: 8px;
+    padding: 2.5rem; text-align: center; color: var(--text-muted);
+  }
+  .empty code { background: var(--surface-alt); padding: 2px 6px; border-radius: 4px; font-family: var(--font-mono); font-size: 0.85em; }
+  footer { margin-top: 3rem; color: var(--text-muted); font-size: 0.85rem; }
+  footer a { color: inherit; }
+</style>
+</head>
+<body>
+<main>
+
+  <h1>Artifact Catalog</h1>
+  <p class="lead">Every HTML artifact generated for this project. Newest first.</p>
+
+  <!-- When you have artifacts, replace the .empty block below with the table.
+       Sample row layout:
+
+  <table>
+    <thead>
+      <tr><th>Date</th><th>Type</th><th>Title</th><th>Purpose</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>2026-05-11</td>
+        <td><span class="badge">spec</span></td>
+        <td><a href="2026-05-11-onboarding-spec.html">Onboarding screen — 6 approaches</a></td>
+        <td>Side-by-side comparison of layouts before committing</td>
+      </tr>
+    </tbody>
+  </table>
+  -->
+
+  <div class="empty">
+    No artifacts yet. Ask Claude to generate one — for example:<br>
+    <code>"Make an HTML spec exploring 6 approaches to the onboarding screen."</code>
+  </div>
+
+  <footer>
+    Tokens defined in <a href="design-system.html">design-system.html</a>.
+  </footer>
+
+</main>
+</body>
+</html>

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,7 @@ UPGRADE=false
 DIFF_MODE=false
 GITIGNORE=false
 WIKI=false
+HTML=false
 TARGET_VERSION=""
 LOCAL_SOURCE=false
 DEST="$(pwd)"
@@ -517,6 +518,10 @@ while [[ $# -gt 0 ]]; do
       WIKI=true
       shift
       ;;
+    --html)
+      HTML=true
+      shift
+      ;;
     --version|-v)
       [ $# -ge 2 ] || error "--version requires an argument"
       TARGET_VERSION="$2"
@@ -535,6 +540,7 @@ while [[ $# -gt 0 ]]; do
       echo "  --diff, -d       Compare local installation against latest kit (read-only)"
       echo "  --gitignore, -g  Add kit files to .gitignore (keep kit local, don't push to repo)"
       echo "  --wiki           Add knowledge wiki module (personal knowledge base)"
+      echo "  --html           Add HTML artifacts module (specs, reports, PR writeups as HTML)"
       echo "  --version, -v    Install a specific version (e.g., --version v1.0.0)"
       echo "  --help, -h       Show this help"
       echo ""
@@ -949,6 +955,33 @@ if [ "$WIKI" = true ] && [ "$PROFILE" != "minimal" ]; then
   ok "Added wiki module ($WIKI_SKILLS skills, 1 agent)"
 fi
 
+# --- HTML artifacts module (optional) ---
+if [ "$HTML" = true ] && [ "$PROFILE" != "minimal" ]; then
+  # Copy ARTIFACTS.md schema
+  manifest_add "ARTIFACTS.md"
+  if [ ! -f "$DEST/ARTIFACTS.md" ]; then
+    cp "$CLONE_DIR/ARTIFACTS.md" "$DEST/ARTIFACTS.md"
+    ok "Created ARTIFACTS.md (HTML artifact conventions)"
+  elif [ "$UPGRADE" = true ]; then
+    cp "$CLONE_DIR/ARTIFACTS.md" "$DEST/ARTIFACTS.md"
+    ok "Updated ARTIFACTS.md"
+  else
+    warn "Skipped ARTIFACTS.md (already exists)"
+  fi
+
+  # Scaffold artifacts/ directory with design-system.html and index.html
+  if [ ! -d "$DEST/artifacts" ]; then
+    mkdir -p "$DEST/artifacts"
+    cp "$CLONE_DIR/html-module/templates/design-system.html" "$DEST/artifacts/design-system.html"
+    cp "$CLONE_DIR/html-module/templates/index.html" "$DEST/artifacts/index.html"
+    ok "Created artifacts/ (design-system.html + index.html)"
+  else
+    # Add the reference files only if missing — never overwrite user-edited tokens
+    [ -f "$DEST/artifacts/design-system.html" ] || cp "$CLONE_DIR/html-module/templates/design-system.html" "$DEST/artifacts/design-system.html"
+    [ -f "$DEST/artifacts/index.html" ] || cp "$CLONE_DIR/html-module/templates/index.html" "$DEST/artifacts/index.html"
+  fi
+fi
+
 # Write manifest
 manifest_add "$MANIFEST_FILE"
 manifest_write "$DEST"
@@ -984,6 +1017,10 @@ if [ "$GITIGNORE" = true ]; then
         echo "WIKI.md"
         echo "raw-sources/"
         echo "wiki/"
+      fi
+      if [ "$HTML" = true ]; then
+        echo "ARTIFACTS.md"
+        echo "artifacts/"
       fi
     } >> "$GITIGNORE_FILE"
     ok "Added kit files to .gitignore (kit stays local, won't be pushed)"
@@ -1021,6 +1058,14 @@ else
     echo "  - Run /wiki-briefing for a daily summary"
     echo "  - Run /wiki-lint for periodic health checks"
     echo "  - Open the project folder in your markdown editor to browse the wiki"
+  fi
+  if [ "$HTML" = true ]; then
+    echo ""
+    echo "  HTML artifacts module:"
+    echo "  - Edit artifacts/design-system.html tokens to match your project's taste"
+    echo "  - Ask Claude to produce specs, reports, PR writeups, or editors as HTML"
+    echo "  - New artifacts land in artifacts/ and auto-link from artifacts/index.html"
+    echo "  - Open artifacts/<file>.html in a browser to view, share via S3/CDN"
   fi
 fi
 echo ""


### PR DESCRIPTION
## Summary

- Optional `--html` install flag adds an HTML artifacts module — convention + reference styling for generating specs, plans, PR explainers, reports, design prototypes, and custom editors as HTML instead of markdown.
- Based on the Claude Code team's pattern (Thariq's "Unreasonable Effectiveness of HTML" post): richer information density, easier to share, supports two-way interaction (copy-as-JSON / copy-as-prompt buttons), better for anything over ~100 lines.
- Ships ARTIFACTS.md (schema), `artifacts/design-system.html` (token + component reference), `artifacts/index.html` (catalog starter), CLAUDE.md conditional section, and installer wiring.
- **Deliberately ships without a /html skill** — the original advice is to just prompt for HTML, not to over-structure it. Skills can be added later if real usage shows repeating prompt structures.

## What's in the box

| File | Role |
|---|---|
| `ARTIFACTS.md` | Schema: when HTML vs markdown, directory layout, artifact types, two-way interaction patterns, anti-patterns |
| `html-module/templates/design-system.html` | Standalone reference — CSS variables, light+dark mode, type scale, buttons, tables, SVG diagrams, copy-to-clipboard pattern |
| `html-module/templates/index.html` | Artifact catalog starter |
| `install.sh` | `--html` flag, scaffolding, `--gitignore` support, post-install message |
| `CLAUDE.md` | Conditional section telling Claude to prefer HTML for specs/reports/PRs when `ARTIFACTS.md` exists |

## Test plan

- [x] `bash install.sh --local <kit> --html` in temp dir creates ARTIFACTS.md, artifacts/ with both templates
- [x] Standard profile triggers HTML scaffolding; minimal skips it (parallel to wiki behavior)
- [x] `--gitignore` flag adds `ARTIFACTS.md` and `artifacts/` to .gitignore when `--html` is set
- [x] `bash -n install.sh` syntax check clean
- [x] design-system.html renders correctly in browser (dark mode auto, copy-tokens button works, SVG sharp)
- [ ] release-please bumps to 1.8.0 on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)