### PR TITLE
feat(hooks): bash output budget observability (PostToolUse signal hook)

### DIFF
--- a/.claude/hooks/bash-budget.sh
+++ b/.claude/hooks/bash-budget.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# bash-budget.sh — PostToolUse hook (matcher: Bash)
+#
+# Tracks cumulative Bash output token cost per session. Emits a one-time
+# stderr warning when a configurable threshold is crossed. Does NOT block.
+#
+# Rationale: Bash output is empirically the #1 context-window consumer in
+# agentic sessions. Edit/Write hooks already cover file changes; this hook
+# closes the observability gap on the shell side.
+#
+# State: .hook-state/bash-budget.json (atomic write; self-gitignored).
+# Threshold: $BASH_BUDGET_THRESHOLD env var, default 50000 tokens.
+# Estimate: (chars stdout + chars stderr) / 4 — no LLM calls, no deps.
+#
+# Inspired by rtk's "command output dominates context cost" observation,
+# without rtk's lossy proxy-rewrite model. We measure and signal; we never
+# rewrite or truncate.
+#
+
+set -euo pipefail
+
+INPUT=$(cat)
+HOOK_LIB="$(cd "$(dirname "$0")/lib" 2>/dev/null && pwd)"
+source "$HOOK_LIB/json-parse.sh"
+
+TOOL_NAME=$(parse_json_field "tool_name")
+[ "$TOOL_NAME" = "Bash" ] || exit 0
+
+COMMAND=$(parse_json_field "command")
+
+# Read tool_response.{stdout,stderr}. The shared json-parse.sh only handles
+# tool_input.X and top-level X; tool_response lives one level deep, so parse
+# inline here.
+if command -v jq &>/dev/null; then
+  STDOUT=$(printf '%s' "$INPUT" | jq -r '.tool_response.stdout // ""' 2>/dev/null || printf '')
+  STDERR=$(printf '%s' "$INPUT" | jq -r '.tool_response.stderr // ""' 2>/dev/null || printf '')
+elif command -v python3 &>/dev/null; then
+  STDOUT=$(printf '%s' "$INPUT" | python3 -c "import sys,json
+try:
+    d=json.load(sys.stdin)
+    r=d.get('tool_response',{}) or {}
+    sys.stdout.write(r.get('stdout','') or '')
+except Exception:
+    pass" 2>/dev/null || printf '')
+  STDERR=$(printf '%s' "$INPUT" | python3 -c "import sys,json
+try:
+    d=json.load(sys.stdin)
+    r=d.get('tool_response',{}) or {}
+    sys.stdout.write(r.get('stderr','') or '')
+except Exception:
+    pass" 2>/dev/null || printf '')
+else
+  # No JSON parser available — best effort, treat as empty.
+  STDOUT=""
+  STDERR=""
+fi
+
+# Token estimate: chars / 4 (well-established heuristic for English/code).
+TOTAL_CHARS=$(( ${#STDOUT} + ${#STDERR} ))
+TOKENS=$(( TOTAL_CHARS / 4 ))
+
+# Find project root (same algorithm as quality-gate.sh).
+DIR=$(pwd)
+ROOT="$DIR"
+while [ "$ROOT" != "/" ]; do
+  if [ -f "$ROOT/package.json" ] || [ -f "$ROOT/pyproject.toml" ] || [ -f "$ROOT/go.mod" ] || [ -f "$ROOT/Cargo.toml" ] || [ -d "$ROOT/.git" ]; then
+    break
+  fi
+  ROOT=$(dirname "$ROOT")
+done
+[ "$ROOT" = "/" ] && exit 0  # no project root → nothing to track
+
+STATE_DIR="$ROOT/.hook-state"
+mkdir -p "$STATE_DIR"
+# Self-gitignore: state is transient, never commit.
+[ -f "$STATE_DIR/.gitignore" ] || printf '*\n!.gitignore\n' >"$STATE_DIR/.gitignore"
+
+STATE_FILE="$STATE_DIR/bash-budget.json"
+THRESHOLD="${BASH_BUDGET_THRESHOLD:-50000}"
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# Extract first 1-2 words of the command for top5 bucketing.
+CMD_HEAD=$(printf '%s' "$COMMAND" | awk '{print $1" "$2}' | sed 's/[[:space:]]*$//')
+[ -z "$CMD_HEAD" ] && CMD_HEAD="(empty)"
+
+# State mutation: python3 owns the atomic JSON read-modify-write. Signals a
+# threshold crossing via exit code 42 (chosen to avoid collision with 0/2).
+PY_RC=0
+if command -v python3 &>/dev/null; then
+  set +e
+  python3 - "$STATE_FILE" "$TOKENS" "$THRESHOLD" "$NOW" "$CMD_HEAD" <<'PY' 2>/dev/null
+import json, os, sys
+
+state_file = sys.argv[1]
+tokens = int(sys.argv[2])
+threshold = int(sys.argv[3])
+now = sys.argv[4]
+cmd_head = sys.argv[5]
+
+try:
+    with open(state_file) as f:
+        state = json.load(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    state = None
+
+if not isinstance(state, dict) or state.get("schema_version") != 1:
+    state = {
+        "schema_version": 1,
+        "cumulative_tokens": 0,
+        "threshold": threshold,
+        "warned": False,
+        "since_session_start": now,
+        "by_command_top5": {},
+    }
+
+prev_total = int(state.get("cumulative_tokens", 0))
+new_total = prev_total + tokens
+state["cumulative_tokens"] = new_total
+state["threshold"] = threshold
+
+by_cmd = dict(state.get("by_command_top5", {}))
+by_cmd[cmd_head] = int(by_cmd.get(cmd_head, 0)) + tokens
+state["by_command_top5"] = dict(sorted(by_cmd.items(), key=lambda kv: -kv[1])[:5])
+
+crossed_now = (not state.get("warned", False)) and new_total >= threshold
+if crossed_now:
+    state["warned"] = True
+
+tmp = state_file + ".tmp"
+with open(tmp, "w") as f:
+    json.dump(state, f, indent=2)
+os.replace(tmp, state_file)
+
+sys.exit(42 if crossed_now else 0)
+PY
+  PY_RC=$?
+  set -e
+fi
+
+if [ "$PY_RC" = "42" ]; then
+  cat >&2 <<EOF
+[bash-budget] Cumulative Bash output has crossed ${THRESHOLD} tokens this session.
+Context compaction risk is high. Prefer compact-output flags:
+  git status        → git status --short
+  pytest            → pytest -q --tb=line
+  cargo test        → cargo test --quiet
+  rg "x" .          → rg --count "x" .
+See agent_docs/conventions.md → Compact Output Flags.
+This warning is one-shot per session; further high-volume commands will be tracked silently.
+EOF
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -115,6 +115,15 @@
             "command": ".claude/hooks/quality-gate.sh"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/bash-budget.sh"
+          }
+        ]
       }
     ],
     "Stop": [

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -84,6 +84,7 @@ Developers using Claude Code and similar agents often get inconsistent results �
 │   │   ├── unicode-scan.sh        # PostToolUse: detect invisible Unicode (Glassworm)
 │   │   ├── loop-detect.sh         # PostToolUse: edit loop detection
 │   │   ├── quality-gate.sh        # PostToolUse: run typecheck/lint, write .hook-state/
+│   │   ├── bash-budget.sh         # PostToolUse (Bash): estimate cumulative output token cost, one-shot warn at threshold
 │   │   ├── stop-gate.sh           # Stop: block completion when last quality gate failed
 │   │   ├── task-complete-notify.sh # Stop: desktop notification on success
 │   │   ├── session-end.sh         # SessionEnd: append audit line to reports/session-audit.log

--- a/agent_docs/conventions.md
+++ b/agent_docs/conventions.md
@@ -110,6 +110,31 @@ chore/short-description
 
 ---
 
+## Compact Output Flags
+
+Bash output is the #1 context-window consumer in agentic sessions. The `bash-budget.sh` PostToolUse hook tracks cumulative output cost and warns once when the session crosses `$BASH_BUDGET_THRESHOLD` (default 50 000 tokens). To stay under the line, prefer the compact form of common commands. The verbose form is fine for one-shot inspection; reach for the compact form once a command appears in a loop or is run on a large repo.
+
+| Verbose | Compact | When to use the compact form |
+|---------|---------|------------------------------|
+| `git status` | `git status --short` | Exploring repo state; the long form repeats the same hints every call |
+| `git diff` | `git diff --stat` (then `git diff <file>` selectively) | Surveying a change set before drilling in |
+| `git log` | `git log --oneline -n 20` | Recent-history scan; full bodies needed rarely |
+| `pytest` | `pytest -q --tb=line` | Smoke / pass-fail check; full traceback only on red |
+| `cargo test` | `cargo test --quiet` | Compile + pass/fail summary; expand on failure |
+| `cargo build` | `cargo build --message-format=short` | Build error count; full diagnostics on demand |
+| `go test ./...` | `go test -count=1 ./... 2>&1 \| tail -40` | Trim the per-package PASS spam, surface the tail |
+| `npm test` | `npm test --silent` | Drops setup chatter; keep verbose for the failing case |
+| `rg "pat" .` | `rg --count "pat" .` or `rg -l "pat" .` | Counts or filenames first; widen to context only after a target picks itself |
+| `find . -name '*.x'` | `fd -e x` (or `rg --files \| rg '\.x$'`) | Faster + shorter listing |
+| `tree` | `ls -F` or `tree -L 2 -I 'node_modules\|.git'` | Bounded depth and exclusions |
+| `kubectl logs` | `kubectl logs --tail=200` | Avoid full-history dump; widen only after sampling |
+| `docker logs` | `docker logs --tail=200 --since=10m` | Same — bounded by time and lines |
+| `cat <file>` | `head -50 <file>` / `tail -50 <file>` | Sample first; full Read via the Read tool is cheaper than `cat` in long files |
+
+When the hook fires its one-shot warning, switch to the compact column for high-volume commands for the rest of the session. Avoid piping large outputs through `cat`/`echo` echoes — they double the token count without adding signal.
+
+---
+
 ## Code Review Expectations
 
 When reviewing or preparing code for review:

--- a/agent_docs/hooks.md
+++ b/agent_docs/hooks.md
@@ -33,12 +33,13 @@ Philosophy: **Use prompts for guidance. Use hooks for behavior that should run e
 
 ### PostToolUse (runs AFTER a tool executes)
 
-| Hook | File | What it does |
-|------|------|-------------|
-| **secret-scan** | `.claude/hooks/secret-scan.sh` | Scans edited files for API keys, tokens, passwords |
-| **unicode-scan** | `.claude/hooks/unicode-scan.sh` | Detects invisible Unicode (Glassworm vector) |
-| **loop-detect** | `.claude/hooks/loop-detect.sh` | Warns at 4 edits, blocks at 6 edits to the same file |
-| **quality-gate** | `.claude/hooks/quality-gate.sh` | Runs a fast typecheck/lint after Edit/Write, writes `.hook-state/last_quality_gate.json`. Does NOT block — `stop-gate.sh` does the blocking based on the persisted result. |
+| Hook | File | Matcher | What it does |
+|------|------|---------|-------------|
+| **secret-scan** | `.claude/hooks/secret-scan.sh` | `Edit\|Write\|NotebookEdit` | Scans edited files for API keys, tokens, passwords |
+| **unicode-scan** | `.claude/hooks/unicode-scan.sh` | `Edit\|Write\|NotebookEdit` | Detects invisible Unicode (Glassworm vector) |
+| **loop-detect** | `.claude/hooks/loop-detect.sh` | `Edit\|Write\|NotebookEdit` | Warns at 4 edits, blocks at 6 edits to the same file |
+| **quality-gate** | `.claude/hooks/quality-gate.sh` | `Edit\|Write\|NotebookEdit` | Runs a fast typecheck/lint after Edit/Write, writes `.hook-state/last_quality_gate.json`. Does NOT block — `stop-gate.sh` does the blocking based on the persisted result. |
+| **bash-budget** | `.claude/hooks/bash-budget.sh` | `Bash` | Estimates cumulative Bash output token cost per session (chars / 4). One-shot stderr warning when `$BASH_BUDGET_THRESHOLD` (default 50000) is first crossed. Does NOT block — observability only. Writes `.hook-state/bash-budget.json`. |
 
 ### Stop (runs when Claude tries to finish a turn)
 
@@ -73,6 +74,7 @@ Three hooks share state through transient files at the project root. These are *
 | File | Written by | Read by | Purpose |
 |------|-----------|---------|---------|
 | `.hook-state/last_quality_gate.json` | `quality-gate.sh` | `stop-gate.sh`, `session-end.sh` | Most recent verification result: `{status, exit_code, tool, edited_file, duration_seconds, stderr_tail}` |
+| `.hook-state/bash-budget.json` | `bash-budget.sh` | (operator review) | Cumulative Bash output token estimate for the session: `{schema_version, cumulative_tokens, threshold, warned, since_session_start, by_command_top5}` |
 | `reports/session-audit.log` | `session-end.sh` | (operator review) | One JSON line per session: timestamp, session_id, reason, transcript_path, last_quality_gate |
 
 Both directories are created on demand. Delete them anytime — the next hook run re-creates them.
@@ -90,6 +92,7 @@ Some hooks block actions or completion. When they get in the way (broken test in
 | `CLAUDE_APPROVED=1` | `protect-changes.sh` skips its block. Record the rationale in `tasks/decisions.md` (ADR template) — that is the agreed audit trail. |
 | `SKIP_QUALITY_GATE=1` | `stop-gate.sh` allows completion even with a failed gate. Use sparingly; the failure is still recorded in `.hook-state/last_quality_gate.json`. |
 | `CLAUDE_SKIP_QUALITY_GATE=1` | Alias for the above. |
+| `BASH_BUDGET_THRESHOLD=<n>` | Overrides the default 50000-token threshold used by `bash-budget.sh`. Set to a high number (e.g. 999999999) to suppress the warning entirely; set lower to surface it earlier. |
 
 Set per-session (`export CLAUDE_APPROVED=1`) or per-command (`CLAUDE_APPROVED=1 claude ...`). Never put these in committed config — they defeat the purpose.
 
@@ -142,6 +145,7 @@ The installer supports three profiles (`--profile minimal|standard|strict`). Eac
 | unicode-scan | | ✓ | ✓ |
 | loop-detect | | ✓ | ✓ |
 | quality-gate | | ✓ | ✓ |
+| bash-budget | | ✓ | ✓ |
 | stop-gate | | ✓ | ✓ |
 | task-complete-notify | | ✓ | ✓ |
 | session-end | | ✓ | ✓ |

--- a/install.sh
+++ b/install.sh
@@ -486,6 +486,15 @@ generate_strict_settings() {
             "command": ".claude/hooks/quality-gate.sh"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/bash-budget.sh"
+          }
+        ]
       }
     ],
     "Stop": [

--- a/tasks/decisions.md
+++ b/tasks/decisions.md
@@ -37,6 +37,29 @@ Track important technical decisions here so they don't get lost between sessions
 
 <!-- Add new decisions below this line -->
 
+### ADR-005: Bash output budget observability (PostToolUse signal hook, non-blocking)
+- **Date**: 2026-05-18
+- **Status**: accepted
+- **Context**: The kit ships 18 hooks watching Edit/Write but zero observability on Bash output. Empirically, Bash output (test logs, diff dumps, find/rg results) is the #1 context-window consumer in agentic sessions — frequently 30K+ tokens before the agent realises compaction is near. Inspired by [rtk](https://github.com/rtk-ai/rtk)'s core observation about command output dominance, but rtk's approach (lossy proxy-rewrite) conflicts with the kit's titiz / fidelity-preserving stance. The gap to close is awareness, not silent compression.
+- **Options**:
+  - A) **Adopt rtk-style proxy rewrite** — wrap Bash to rewrite verbose output (truncate, summarise). Pros: directly reduces tokens. Cons: lossy, hides information the agent might need, violates "verbatim outputs" expectations, introduces a wrapper layer.
+  - B) **Signal-only PostToolUse hook** — track cumulative `len(stdout)+len(stderr)` per session as a `chars/4` token estimate; emit one-shot stderr warning at `$BASH_BUDGET_THRESHOLD` (default 50K). Pros: zero lossy behaviour, deterministic, no deps, low maintenance. Cons: doesn't reduce tokens itself — agent must react.
+  - C) **Per-command policy with replacement suggestions** — hook inspects the command and rewrites verbose forms (e.g. `git status` → `git status --short`) before they run. Pros: actually saves tokens. Cons: surprising rewrites, command semantics shift mid-session, breaks scripts that parse output, much more code to maintain.
+- **Decision**: B (signal-only). Rationale: the kit's hook philosophy is "measure and block", not "rewrite silently". Awareness + a `Compact Output Flags` table in `agent_docs/conventions.md` lets the agent react with full agency. The hook never alters behaviour; it only annotates the cost.
+- **Sub-decisions**:
+  - **Threshold default 50000 tokens** — covers ~200K chars stdout, roughly the point where compaction risk becomes material on a 200K-context model.
+  - **One-shot warning per session** (`warned: true` latch) — repeating the warning every call past threshold would become noise; the agent already has the signal.
+  - **`chars / 4` heuristic, no tokeniser** — deterministic, no Python/tokeniser dependency, accurate enough for a threshold signal (true token count would be marginally different but not directionally).
+  - **First two words of the command** as the `by_command_top5` bucket key — distinguishes `git diff` from `git status` without proliferating one-off keys per file argument.
+  - **Profile**: standard + strict (mirrors quality-gate). Observability is core, not opt-in.
+- **Consequences**:
+  - New hook `.claude/hooks/bash-budget.sh` (PostToolUse, matcher `Bash`)
+  - New state file `.hook-state/bash-budget.json` (schema_version 1; self-gitignored via existing `.hook-state/.gitignore` pattern)
+  - New env var `BASH_BUDGET_THRESHOLD` (escape hatch / tuning knob)
+  - `agent_docs/conventions.md` gains a `## Compact Output Flags` reference table
+  - `agent_docs/hooks.md` PostToolUse table gains a `Matcher` column (now that two matchers coexist there)
+  - The hook reads `tool_response.stdout/stderr` directly via `jq` / `python3` because `lib/json-parse.sh` only handles `tool_input.*`. If a third hook needs `tool_response.*`, factor that into the shared lib.
+
 ### ADR-004: Adopt three skill conventions from codex-complexity-optimizer (Core Rule, Default Behavior, Phase 1 Inventory)
 - **Date**: 2026-05-18
 - **Status**: accepted

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -6,6 +6,20 @@ Track current and upcoming tasks here. The agent updates this file as work progr
 
 ## In Progress
 
+### v1.11.0 batch — Inspiration triad (rtk + GBrain + karpathy)
+
+Imported from GitHub #105–#116 into Linear (CLA-5 → CLA-11). Single batch, branch per issue, deploy on completion.
+
+- [x] **CLA-5** / GH #105 — `bash-budget.sh` PostToolUse hook (rtk-inspired, signal-only). ADR-005 recorded.
+- [ ] **CLA-7** / GH #107 — typed lesson links via frontmatter + `scripts/lesson-graph.sh`. ADR-006.
+- [ ] **CLA-6** / GH #106 — session scorecards (enriched `session-end.sh` + `/scorecard` skill). ADR-007.
+- [ ] **CLA-8** / GH #108 — KitBench eval harness (`bench/`, `scripts/run-bench.sh`, 15 scenarios). ADR-008.
+- [ ] **CLA-9** / GH #114 — Goal-Driven Task Reframing (docs in `agent_docs/workflow.md` + CLAUDE.md pointer).
+- [ ] **CLA-10** / GH #115 — explicit "Match existing style" rule (docs in `CLAUDE.md` + `agent_docs/conventions.md`).
+- [ ] **CLA-11** / GH #116 — Claude Code plugin marketplace entry (`.claude-plugin/` + manifest). Separate scope — v1.12.0 candidate, included in this batch per user direction.
+
+Ordering rationale: implementation issues first (5 → 7 → 6 → 8) so downstream features can pick up upstream state. Pure docs (9, 10) follow. Plugin marketplace (11) last because it ships an alternate distribution channel separate from kit internals.
+
 ---
 
 ## Up Next


### PR DESCRIPTION
## Summary

Adds `bash-budget.sh` — a PostToolUse hook (matcher `Bash`) that estimates cumulative Bash output token cost per session and emits a one-shot stderr warning when `$BASH_BUDGET_THRESHOLD` (default 50 000 tokens) is crossed. Closes the kit's observability gap on the #1 context-window consumer.

Signal-only by design — never blocks, rewrites, or truncates output. The agent reacts by switching to the new **Compact Output Flags** table in `agent_docs/conventions.md`.

## Why this approach

Inspired by [rtk](https://github.com/rtk-ai/rtk)'s observation that command output dominates context cost. Rejected rtk's proxy-rewrite approach (lossy, surprising) in favor of pure observability. See `tasks/decisions.md → ADR-005` for the full rationale and the three options considered.

## What's in scope

- `.claude/hooks/bash-budget.sh` — bash hook, atomic JSON state via python3
- `.hook-state/bash-budget.json` — schema_version 1, self-gitignored via existing `.hook-state/.gitignore` pattern
- `.claude/settings.json` + `install.sh` strict heredoc — wired into standard + strict profiles
- `agent_docs/conventions.md` — new `## Compact Output Flags` section with 14-row substitution table
- `agent_docs/hooks.md` — `Matcher` column added to PostToolUse table, bash-budget entry in State Files + Escape Hatches + Profile tables
- `CODEBASE_MAP.md` — new bash-budget entry in directory listing
- `tasks/decisions.md` → ADR-005 (renumbered: the issue text said ADR-004, but ADR-004 is already taken by codex-complexity-optimizer skill conventions from v1.10.0)
- `tasks/todo.md` — v1.11.0 batch plan with this row complete

## Smoke test results (local)

| Scenario | Expectation | Result |
|---|---|---|
| Small output below threshold | tracked, no warning | pass |
| Accumulate ~10k tokens | cumulative updates correctly | pass |
| Cross 50k threshold | one-shot stderr warning, warned=true | pass |
| Continue past threshold | silent (latch holds) | pass |
| Non-Bash tool | state unchanged | pass |

## Acceptance criteria

- [x] Hook fires on every PostToolUse Bash and atomically updates state file
- [x] Token estimate uses chars / 4 heuristic (no LLM, no external deps)
- [x] State file self-gitignored (matches existing `.hook-state/` pattern)
- [x] Warning is one-shot per session (`warned` flag latch)
- [x] `agent_docs/conventions.md` includes the compact-flag table
- [x] `agent_docs/hooks.md` documents the new hook + state file format
- [x] Smoke test: simulated 60K cumulative produces stderr warning exactly once
- [x] No regression on existing PostToolUse chain (Edit/Write/NotebookEdit matcher untouched)
- [x] ADR recorded in `tasks/decisions.md` (ADR-005, not ADR-004 — already taken)

Closes #105.

Part of the v1.11.0 inspiration triad (rtk + GBrain + karpathy). Companions: #106, #107, #108, #114, #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)