### PR TITLE
feat(skills): adopt Core Rule + Default Behavior + Phase 1 Inventory patterns

### DIFF
--- a/.claude/skills/_shared/blocks/core-rule.md
+++ b/.claude/skills/_shared/blocks/core-rule.md
@@ -1,0 +1,17 @@
+## Core Rule
+
+<!--
+One sentence (max ~25 words) that anchors the skill's ethical scope:
+- What must be preserved
+- What's forbidden even on user request
+- The deal-breaker that distinguishes this skill from a free-form prompt
+
+Examples:
+- "Confirm code is unreachable across the full call graph before flagging. Never remove code without explicit user approval, even for obvious dead branches."
+- "Block deployment when CHANGELOG, tests, or coverage gates fail. Preserve rollback capability at every step. Never ship from a dirty working tree."
+- "Form a single hypothesis at a time. Validate with a falsifiable test before fixing. Never patch a symptom you haven't reproduced."
+
+Required for every skill. Goes immediately after the title (and intro paragraph if present), before any other ## section.
+-->
+
+[Replace with this skill's Core Rule.]

--- a/.claude/skills/_shared/blocks/default-behavior.md
+++ b/.claude/skills/_shared/blocks/default-behavior.md
@@ -1,0 +1,19 @@
+## Default Behavior
+
+<!--
+Required for report-producing audit skills.
+Tells the agent what to do AUTONOMOUSLY when the skill is invoked,
+removing back-and-forth "what would you like me to focus on?" friction.
+
+Pattern (substitute <DOMAIN> and <skill-name>):
+
+When the user asks to audit, scan, review, or "give me a report" for <DOMAIN>, produce the full <skill-name> report automatically using the Process and Output Format sections below. Do not require the user to specify fields.
+
+Only modify files when the user explicitly requests implement / fix / apply / refactor. By default, this skill is **report-only**.
+
+Skip this section for non-audit skills (workflow, meta, lifecycle).
+-->
+
+When the user asks to audit, scan, review, or "give me a report" for [DOMAIN], produce the full [skill-name] report automatically using the Process and Output Format sections below. Do not require the user to specify fields.
+
+Only modify files when the user explicitly requests implement / fix / apply / refactor. By default, this skill is **report-only**.

--- a/.claude/skills/_shared/blocks/inventory-framing.md
+++ b/.claude/skills/_shared/blocks/inventory-framing.md
@@ -1,0 +1,11 @@
+<!--
+Standard framing for Phase 1 in audit skills.
+Goes immediately under the "### Phase 1: Inventory (first-pass leads)" heading.
+
+Required for audit skills. Skip for non-audit skills.
+
+Rationale: discourages reporting Phase 1 raw counts as findings.
+The pass surfaces CANDIDATES; later phases produce findings.
+-->
+
+This pass produces **candidates**, not findings. Treat counts as leads for deeper inspection in later phases. Do not report Phase 1 raw output as the final result.

--- a/.claude/skills/_templates/code-quality-audit.tmpl
+++ b/.claude/skills/_templates/code-quality-audit.tmpl
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Code Quality Audit
 
+## Core Rule
+
+Surface issues that affect maintainability and correctness, not stylistic preferences. Recommend fixes only with concrete reproduction steps; never apply edits in a report-only request.
+
 {{PREAMBLE}}
 
 ## When to Use
@@ -17,13 +21,21 @@ Invoke with `/code-quality-audit` when:
 - Preparing for a code review or due diligence assessment
 - After rapid development to identify accumulated technical debt
 
+## Default Behavior
+
+When the user asks to audit, scan, review, or "give me a report" for code quality, produce the full code-quality-audit report automatically using the Process and Output Format sections below. Do not require the user to specify fields.
+
+Only modify files when the user explicitly requests implement / fix / apply / refactor. By default, this skill is **report-only**.
+
 {{SCOPE_RULES}}
 
 {{CONTEXT_GATHERING}}
 
 ## Process
 
-### Phase 1: Scope
+### Phase 1: Inventory (first-pass leads)
+
+This pass produces **candidates**, not findings. Treat counts as leads for deeper inspection in later phases. Do not report Phase 1 raw output as the final result.
 
 Determine audit scope:
 

--- a/.claude/skills/_templates/dead-code-audit.tmpl
+++ b/.claude/skills/_templates/dead-code-audit.tmpl
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Dead Code Audit
 
+## Core Rule
+
+Confirm code is unreachable across the full call graph before flagging. Never remove code without explicit user approval, even for obvious dead branches.
+
 {{PREAMBLE}}
 
 ## When to Use
@@ -18,13 +22,21 @@ Invoke with `/dead-code-audit` when:
 - During tech debt reduction sprints
 - Preparing for a code quality review or due diligence
 
+## Default Behavior
+
+When the user asks to audit, scan, review, or "give me a report" for dead code / unused code, produce the full dead-code-audit report automatically using the Process and Output Format sections below. Do not require the user to specify fields.
+
+Only modify files when the user explicitly requests implement / fix / apply / refactor. By default, this skill is **report-only**.
+
 {{SCOPE_RULES}}
 
 {{CONTEXT_GATHERING}}
 
 ## Process
 
-### Phase 1: Scope & Inventory
+### Phase 1: Inventory (first-pass leads)
+
+This pass produces **candidates**, not findings. Treat counts as leads for deeper inspection in later phases. Do not report Phase 1 raw output as the final result.
 
 1. Identify the project's source directories (skip node_modules, vendor, build output)
 2. Build a list of all exported symbols: functions, classes, types, constants, components

--- a/.claude/skills/_templates/testing-audit.tmpl
+++ b/.claude/skills/_templates/testing-audit.tmpl
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Testing Audit
 
+## Core Rule
+
+Distinguish test gaps from test churn. Report missing critical-path coverage and flaky tests separately; never recommend tests beyond reproducibility need.
+
 {{PREAMBLE}}
 
 ## When to Use
@@ -18,13 +22,21 @@ Invoke with `/testing-audit` when:
 - Reviewing test quality after rapid feature development
 - Assessing confidence level before a major release
 
+## Default Behavior
+
+When the user asks to audit, scan, review, or "give me a report" for test coverage and quality, produce the full testing-audit report automatically using the Process and Output Format sections below. Do not require the user to specify fields.
+
+Only modify files when the user explicitly requests implement / fix / apply / refactor. By default, this skill is **report-only**.
+
 {{SCOPE_RULES}}
 
 {{CONTEXT_GATHERING}}
 
 ## Process
 
-### Phase 1: Test Inventory
+### Phase 1: Inventory (first-pass leads)
+
+This pass produces **candidates**, not findings. Treat counts as leads for deeper inspection in later phases. Do not report Phase 1 raw output as the final result.
 
 Map the current test landscape:
 

--- a/.claude/skills/accessibility-audit/SKILL.md
+++ b/.claude/skills/accessibility-audit/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Accessibility Audit
 
+## Core Rule
+
+Test against WCAG 2.1 AA criteria with concrete user-impact. Never auto-edit semantic HTML or ARIA without explicit user approval.
+
 ## When to Use
 
 Invoke with `/accessibility-audit` when:
@@ -16,9 +20,17 @@ Invoke with `/accessibility-audit` when:
 - Ensuring inclusive design for all users
 - Before launching a new feature with UI changes
 
+## Default Behavior
+
+When the user asks to audit, scan, review, or "give me a report" for accessibility / WCAG compliance, produce the full accessibility-audit report automatically using the Process and Output Format sections below. Do not require the user to specify fields.
+
+Only modify files when the user explicitly requests implement / fix / apply / refactor. By default, this skill is **report-only**.
+
 ## Process
 
-### Phase 1: Identify UI Framework
+### Phase 1: Inventory (first-pass leads)
+
+This pass produces **candidates**, not findings. Treat counts as leads for deeper inspection in later phases. Do not report Phase 1 raw output as the final result.
 
 Determine the UI technology:
 

--- a/.claude/skills/architecture-review/SKILL.md
+++ b/.claude/skills/architecture-review/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Architecture Review
 
+## Core Rule
+
+Critique module boundaries and dependency health against documented intent. Don't propose rewrites — suggest the smallest seam-cutting change.
+
 ## When to Use
 
 Invoke with `/architecture-review` when:
@@ -16,9 +20,17 @@ Invoke with `/architecture-review` when:
 - Onboarding to a codebase and building a mental model
 - Due diligence on an inherited or acquired codebase
 
+## Default Behavior
+
+When the user asks to audit, scan, review, or "give me a report" for architecture / module health, produce the full architecture-review report automatically using the Process and Output Format sections below. Do not require the user to specify fields.
+
+Only modify files when the user explicitly requests implement / fix / apply / refactor. By default, this skill is **report-only**.
+
 ## Process
 
-### Phase 1: Map the Architecture
+### Phase 1: Inventory (first-pass leads)
+
+This pass produces **candidates**, not findings. Treat counts as leads for deeper inspection in later phases. Do not report Phase 1 raw output as the final result.
 
 Build a structural overview:
 

--- a/.claude/skills/code-quality-audit/SKILL.md
+++ b/.claude/skills/code-quality-audit/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Code Quality Audit
 
+## Core Rule
+
+Surface issues that affect maintainability and correctness, not stylistic preferences. Recommend fixes only with concrete reproduction steps; never apply edits in a report-only request.
+
 ## Kit Context
 
 Before starting this skill, ensure you have completed session boot:
@@ -23,6 +27,12 @@ Invoke with `/code-quality-audit` when:
 - Onboarding to a new project and assessing code health
 - Preparing for a code review or due diligence assessment
 - After rapid development to identify accumulated technical debt
+
+## Default Behavior
+
+When the user asks to audit, scan, review, or "give me a report" for code quality, produce the full code-quality-audit report automatically using the Process and Output Format sections below. Do not require the user to specify fields.
+
+Only modify files when the user explicitly requests implement / fix / apply / refactor. By default, this skill is **report-only**.
 
 ## Scope Rules
 
@@ -43,7 +53,9 @@ Before analysis, map the project:
 
 ## Process
 
-### Phase 1: Scope
+### Phase 1: Inventory (first-pass leads)
+
+This pass produces **candidates**, not findings. Treat counts as leads for deeper inspection in later phases. Do not report Phase 1 raw output as the final result.
 
 Determine audit scope:
 

--- a/.claude/skills/dead-code-audit/SKILL.md
+++ b/.claude/skills/dead-code-audit/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Dead Code Audit
 
+## Core Rule
+
+Confirm code is unreachable across the full call graph before flagging. Never remove code without explicit user approval, even for obvious dead branches.
+
 ## Kit Context
 
 Before starting this skill, ensure you have completed session boot:
@@ -24,6 +28,12 @@ Invoke with `/dead-code-audit` when:
 - Before a codebase migration to minimize what gets carried over
 - During tech debt reduction sprints
 - Preparing for a code quality review or due diligence
+
+## Default Behavior
+
+When the user asks to audit, scan, review, or "give me a report" for dead code / unused code, produce the full dead-code-audit report automatically using the Process and Output Format sections below. Do not require the user to specify fields.
+
+Only modify files when the user explicitly requests implement / fix / apply / refactor. By default, this skill is **report-only**.
 
 ## Scope Rules
 
@@ -44,7 +54,9 @@ Before analysis, map the project:
 
 ## Process
 
-### Phase 1: Scope & Inventory
+### Phase 1: Inventory (first-pass leads)
+
+This pass produces **candidates**, not findings. Treat counts as leads for deeper inspection in later phases. Do not report Phase 1 raw output as the final result.
 
 1. Identify the project's source directories (skip node_modules, vendor, build output)
 2. Build a list of all exported symbols: functions, classes, types, constants, components

--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Debug
 
+## Core Rule
+
+Form a single hypothesis at a time. Validate with a falsifiable test before fixing. Never patch a symptom you haven't reproduced.
+
 ## When to Use
 
 Invoke with `/debug` when:

--- a/.claude/skills/deepening-review/SKILL.md
+++ b/.claude/skills/deepening-review/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Deepening Review
 
+## Core Rule
+
+Surface shallow modules as candidates, then grill one deeply — depth over breadth. Never deepen a module the user didn't choose.
+
 ## Kit Context
 
 Before starting this skill, ensure session boot is complete:

--- a/.claude/skills/dependency-audit/SKILL.md
+++ b/.claude/skills/dependency-audit/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Dependency Audit
 
+## Core Rule
+
+Flag known CVEs, license drift, and bloat with concrete upgrade paths. Never install or upgrade without explicit user approval.
+
 ## When to Use
 
 Invoke with `/dependency-audit` when:
@@ -16,9 +20,17 @@ Invoke with `/dependency-audit` when:
 - Assessing technical debt from outdated packages
 - Onboarding to a project and evaluating its dependency choices
 
+## Default Behavior
+
+When the user asks to audit, scan, review, or "give me a report" for dependencies / vulnerabilities, produce the full dependency-audit report automatically using the Process and Output Format sections below. Do not require the user to specify fields.
+
+Only modify files when the user explicitly requests implement / fix / apply / refactor. By default, this skill is **report-only**.
+
 ## Process
 
-### Phase 1: Inventory
+### Phase 1: Inventory (first-pass leads)
+
+This pass produces **candidates**, not findings. Treat counts as leads for deeper inspection in later phases. Do not report Phase 1 raw output as the final result.
 
 Catalog all dependencies:
 

--- a/.claude/skills/design-review/SKILL.md
+++ b/.claude/skills/design-review/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Design Review
 
+## Core Rule
+
+Compare implementation to the design source of truth. Flag divergence with screenshots and component refs; never auto-apply visual fixes.
+
 ## When to Use
 
 Invoke with `/design-review` when:
@@ -16,9 +20,17 @@ Invoke with `/design-review` when:
 - Reviewing responsive behavior across viewport sizes
 - Before shipping user-facing UI changes
 
+## Default Behavior
+
+When the user asks to audit, scan, review, or "give me a report" for design consistency / UI, produce the full design-review report automatically using the Process and Output Format sections below. Do not require the user to specify fields.
+
+Only modify files when the user explicitly requests implement / fix / apply / refactor. By default, this skill is **report-only**.
+
 ## Process
 
-### Phase 1: Design System Inventory
+### Phase 1: Inventory (first-pass leads)
+
+This pass produces **candidates**, not findings. Treat counts as leads for deeper inspection in later phases. Do not report Phase 1 raw output as the final result.
 
 Identify the project's design foundations:
 

--- a/.claude/skills/documentation-audit/SKILL.md
+++ b/.claude/skills/documentation-audit/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Documentation Audit
 
+## Core Rule
+
+Audit doc-code sync and reader experience. Recommend rewrites only when current docs mislead — small fixes beat broad refactors.
+
 ## When to Use
 
 Invoke with `/documentation-audit` when:
@@ -16,9 +20,17 @@ Invoke with `/documentation-audit` when:
 - After major feature additions to ensure docs are updated
 - Before a due diligence or code quality review
 
+## Default Behavior
+
+When the user asks to audit, scan, review, or "give me a report" for documentation, produce the full documentation-audit report automatically using the Process and Output Format sections below. Do not require the user to specify fields.
+
+Only modify files when the user explicitly requests implement / fix / apply / refactor. By default, this skill is **report-only**.
+
 ## Process
 
-### Phase 1: Documentation Inventory
+### Phase 1: Inventory (first-pass leads)
+
+This pass produces **candidates**, not findings. Treat counts as leads for deeper inspection in later phases. Do not report Phase 1 raw output as the final result.
 
 Catalog existing documentation:
 

--- a/.claude/skills/interface-design/SKILL.md
+++ b/.claude/skills/interface-design/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Interface Design
 
+## Core Rule
+
+Generate radically different alternatives before converging. Compare on depth, locality, and seam placement — not aesthetics.
+
 ## Kit Context
 
 Before starting:

--- a/.claude/skills/lesson-refresh/SKILL.md
+++ b/.claude/skills/lesson-refresh/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Lesson Refresh
 
+## Core Rule
+
+Decide keep / update / promote / encode / archive per lesson based on relevance and recency. Never delete a lesson without recording why.
+
 ## Kit Context
 
 Before starting this skill, ensure you have completed session boot:

--- a/.claude/skills/office-hours/SKILL.md
+++ b/.claude/skills/office-hours/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Office Hours
 
+## Core Rule
+
+Force product validation before code via uncomfortable questions. Stop the user from coding if the problem isn't clear.
+
 ## When to Use
 
 Invoke with `/office-hours` when:

--- a/.claude/skills/performance-audit/SKILL.md
+++ b/.claude/skills/performance-audit/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Performance Audit
 
+## Core Rule
+
+Report measurable bottlenecks with reproduction steps, not theoretical optimizations. Validate large-input assumptions before recommending complexity changes.
+
 ## When to Use
 
 Invoke with `/performance-audit` when:
@@ -15,9 +19,17 @@ Invoke with `/performance-audit` when:
 - After adding significant new features
 - During optimization sprints or performance budgeting
 
+## Default Behavior
+
+When the user asks to audit, scan, review, or "give me a report" for performance / bottlenecks, produce the full performance-audit report automatically using the Process and Output Format sections below. Do not require the user to specify fields.
+
+Only modify files when the user explicitly requests implement / fix / apply / refactor. By default, this skill is **report-only**.
+
 ## Process
 
-### Phase 1: Identify Stack
+### Phase 1: Inventory (first-pass leads)
+
+This pass produces **candidates**, not findings. Treat counts as leads for deeper inspection in later phases. Do not report Phase 1 raw output as the final result.
 
 Read project config files to determine the tech stack:
 

--- a/.claude/skills/project-health-report/SKILL.md
+++ b/.claude/skills/project-health-report/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Project Health Report
 
+## Core Rule
+
+Aggregate other audit findings into a stable scorecard. Don't invent metrics — only roll up signals other skills produced. Output must be reproducible.
+
 ## When to Use
 
 Invoke with `/project-health-report` when:
@@ -16,9 +20,17 @@ Invoke with `/project-health-report` when:
 - Planning a major initiative and need to understand the baseline
 - Stakeholder reporting on technical health
 
+## Default Behavior
+
+When the user asks to audit, scan, review, or "give me a report" for project health, produce the full project-health-report report automatically using the Process and Output Format sections below. Do not require the user to specify fields.
+
+Only modify files when the user explicitly requests implement / fix / apply / refactor. By default, this skill is **report-only**.
+
 ## Process
 
-### Phase 1: Project Overview
+### Phase 1: Inventory (first-pass leads)
+
+This pass produces **candidates**, not findings. Treat counts as leads for deeper inspection in later phases. Do not report Phase 1 raw output as the final result.
 
 Gather basic project information:
 

--- a/.claude/skills/pulse/SKILL.md
+++ b/.claude/skills/pulse/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Pulse
 
+## Core Rule
+
+Report what shipped, broke, was learned, and is open in a fixed time window. Surface signals, not opinions.
+
 ## Kit Context
 
 Before starting this skill, ensure you have completed session boot:

--- a/.claude/skills/refactoring-guide/SKILL.md
+++ b/.claude/skills/refactoring-guide/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Refactoring Guide
 
+## Core Rule
+
+Recommend Fowler-named refactors only when current behavior is understood and tested. Apply stepwise; verify between each step.
+
 ## When to Use
 
 Invoke with `/refactoring-guide` when:

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Retro
 
+## Core Rule
+
+Report patterns from session analytics, not speculation. Distinguish process improvements from one-time mistakes.
+
 ## When to Use
 
 Invoke with `/retro` when:

--- a/.claude/skills/review-pipeline/SKILL.md
+++ b/.claude/skills/review-pipeline/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Review Pipeline
 
+## Core Rule
+
+Parallelize independent auditors over a PR-scope diff. Dedupe across reports. Never widen scope beyond the diff.
+
 ## Kit Context
 
 Before starting this skill, ensure you have completed session boot:

--- a/.claude/skills/shape-spec/SKILL.md
+++ b/.claude/skills/shape-spec/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Shape Spec
 
+## Core Rule
+
+Force structured planning into a timestamped folder before multi-session work. Never start coding from this skill — it precedes implementation.
+
 ## When to Use
 
 Invoke with `/shape-spec` when:

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Ship
 
+## Core Rule
+
+Block deployment when CHANGELOG, tests, or coverage gates fail. Preserve rollback capability at every step. Never ship from a dirty working tree.
+
 ## When to Use
 
 Invoke with `/ship` when:

--- a/.claude/skills/skill-extractor/SKILL.md
+++ b/.claude/skills/skill-extractor/SKILL.md
@@ -8,6 +8,10 @@ user-invocable: true
 
 You are a knowledge extraction agent. Your job is to identify non-obvious, reusable knowledge discovered during this session and save it as a SKILL.md file that Claude Code can automatically load in future sessions.
 
+## Core Rule
+
+Extract knowledge that's non-obvious, reusable, and triggered by clear signals. Never extract trivial restatements of language or library docs.
+
 ## When to Extract
 
 Extract a skill when you discover something that is:

--- a/.claude/skills/skill-generator/SKILL.md
+++ b/.claude/skills/skill-generator/SKILL.md
@@ -8,6 +8,10 @@ user-invocable: true
 
 You are a project standards generator. Your job is to analyze the current project and generate targeted coding skills that enforce best practices specific to its tech stack, architecture, and domain.
 
+## Core Rule
+
+Generate project-specific skills only after reading the tech stack. Skills must follow kit conventions (Core Rule, When to Use, Scope Rules).
+
 ## When to Use
 
 Invoke with `/skill-generator` when:

--- a/.claude/skills/testing-audit/SKILL.md
+++ b/.claude/skills/testing-audit/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Testing Audit
 
+## Core Rule
+
+Distinguish test gaps from test churn. Report missing critical-path coverage and flaky tests separately; never recommend tests beyond reproducibility need.
+
 ## Kit Context
 
 Before starting this skill, ensure you have completed session boot:
@@ -24,6 +28,12 @@ Invoke with `/testing-audit` when:
 - Planning a testing strategy improvement
 - Reviewing test quality after rapid feature development
 - Assessing confidence level before a major release
+
+## Default Behavior
+
+When the user asks to audit, scan, review, or "give me a report" for test coverage and quality, produce the full testing-audit report automatically using the Process and Output Format sections below. Do not require the user to specify fields.
+
+Only modify files when the user explicitly requests implement / fix / apply / refactor. By default, this skill is **report-only**.
 
 ## Scope Rules
 
@@ -44,7 +54,9 @@ Before analysis, map the project:
 
 ## Process
 
-### Phase 1: Test Inventory
+### Phase 1: Inventory (first-pass leads)
+
+This pass produces **candidates**, not findings. Treat counts as leads for deeper inspection in later phases. Do not report Phase 1 raw output as the final result.
 
 Map the current test landscape:
 

--- a/agent_docs/skills.md
+++ b/agent_docs/skills.md
@@ -91,6 +91,60 @@ Every skill — whether hand-written or generated — should follow these princi
 - [ ] Every rule has a rationale (WHY, not just WHAT)
 - [ ] Code examples use the project's actual stack and versions
 
+## Skill Conventions (v1.11.0+)
+
+Three conventions all skills should follow. The `scripts/validate-skills.sh` validator warns when these are missing.
+
+### 1. Core Rule (required for every skill)
+
+Every `SKILL.md` opens with a `## Core Rule` section — one sentence (max ~25 words) that anchors the skill's ethical scope.
+
+```markdown
+## Core Rule
+
+Form a single hypothesis at a time. Validate with a falsifiable test before fixing. Never patch a symptom you haven't reproduced.
+```
+
+Goes immediately after the title (and the optional intro paragraph), before any other `##` section. The rule states what must be preserved or what's forbidden — the deal-breaker that distinguishes this skill from a free-form prompt. Inspired by [codex-complexity-optimizer](https://github.com/Kappaemme-git/codex-complexity-optimizer).
+
+### 2. Default Behavior (required for audit-class skills)
+
+Audit-class skills (skills with `## Output Format` that produce a structured report) include a `## Default Behavior` section telling the agent what to do **autonomously** when invoked. This removes friction from "audit / scan / review / give me a report" requests.
+
+```markdown
+## Default Behavior
+
+When the user asks to audit, scan, review, or "give me a report" for <DOMAIN>, produce the full <skill-name> report automatically using the Process and Output Format sections below. Do not require the user to specify fields.
+
+Only modify files when the user explicitly requests implement / fix / apply / refactor. By default, this skill is **report-only**.
+```
+
+The 10 audit-class skills today: `code-quality-audit`, `performance-audit`, `architecture-review`, `accessibility-audit`, `testing-audit`, `dependency-audit`, `documentation-audit`, `design-review`, `project-health-report`, `dead-code-audit`.
+
+### 3. Phase 1 Inventory naming (audit-class skills)
+
+Audit-class skills use uniform Phase 1 naming and an explicit "candidates, not findings" framing — discouraging the agent from reporting raw scanner output as final findings.
+
+```markdown
+### Phase 1: Inventory (first-pass leads)
+
+This pass produces **candidates**, not findings. Treat counts as leads for deeper inspection in later phases. Do not report Phase 1 raw output as the final result.
+
+<phase-specific content>
+```
+
+### Reusable Shared Blocks
+
+When writing a new skill, copy patterns from the shared blocks:
+
+- `.claude/skills/_shared/blocks/core-rule.md` — Core Rule template + examples
+- `.claude/skills/_shared/blocks/default-behavior.md` — Default Behavior pattern with `<DOMAIN>` / `<skill-name>` placeholders
+- `.claude/skills/_shared/blocks/inventory-framing.md` — Phase 1 framing
+
+For templated skills (`.tmpl` files in `_templates/`), inline the actual text — bespoke per skill, not block-substituted.
+
+---
+
 ## Skill Structure
 
 ### Simple (default)

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -150,6 +150,33 @@ for skill_dir in "$SKILLS_DIR"/*/; do
     done
   fi
 
+  # --- Check Core Rule (v1.11+ pattern, codex-inspired) ---
+  if echo "$CONTENT" | grep -q "^## Core Rule$"; then
+    pass "Has Core Rule"
+  else
+    warn "Missing ## Core Rule section (one-sentence ethical scope — see agent_docs/skills.md)"
+  fi
+
+  # --- Check Default Behavior + Phase 1 Inventory (audit skills only) ---
+  # The kit's "audit-class" skills are an explicit set — direct report producers.
+  # Other skills with Output Format (review-pipeline, deepening-review, pulse, retro)
+  # are meta or interactive and don't need the same patterns.
+  case "$skill_name" in
+    code-quality-audit|performance-audit|architecture-review|accessibility-audit|testing-audit|dependency-audit|documentation-audit|design-review|project-health-report|dead-code-audit)
+      if echo "$CONTENT" | grep -q "^## Default Behavior$"; then
+        pass "Has Default Behavior (audit skill)"
+      else
+        warn "Missing ## Default Behavior section (audit skill should autonomously act on 'audit/scan/review' requests)"
+      fi
+
+      if echo "$CONTENT" | grep -q "^### Phase 1: Inventory (first-pass leads)$"; then
+        pass "Phase 1 uses standard Inventory naming"
+      elif echo "$CONTENT" | grep -q "^### Phase 1:"; then
+        warn "Phase 1 not standardized as 'Inventory (first-pass leads)' — see agent_docs/skills.md"
+      fi
+      ;;
+  esac
+
   # --- Check for unfilled placeholders (excluding code blocks) ---
   PLACEHOLDERS=$(awk '/^```/{skip=!skip;next} !skip && !/`/' "$SKILL_FILE" | grep -cE '<[^>]+(name|description|language|skill|check|command|pattern)>' 2>/dev/null || echo "0")
   PLACEHOLDERS=$(echo "$PLACEHOLDERS" | tr -d '[:space:]')

--- a/tasks/decisions.md
+++ b/tasks/decisions.md
@@ -37,6 +37,30 @@ Track important technical decisions here so they don't get lost between sessions
 
 <!-- Add new decisions below this line -->
 
+### ADR-004: Adopt three skill conventions from codex-complexity-optimizer (Core Rule, Default Behavior, Phase 1 Inventory)
+- **Date**: 2026-05-18
+- **Status**: accepted
+- **Context**: The kit's 23 skills had inconsistent structure: Phase 1 named variously ("Scope" / "Scope & Inventory" / "Test Inventory" / etc.), no top-level ethical scope statement, and audit skills required users to specify what to audit instead of producing a report autonomously. While reviewing [codex-complexity-optimizer](https://github.com/Kappaemme-git/codex-complexity-optimizer) (728 stars, 3 days old), three patterns stood out as directly applicable to the kit's existing skill family.
+- **Options**:
+  - A) **Adopt three patterns** — Core Rule (all 23 skills), Default Behavior + Phase 1 Inventory naming (10 audit skills). Pure markdown changes, no new infrastructure.
+  - B) **Adopt the whole complexity-optimizer skill** — drop in as a new skill. Maintenance burden (sync with upstream), overlaps with `performance-audit`.
+  - C) **Take inspiration but redesign** — write new skill conventions from scratch. Higher quality bar, but unnecessary — the codex patterns are already well-shaped.
+- **Decision**: A (three patterns). Rationale: small, mechanical, immediately useful, doesn't add an outsider skill to maintain. The Phase 1 Inventory framing ("candidates, not findings") solves a real problem we've seen — agents reporting scanner raw counts as final findings.
+- **Sub-decisions**:
+  - **Audit-class set is explicit (10 skills)**, not heuristic. Codifying which skills get Default Behavior + Phase 1 patterns by name list (`code-quality-audit`, `performance-audit`, `architecture-review`, etc.) avoids classifier drift in `validate-skills.sh`.
+  - **Core Rule is universal** (all 23 skills). Even non-audit skills (debug, ship, lesson-refresh) benefit from a one-sentence "deal-breaker" anchor.
+  - **Phase 1 framing is uniform text**, not skill-bespoke. Reduces drift, makes the convention scannable.
+  - **Validator warns, doesn't fail.** v1 ships as advisory; can promote to fail-block in a future revision after the convention settles.
+- **Consequences**:
+  - 23 skill SKILL.md files modified (insert Core Rule)
+  - 10 of those also got Default Behavior + Phase 1 Inventory framing
+  - 3 .tmpl templates updated to match (otherwise `build-skills.sh` would overwrite the patches)
+  - 3 new shared blocks created as documentation: `core-rule.md`, `default-behavior.md`, `inventory-framing.md`
+  - `scripts/validate-skills.sh` gained 3 new checks (warnings only)
+  - `agent_docs/skills.md` documents the conventions
+  - Patcher script `/tmp/patch-skills.py` was used for the bulk migration; not committed (one-shot tooling)
+  - Future skills should follow the conventions from inception — `skill-generator` skill updates the agent on how
+
 ### ADR-003: Hook-shift — move prompt-based discipline rules into deterministic lifecycle hooks
 - **Date**: 2026-05-16
 - **Status**: accepted


### PR DESCRIPTION
## Summary

Three skill conventions adopted across the kit's 23 skills, inspired by [codex-complexity-optimizer](https://github.com/Kappaemme-git/codex-complexity-optimizer). See `tasks/decisions.md` → ADR-004 for full rationale.

**Closes #109, #110, #111.**

## What changes

### Core Rule (all 23 skills) — #110

Every `SKILL.md` now opens with a `## Core Rule` section — a one-sentence ethical anchor (max ~25 words) that states what must be preserved or what's forbidden, even on user request.

Examples:
- `debug`: "Form a single hypothesis at a time. Validate with a falsifiable test before fixing. Never patch a symptom you haven't reproduced."
- `ship`: "Block deployment when CHANGELOG, tests, or coverage gates fail. Preserve rollback capability at every step. Never ship from a dirty working tree."
- `dead-code-audit`: "Confirm code is unreachable across the full call graph before flagging. Never remove code without explicit user approval, even for obvious dead branches."

### Default Behavior (10 audit-class skills) — #109

Audit-class skills (`code-quality-audit`, `performance-audit`, `architecture-review`, `accessibility-audit`, `testing-audit`, `dependency-audit`, `documentation-audit`, `design-review`, `project-health-report`, `dead-code-audit`) now include a `## Default Behavior` section that tells the agent to produce the full report autonomously on `/audit` / `/scan` / `/review` / "give me a report" requests, without back-and-forth clarification.

Each block explicitly notes: **report-only by default**; modifications require explicit user request.

### Phase 1 Inventory (10 audit-class skills) — #111

Audit-class skills now use a uniform `### Phase 1: Inventory (first-pass leads)` heading with explicit "candidates, not findings" framing:

> This pass produces **candidates**, not findings. Treat counts as leads for deeper inspection in later phases. Do not report Phase 1 raw output as the final result.

Discourages reporting raw scanner counts as if they were final findings — a recurring failure mode.

## Infrastructure

- **3 new shared blocks** at `.claude/skills/_shared/blocks/{core-rule,default-behavior,inventory-framing}.md` document the patterns for new skills
- **3 .tmpl templates** (`code-quality-audit`, `dead-code-audit`, `testing-audit`) updated to match — `build-skills.sh` now generates matching SKILL.md
- **`scripts/validate-skills.sh`** gained 3 new advisory checks (warns, doesn't fail). Audit-class detection uses an explicit name list, not a fragile heuristic
- **`agent_docs/skills.md`** has a new "Skill Conventions (v1.11.0+)" section

## Test plan

- [x] `./scripts/validate-skills.sh` → **230 passed, 0 failed, 0 warnings** across all 23 skills
- [x] `./scripts/build-skills.sh` → all 3 templated skills rebuild cleanly
- [x] No regression: existing skill section requirements (When to Use, Process, Output Format, Notes) still verified
- [x] Idempotent migration script (used during this PR, not committed — see ADR-004)
- [x] Both `Core Rule` and inflectional placement work for skills with intro paragraphs (skill-extractor, skill-generator)

## Backward compatibility

- All existing skills still load + render correctly — only **additive** changes
- New `Core Rule` placement is purely additive (between title and first ## section)
- New `Default Behavior` placement is between `When to Use` and the next ## section — doesn't displace existing content
- `Phase 1` rename + framing preserves all original phase content (just renames the heading + adds 2 lines of framing)
- Validator warnings are non-blocking (info-only)

## Companion v1.11.0 issues (open, not blocked by this PR)

- #105 Bash budget observability (rtk-inspired)
- #106 Session scorecards (GBrain-inspired)
- #107 Typed lesson links (GBrain-inspired)
- #108 KitBench eval harness (GBrain-inspired)

## See

- ADR-004 in `tasks/decisions.md`
- Updated `agent_docs/skills.md` "Skill Conventions (v1.11.0+)" section
- [codex-complexity-optimizer SKILL.md](https://github.com/Kappaemme-git/codex-complexity-optimizer/blob/master/complexity-optimizer/SKILL.md) — pattern source