### PR TITLE
feat(html): integrate HTML module into uninstall, doctor, and ARTIFACTS

### DIFF
--- a/ARTIFACTS.md
+++ b/ARTIFACTS.md
@@ -13,6 +13,22 @@ HTML takes over for files you only read.
 
 ## When HTML, when Markdown
 
+**Mental model** (Shann Holmberg, building on Thariq):
+
+> Markdown for agents only. HTML for agents *and* humans.
+
+Every rule below follows from this: the moment a human enters the loop — review
+gate, sharing, sign-off, browse-without-grep — switch to HTML. If only agents
+read and write the file, markdown is fine.
+
+**Karpathy's progression**: raw text → markdown (current default) → **HTML** (the
+new forming default — flexibility on graphics, layout, interactivity) → eventually
+interactive neural simulations. We're aiming for the third rung.
+
+**Minimum invocation**: end your prompt with `"structure your response as HTML"`
+(or `"as a slideshow"`, `"as a single-page artifact"`). That's it. No skill, no
+scaffolding required.
+
 Prefer **HTML** when one or more is true:
 
 - Output will exceed ~100 lines (nobody reads a long markdown plan)
@@ -55,6 +71,7 @@ artifacts/
 | `spec`        | Implementation plan, design exploration       | Mockups, code snippets, tradeoff tables, N-up grid |
 | `pr-explain`  | PR or code review writeup                     | Diff blocks, inline annotations, severity colors   |
 | `report`      | Research, weekly recap, incident, deep-dive   | SVG diagrams, sections, summary box                |
+| `slideshow`   | Decks, presentations, "show this to leadership"| One section per slide, keyboard nav, progress bar |
 | `design`      | Component prototype, animation tuning         | Sliders/knobs, live preview, copy-params button    |
 | `editor`      | Throwaway data editor (triage, config, prompt)| Copy-as-JSON / Copy-as-prompt export button        |
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -209,7 +209,8 @@ else
 fi
 
 if [ -d ".claude/hooks/project" ]; then
-  PROJECT_HOOK_COUNT=$(ls -1 .claude/hooks/project/*.sh 2>/dev/null | wc -l | tr -d ' ')
+  # find is pipefail-safe when no matches (unlike ls glob)
+  PROJECT_HOOK_COUNT=$(find .claude/hooks/project -maxdepth 1 -type f -name "*.sh" 2>/dev/null | wc -l | tr -d ' ')
   if [ "$PROJECT_HOOK_COUNT" -gt 0 ]; then
     pass ".claude/hooks/project/ has $PROJECT_HOOK_COUNT hook(s)"
     # Check executability
@@ -224,6 +225,62 @@ if [ -d ".claude/hooks/project" ]; then
   fi
 else
   info ".claude/hooks/project/ not found (optional — create for project-specific hooks)"
+fi
+
+echo ""
+
+# --- 7. Optional Modules ---
+echo "  Optional Modules"
+echo "  ----------------"
+
+# Knowledge Wiki module
+if [ -f "WIKI.md" ]; then
+  pass "WIKI.md exists (knowledge wiki module active)"
+  if [ -d "raw-sources" ]; then
+    RAW_COUNT=$(find raw-sources -mindepth 1 -type f ! -name ".DS_Store" 2>/dev/null | wc -l | tr -d ' ')
+    pass "raw-sources/ exists ($RAW_COUNT source file(s))"
+  else
+    warn "raw-sources/ missing (WIKI.md is present — expected the source directory)"
+  fi
+  if [ -d "wiki" ]; then
+    WIKI_PAGE_COUNT=0
+    for sub in summaries entities concepts; do
+      [ -d "wiki/$sub" ] || continue
+      SUB_COUNT=$(find "wiki/$sub" -mindepth 1 -type f -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
+      WIKI_PAGE_COUNT=$((WIKI_PAGE_COUNT + SUB_COUNT))
+    done
+    pass "wiki/ exists ($WIKI_PAGE_COUNT wiki page(s))"
+    [ -f "wiki/index.md" ] || warn "wiki/index.md missing (catalog)"
+    [ -f "wiki/log.md" ]   || warn "wiki/log.md missing (activity log)"
+  else
+    warn "wiki/ missing (WIKI.md is present — expected the vault directory)"
+  fi
+else
+  info "Wiki module not installed (optional — install with --wiki)"
+fi
+
+# HTML Artifacts module
+if [ -f "ARTIFACTS.md" ]; then
+  pass "ARTIFACTS.md exists (HTML artifacts module active)"
+  if [ -d "artifacts" ]; then
+    if [ -f "artifacts/design-system.html" ]; then
+      pass "artifacts/design-system.html exists (token reference)"
+    else
+      fail "artifacts/design-system.html missing — artifacts will drift in style"
+    fi
+    if [ -f "artifacts/index.html" ]; then
+      pass "artifacts/index.html exists (catalog)"
+    else
+      warn "artifacts/index.html missing (catalog page)"
+    fi
+    ART_COUNT=$(find artifacts -mindepth 1 -maxdepth 1 -type f -name "*.html" \
+      ! -name "design-system.html" ! -name "index.html" 2>/dev/null | wc -l | tr -d ' ')
+    info "artifacts/ has $ART_COUNT generated artifact(s) beyond the reference files"
+  else
+    warn "artifacts/ missing (ARTIFACTS.md is present — expected the output directory)"
+  fi
+else
+  info "HTML Artifacts module not installed (optional — install with --html)"
 fi
 
 echo ""

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -16,6 +16,8 @@ DRY_RUN=false
 FORCE=false
 KEEP_TASKS=false
 KEEP_PROJECT=false
+KEEP_WIKI=false
+KEEP_ARTIFACTS=false
 
 # Colors
 RED='\033[0;31m'
@@ -50,14 +52,24 @@ while [[ $# -gt 0 ]]; do
       KEEP_PROJECT=true
       shift
       ;;
+    --keep-wiki)
+      KEEP_WIKI=true
+      shift
+      ;;
+    --keep-artifacts)
+      KEEP_ARTIFACTS=true
+      shift
+      ;;
     --help|-h)
-      echo "Usage: uninstall.sh [--dry-run] [--force] [--keep-tasks] [--keep-project]"
+      echo "Usage: uninstall.sh [--dry-run] [--force] [--keep-tasks] [--keep-project] [--keep-wiki] [--keep-artifacts]"
       echo ""
       echo "Options:"
       echo "  --dry-run, -n       Show what would be removed without deleting"
       echo "  --force, -f         Remove without confirmation"
       echo "  --keep-tasks, -k    Keep tasks/ directory (lessons, decisions, handoffs)"
       echo "  --keep-project, -p  Keep project overlay files (CLAUDE.project.md, agent_docs/project/, .claude/hooks/project/)"
+      echo "  --keep-wiki         Keep WIKI.md, raw-sources/, and wiki/ (knowledge wiki module data)"
+      echo "  --keep-artifacts    Keep ARTIFACTS.md and artifacts/ (HTML artifacts module data)"
       echo "  --help, -h          Show this help"
       exit 0
       ;;
@@ -77,6 +89,8 @@ echo ""
 FILES_TO_REMOVE=()
 DIRS_TO_REMOVE=()
 HAS_USER_DATA=false
+HAS_WIKI_USER_DATA=false
+HAS_ARTIFACTS_USER_DATA=false
 
 # Root files
 [ -f "$DEST/VERSION" ] && FILES_TO_REMOVE+=("VERSION")
@@ -135,7 +149,8 @@ if [ -d "$DEST/tasks" ]; then
         TASK_FILES=$((TASK_FILES + 1))
       fi
     fi
-    HANDOFF_COUNT=$(ls -1 "$DEST/tasks/handoff-"*.md 2>/dev/null | wc -l | tr -d ' ')
+    # find is pipefail-safe when no matches (unlike ls glob)
+    HANDOFF_COUNT=$(find "$DEST/tasks" -maxdepth 1 -type f -name "handoff-*.md" 2>/dev/null | wc -l | tr -d ' ')
     if [ "$HANDOFF_COUNT" -gt 0 ]; then
       TASK_FILES=$((TASK_FILES + HANDOFF_COUNT))
     fi
@@ -145,6 +160,67 @@ if [ -d "$DEST/tasks" ]; then
     fi
 
     DIRS_TO_REMOVE+=("tasks/")
+  fi
+fi
+
+# Wiki module (optional, installed via --wiki) — may contain user data
+WIKI_PRESENT=false
+if [ -f "$DEST/WIKI.md" ] || [ -d "$DEST/wiki" ] || [ -d "$DEST/raw-sources" ]; then
+  WIKI_PRESENT=true
+fi
+if [ "$WIKI_PRESENT" = true ]; then
+  if [ "$KEEP_WIKI" = true ]; then
+    warn "Keeping WIKI.md, wiki/, raw-sources/ (--keep-wiki)"
+  else
+    # User-data detection: any source file, or wiki pages beyond seed
+    WIKI_USER_FILES=0
+    if [ -d "$DEST/raw-sources" ]; then
+      RAW_COUNT=$(find "$DEST/raw-sources" -mindepth 1 -type f ! -name ".DS_Store" 2>/dev/null | wc -l | tr -d ' ')
+      WIKI_USER_FILES=$((WIKI_USER_FILES + RAW_COUNT))
+    fi
+    if [ -d "$DEST/wiki" ]; then
+      for sub in summaries entities concepts; do
+        if [ -d "$DEST/wiki/$sub" ]; then
+          SUB_COUNT=$(find "$DEST/wiki/$sub" -mindepth 1 -type f ! -name ".DS_Store" 2>/dev/null | wc -l | tr -d ' ')
+          WIKI_USER_FILES=$((WIKI_USER_FILES + SUB_COUNT))
+        fi
+      done
+      # log.md beyond seed (template has just the header line)
+      if [ -f "$DEST/wiki/log.md" ]; then
+        LOG_LINES=$(wc -l < "$DEST/wiki/log.md" | tr -d ' ')
+        [ "$LOG_LINES" -gt 1 ] && WIKI_USER_FILES=$((WIKI_USER_FILES + 1))
+      fi
+    fi
+    if [ "$WIKI_USER_FILES" -gt 0 ]; then
+      HAS_WIKI_USER_DATA=true
+    fi
+
+    [ -f "$DEST/WIKI.md" ] && FILES_TO_REMOVE+=("WIKI.md")
+    [ -d "$DEST/wiki" ] && DIRS_TO_REMOVE+=("wiki/")
+    [ -d "$DEST/raw-sources" ] && DIRS_TO_REMOVE+=("raw-sources/")
+  fi
+fi
+
+# HTML artifacts module (optional, installed via --html) — may contain user data
+ARTIFACTS_PRESENT=false
+if [ -f "$DEST/ARTIFACTS.md" ] || [ -d "$DEST/artifacts" ]; then
+  ARTIFACTS_PRESENT=true
+fi
+if [ "$ARTIFACTS_PRESENT" = true ]; then
+  if [ "$KEEP_ARTIFACTS" = true ]; then
+    warn "Keeping ARTIFACTS.md, artifacts/ (--keep-artifacts)"
+  else
+    # User-data detection: any artifact file beyond the two seed templates
+    if [ -d "$DEST/artifacts" ]; then
+      ART_USER_FILES=$(find "$DEST/artifacts" -mindepth 1 -maxdepth 1 -type f \
+        ! -name "design-system.html" ! -name "index.html" ! -name ".DS_Store" 2>/dev/null | wc -l | tr -d ' ')
+      if [ "$ART_USER_FILES" -gt 0 ]; then
+        HAS_ARTIFACTS_USER_DATA=true
+      fi
+    fi
+
+    [ -f "$DEST/ARTIFACTS.md" ] && FILES_TO_REMOVE+=("ARTIFACTS.md")
+    [ -d "$DEST/artifacts" ] && DIRS_TO_REMOVE+=("artifacts/")
   fi
 fi
 
@@ -189,6 +265,10 @@ fi
 if [ ${#DIRS_TO_REMOVE[@]} -gt 0 ]; then
   for d in "${DIRS_TO_REMOVE[@]}"; do
     if [ "$d" = "tasks/" ] && [ "$HAS_USER_DATA" = true ]; then
+      echo -e "    ${RED}✕${NC} $d ${YELLOW}(contains your data!)${NC}"
+    elif { [ "$d" = "wiki/" ] || [ "$d" = "raw-sources/" ]; } && [ "$HAS_WIKI_USER_DATA" = true ]; then
+      echo -e "    ${RED}✕${NC} $d ${YELLOW}(contains your data!)${NC}"
+    elif [ "$d" = "artifacts/" ] && [ "$HAS_ARTIFACTS_USER_DATA" = true ]; then
       echo -e "    ${RED}✕${NC} $d ${YELLOW}(contains your data!)${NC}"
     else
       echo -e "    ${RED}✕${NC} $d"
@@ -235,6 +315,20 @@ echo ""
 if [ "$HAS_USER_DATA" = true ]; then
   warn "tasks/ contains your session data (lessons, decisions, or handoffs)"
   echo -e "       Use ${CYAN}--keep-tasks${NC} to preserve it"
+  echo ""
+fi
+
+# Warn about wiki user data
+if [ "$HAS_WIKI_USER_DATA" = true ]; then
+  warn "wiki/ or raw-sources/ contains your knowledge data (ingested sources, wiki pages)"
+  echo -e "       Use ${CYAN}--keep-wiki${NC} to preserve WIKI.md + wiki/ + raw-sources/"
+  echo ""
+fi
+
+# Warn about artifacts user data
+if [ "$HAS_ARTIFACTS_USER_DATA" = true ]; then
+  warn "artifacts/ contains your generated HTML artifacts (specs, reports, etc.)"
+  echo -e "       Use ${CYAN}--keep-artifacts${NC} to preserve ARTIFACTS.md + artifacts/"
   echo ""
 fi
 


### PR DESCRIPTION
## Summary

Round-trip parity for the new HTML artifacts module + closes the same gap that existed for the wiki module.

### ARTIFACTS.md improvements

- **Shann Holmberg's mental model** — *"Markdown for agents only. HTML for agents and humans."* — added as the single principle every other rule follows from.
- **Karpathy progression** — cited his raw-text → markdown → HTML → interactive-neural-sims arc, since we now have a third independent source converging on the same thesis (Thariq, Shann, Karpathy).
- **Minimum invocation pro-tip** — end your prompt with `"structure your response as HTML"`. No skill required, no scaffolding. Reinforces the "don't over-structure" philosophy.
- **`slideshow` artifact type** — Karpathy explicitly highlights slideshows alongside HTML reports as a successful pattern. Added to the artifact types table.

### uninstall.sh

- New `--keep-wiki` and `--keep-artifacts` flags (parallel to `--keep-tasks`).
- Detects `WIKI.md`, `wiki/`, `raw-sources/`, `ARTIFACTS.md`, `artifacts/`. Previously the uninstaller silently left these behind — both modules had the same gap.
- Per-module user-data detection. Any raw source, wiki page, or non-template artifact triggers a yellow "(contains your data!)" warning + surfaces the matching `--keep` flag.
- **Pre-existing pipefail bug fix** — `ls -1 ... handoff-*.md | wc -l | tr -d ' '` with no matches killed the script under `set -euo pipefail`. Swapped for `find` which is pipefail-safe.

### scripts/doctor.sh

- New "Optional Modules" section. If `WIKI.md` exists, verifies `wiki/`, `raw-sources/`, `wiki/index.md`, `wiki/log.md`. If `ARTIFACTS.md` exists, verifies `artifacts/design-system.html`, `artifacts/index.html`, and counts generated artifacts.
- **Same pre-existing pipefail bug** in `.claude/hooks/project/*.sh` glob count — fixed with `find`.

## Test plan

- [x] `bash scripts/doctor.sh` in fresh `--wiki --html` install: all greens, modules section appears, 40 passed / 4 warnings.
- [x] `bash uninstall.sh --dry-run` after `--wiki --html` install + simulated user data: lists `WIKI.md`, `wiki/`, `raw-sources/`, `ARTIFACTS.md`, `artifacts/`; flags user-data dirs; surfaces both `--keep-wiki` and `--keep-artifacts` hints.
- [x] `bash uninstall.sh --dry-run --keep-artifacts`: keeps `ARTIFACTS.md` + `artifacts/`, still removes `WIKI.md` (flags are independent).
- [x] `bash -n` syntax check passes for both scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)