### PR TITLE
feat(hooks): session scorecards — schema_version 2 metrics in session-end audit

### DIFF
--- a/.claude/hooks/block-dangerous-commands.sh
+++ b/.claude/hooks/block-dangerous-commands.sh
@@ -11,6 +11,9 @@ set -euo pipefail
 INPUT=$(cat)
 HOOK_LIB="$(cd "$(dirname "$0")/lib" 2>/dev/null && pwd)"
 source "$HOOK_LIB/json-parse.sh"
+source "$HOOK_LIB/state-counter.sh"
+
+ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
 
 TOOL_NAME=$(parse_json_field "tool_name")
 
@@ -82,6 +85,7 @@ if echo "$COMMAND" | grep -qE '(chmod|chown)\s+-R\s+.*\s+/'; then
 fi
 
 if [ "$BLOCKED" = true ]; then
+  bump_counter "$ROOT/.hook-state/hook-firings.json" "block-dangerous-commands"
   echo "BLOCKED: $REASON"
   echo ""
   echo "Command: $COMMAND"

--- a/.claude/hooks/branch-protect.sh
+++ b/.claude/hooks/branch-protect.sh
@@ -11,6 +11,13 @@ set -euo pipefail
 INPUT=$(cat)
 HOOK_LIB="$(cd "$(dirname "$0")/lib" 2>/dev/null && pwd)"
 source "$HOOK_LIB/json-parse.sh"
+source "$HOOK_LIB/state-counter.sh"
+
+ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
+
+bump_branch_block() {
+  bump_counter "$ROOT/.hook-state/hook-firings.json" "branch-protect"
+}
 
 TOOL_NAME=$(parse_json_field "tool_name")
 
@@ -25,6 +32,7 @@ COMMAND=$(parse_json_field "command")
 if echo "$COMMAND" | grep -qE 'git\s+push\s+.*--force-with-lease'; then
   : # Allow --force-with-lease (only overwrites if remote matches expectations)
 elif echo "$COMMAND" | grep -qE 'git\s+push\s+.*--force|git\s+push\s+.*-f\b'; then
+  bump_branch_block
   echo "BLOCKED: Force push detected"
   echo ""
   echo "Force pushing can overwrite remote history."
@@ -35,6 +43,7 @@ fi
 
 # Check for git push to protected branches (explicit branch name)
 if echo "$COMMAND" | grep -qE 'git\s+push\s+(\S+\s+)?(main|master)\s*($|[;&|])|git\s+push\s+.*\s+HEAD:(main|master)\b'; then
+  bump_branch_block
   echo "BLOCKED: Direct push to main/master branch"
   echo ""
   echo "Create a feature branch and open a PR instead:"
@@ -47,6 +56,7 @@ fi
 if echo "$COMMAND" | grep -qE 'git\s+push\s+\S+\s+HEAD\b'; then
   CURRENT_BRANCH=$(git branch --show-current 2>/dev/null) || CURRENT_BRANCH=""
   if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ]; then
+    bump_branch_block
     echo "BLOCKED: 'git push <remote> HEAD' resolves to protected branch '$CURRENT_BRANCH'"
     echo ""
     echo "Create a feature branch and open a PR instead:"
@@ -63,6 +73,7 @@ if echo "$COMMAND" | grep -qE '(^|[;&|]\s*)git\s+push(\s+-u)?(\s+origin)?\s*($|[
     exit 0  # Cannot determine branch, allow the push
   fi
   if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ]; then
+    bump_branch_block
     echo "BLOCKED: You are on '$CURRENT_BRANCH' — bare 'git push' would push to protected branch"
     echo ""
     echo "Create a feature branch and open a PR instead:"

--- a/.claude/hooks/lib/state-counter.sh
+++ b/.claude/hooks/lib/state-counter.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# state-counter.sh — Shared atomic JSON counter helper for kit hooks
+#
+# Usage:
+#
+#   HOOK_LIB="$(cd "$(dirname "$0")/lib" 2>/dev/null && pwd)"
+#   source "$HOOK_LIB/state-counter.sh"
+#
+#   bump_counter "$ROOT/.hook-state/hook-firings.json" "protect-files"
+#
+# The state file is a flat JSON object: {"protect-files": 3, "stop-gate": 1, ...}.
+# Counters are session-scoped: the file is created on first bump of a session
+# and cleared on session-start. Atomic via write-temp-then-rename.
+#
+# Falls back gracefully when python3 is missing (no-op rather than crash).
+#
+
+bump_counter() {
+  local file="$1"
+  local key="$2"
+  local dir
+  dir=$(dirname "$file")
+  mkdir -p "$dir" 2>/dev/null || return 0
+  # Self-gitignore: state files are transient, never commit
+  [ -f "$dir/.gitignore" ] || printf '*\n!.gitignore\n' >"$dir/.gitignore" 2>/dev/null || true
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$file" "$key" <<'PY' 2>/dev/null || true
+import json, os, sys
+f, key = sys.argv[1], sys.argv[2]
+try:
+    with open(f) as fh:
+        d = json.load(fh)
+    if not isinstance(d, dict):
+        d = {}
+except (FileNotFoundError, json.JSONDecodeError):
+    d = {}
+d[key] = int(d.get(key, 0)) + 1
+tmp = f + ".tmp"
+with open(tmp, "w") as fh:
+    json.dump(d, fh, indent=2)
+os.replace(tmp, f)
+PY
+  fi
+  return 0
+}
+
+reset_state() {
+  # Wipe a state file (used by session-start.sh to clear stale counters from
+  # the previous session). No-op if the file doesn't exist.
+  local file="$1"
+  [ -f "$file" ] && rm -f "$file" 2>/dev/null
+  return 0
+}

--- a/.claude/hooks/protect-changes.sh
+++ b/.claude/hooks/protect-changes.sh
@@ -20,6 +20,9 @@ set -euo pipefail
 INPUT=$(cat)
 HOOK_LIB="$(cd "$(dirname "$0")/lib" 2>/dev/null && pwd)"
 source "$HOOK_LIB/json-parse.sh"
+source "$HOOK_LIB/state-counter.sh"
+
+ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
 
 TOOL_NAME=$(parse_json_field "tool_name")
 
@@ -92,6 +95,7 @@ if [ "$BLOCKED" = false ]; then
 fi
 
 if [ "$BLOCKED" = true ]; then
+  bump_counter "$ROOT/.hook-state/hook-firings.json" "protect-changes"
   cat <<EOF >&2
 BLOCKED by protect-changes.sh: $FILE_PATH
 Reason: $REASON

--- a/.claude/hooks/protect-files.sh
+++ b/.claude/hooks/protect-files.sh
@@ -11,6 +11,9 @@ set -euo pipefail
 INPUT=$(cat)
 HOOK_LIB="$(cd "$(dirname "$0")/lib" 2>/dev/null && pwd)"
 source "$HOOK_LIB/json-parse.sh"
+source "$HOOK_LIB/state-counter.sh"
+
+ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
 
 TOOL_NAME=$(parse_json_field "tool_name")
 
@@ -85,6 +88,7 @@ case "$DIRNAME" in
 esac
 
 if [ "$BLOCKED" = true ]; then
+  bump_counter "$ROOT/.hook-state/hook-firings.json" "protect-files"
   echo "BLOCKED: $REASON — $FILE_PATH"
   echo ""
   echo "If you need to modify this file, ask the user to do it manually"

--- a/.claude/hooks/quality-gate.sh
+++ b/.claude/hooks/quality-gate.sh
@@ -128,6 +128,35 @@ esac
 END=$(date +%s)
 DURATION=$((END - START))
 
+# Update quality-gate history (cumulative runs/failures per session). Session-end
+# aggregates this into the scorecard. Atomic via temp-file rename.
+HISTORY_FILE="$STATE_DIR/quality-gate-history.json"
+if command -v python3 &>/dev/null; then
+  python3 - "$HISTORY_FILE" "$STATUS" "$TOOL_USED" <<'PY' 2>/dev/null || true
+import json, os, sys
+f, status, tool = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    with open(f) as fh:
+        d = json.load(fh)
+    if not isinstance(d, dict):
+        d = {}
+except (FileNotFoundError, json.JSONDecodeError):
+    d = {}
+d["runs"] = int(d.get("runs", 0)) + 1
+if status == "failed":
+    d["failures"] = int(d.get("failures", 0)) + 1
+elif "failures" not in d:
+    d["failures"] = 0
+d["last_status"] = status
+d["last_tool"] = tool
+d.setdefault("skip_gate_used", 0)  # stop-gate.sh sets this to 1 on bypass
+tmp = f + ".tmp"
+with open(tmp, "w") as fh:
+    json.dump(d, fh, indent=2)
+os.replace(tmp, f)
+PY
+fi
+
 # Write state file (JSON). Use python3 for safe escaping when available.
 STATE_FILE="$STATE_DIR/last_quality_gate.json"
 if command -v python3 &>/dev/null; then

--- a/.claude/hooks/session-end.sh
+++ b/.claude/hooks/session-end.sh
@@ -2,13 +2,22 @@
 #
 # session-end.sh — SessionEnd hook
 #
-# Appends a JSON-line audit record to reports/session-audit.log when the
-# session ends. Replaces the prompt rule "Session End → write handoff if
-# mid-work" with a deterministic log line.
+# Appends a JSON-line audit record to reports/session-audit.log. As of
+# schema_version 2 the record is a structured session scorecard with metrics
+# aggregated from the session's .hook-state/* files plus the transcript:
 #
-# Captures session_id, exit reason, transcript path, and the most recent
-# quality-gate status so the operator can see at a glance whether the
-# session ended clean.
+#   - blocks_fired           — counts per blocking hook (hook-firings.json)
+#   - quality_gate           — runs / failures / last_status / skip_gate_used
+#   - bash_token_estimate    — cumulative Bash output cost (bash-budget.json)
+#   - edits                  — count of Edit/Write/NotebookEdit/MultiEdit calls (from transcript)
+#   - compactions_observed   — best-effort compaction detection (from transcript)
+#   - lessons_added          — new files in tasks/lessons/ since session_start
+#   - decisions_added        — tasks/decisions.md modified since session_start (0/1)
+#   - session_duration_seconds — now - session-meta.json.started_at
+#
+# All top-level v1 fields (timestamp, event, session_id, reason,
+# transcript_path, last_quality_gate) are preserved verbatim so v1 parsers
+# continue to work.
 #
 
 set -euo pipefail
@@ -22,54 +31,170 @@ mkdir -p "$REPORTS_DIR"
 [ -f "$REPORTS_DIR/.gitignore" ] || printf 'session-audit.log\n' >"$REPORTS_DIR/.gitignore"
 LOG="$REPORTS_DIR/session-audit.log"
 
-# Detect the last quality-gate status (if quality-gate.sh ran this session).
-GATE_STATUS="none"
-STATE_FILE="$ROOT/.hook-state/last_quality_gate.json"
-if [ -f "$STATE_FILE" ]; then
-  if command -v python3 &>/dev/null; then
-    GATE_STATUS=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("status","none"))' "$STATE_FILE" 2>/dev/null || echo "none")
-  elif command -v jq &>/dev/null; then
-    GATE_STATUS=$(jq -r '.status // "none"' "$STATE_FILE" 2>/dev/null || echo "none")
-  else
+STATE_DIR="$ROOT/.hook-state"
+TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+NOW_EPOCH=$(date +%s)
+
+# python3 is required for the rich aggregation path. Without it, fall back to
+# the v1 single-line shape so legacy installs keep getting some signal.
+if ! command -v python3 >/dev/null 2>&1; then
+  GATE_STATUS="none"
+  STATE_FILE="$STATE_DIR/last_quality_gate.json"
+  if [ -f "$STATE_FILE" ]; then
     GATE_STATUS=$(grep -oE '"status"[[:space:]]*:[[:space:]]*"[^"]*"' "$STATE_FILE" | head -1 | sed 's/.*:[[:space:]]*"//;s/"$//' || echo "none")
   fi
-fi
-
-TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-
-# Build the audit JSON in one shot. Prefer python3 (handles quoting, spaces
-# in field values, missing keys). Fall back to a minimal bash construction —
-# acceptable because the SessionEnd payload schema is small and stable.
-#
-# Note: we use `python3 -c` (not `python3 -` + heredoc) because `-` tells
-# python to read the *source* from stdin, which conflicts with the JSON
-# payload we want to pipe in. With `-c`, stdin remains available for
-# `json.load(sys.stdin)`.
-if command -v python3 &>/dev/null; then
-  printf '%s' "$INPUT" | python3 -c '
-import json, sys
-ts = sys.argv[1]
-gate = sys.argv[2]
-try:
-    d = json.load(sys.stdin)
-except Exception:
-    d = {}
-print(json.dumps({
-    "timestamp": ts,
-    "event": "SessionEnd",
-    "session_id": d.get("session_id", ""),
-    "reason": d.get("reason", "unknown"),
-    "transcript_path": d.get("transcript_path", ""),
-    "last_quality_gate": gate,
-}))
-' "$TS" "$GATE_STATUS" >>"$LOG"
-else
-  # Best-effort grep extraction (acceptable: the payload is small and known)
   SESSION_ID=$(printf '%s' "$INPUT" | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*:[[:space:]]*"//;s/"$//')
   REASON=$(printf '%s' "$INPUT" | grep -oE '"reason"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*:[[:space:]]*"//;s/"$//')
   TRANSCRIPT=$(printf '%s' "$INPUT" | grep -oE '"transcript_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*:[[:space:]]*"//;s/"$//')
-  printf '{"timestamp":"%s","event":"SessionEnd","session_id":"%s","reason":"%s","transcript_path":"%s","last_quality_gate":"%s"}\n' \
+  printf '{"timestamp":"%s","event":"SessionEnd","schema_version":1,"session_id":"%s","reason":"%s","transcript_path":"%s","last_quality_gate":"%s"}\n' \
     "$TS" "${SESSION_ID:-}" "${REASON:-unknown}" "${TRANSCRIPT:-}" "$GATE_STATUS" >>"$LOG"
+  exit 0
 fi
+
+# Rich path: python3 aggregates state + transcript and writes one JSON line.
+printf '%s' "$INPUT" | python3 - "$TS" "$NOW_EPOCH" "$STATE_DIR" "$ROOT" >>"$LOG" <<'PY'
+import json, os, sys
+
+ts = sys.argv[1]
+now_epoch = int(sys.argv[2])
+state_dir = sys.argv[3]
+root = sys.argv[4]
+
+# --- Inbound stop-hook payload (session_id, reason, transcript_path) ------
+try:
+    payload = json.load(sys.stdin)
+except Exception:
+    payload = {}
+session_id = payload.get("session_id", "") or ""
+reason = payload.get("reason", "unknown") or "unknown"
+transcript_path = payload.get("transcript_path", "") or ""
+
+# --- Load each state file with graceful absence ---------------------------
+def load_json(path):
+    try:
+        with open(path) as f:
+            d = json.load(f)
+        return d if isinstance(d, dict) else {}
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+last_gate = load_json(os.path.join(state_dir, "last_quality_gate.json"))
+hook_firings = load_json(os.path.join(state_dir, "hook-firings.json"))
+gate_history = load_json(os.path.join(state_dir, "quality-gate-history.json"))
+bash_budget = load_json(os.path.join(state_dir, "bash-budget.json"))
+session_meta = load_json(os.path.join(state_dir, "session-meta.json"))
+
+# --- Derived metrics ------------------------------------------------------
+KNOWN_BLOCKING_HOOKS = (
+    "protect-files",
+    "protect-changes",
+    "branch-protect",
+    "block-dangerous-commands",
+    "stop-gate",
+)
+blocks_fired = {h: int(hook_firings.get(h, 0)) for h in KNOWN_BLOCKING_HOOKS}
+
+quality_gate = {
+    "runs": int(gate_history.get("runs", 0)),
+    "failures": int(gate_history.get("failures", 0)),
+    "last_status": gate_history.get("last_status") or last_gate.get("status") or "none",
+    "skip_gate_used": int(gate_history.get("skip_gate_used", 0)) > 0,
+}
+
+bash_token_estimate = int(bash_budget.get("cumulative_tokens", 0))
+
+# session_duration: prefer started_at_epoch from session-meta; fall back to None.
+started_epoch = session_meta.get("started_at_epoch")
+if isinstance(started_epoch, int):
+    duration = max(0, now_epoch - started_epoch)
+else:
+    duration = None
+
+# --- Best-effort transcript parse (edits + compactions) -------------------
+# Transcript format is a stream of events serialized as JSON; the kit doesn't
+# control it, so be conservative: count events whose tool name matches the
+# editing tools, and events whose payload mentions a compaction marker.
+edits = 0
+compactions_observed = 0
+if transcript_path and os.path.isfile(transcript_path):
+    try:
+        with open(transcript_path, encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                if not line.startswith("{"):
+                    continue
+                try:
+                    ev = json.loads(line)
+                except Exception:
+                    continue
+                # tool-use event with editing tool name
+                name = None
+                if isinstance(ev, dict):
+                    if ev.get("type") == "tool_use":
+                        name = ev.get("name")
+                    msg = ev.get("message") or {}
+                    if isinstance(msg, dict):
+                        content = msg.get("content") or []
+                        if isinstance(content, list):
+                            for c in content:
+                                if isinstance(c, dict) and c.get("type") == "tool_use":
+                                    if c.get("name") in ("Edit", "Write", "NotebookEdit", "MultiEdit"):
+                                        edits += 1
+                    if name in ("Edit", "Write", "NotebookEdit", "MultiEdit"):
+                        edits += 1
+                    # compaction marker — kit doesn't control the wire format,
+                    # but "compact" inside an event type or message hint is a
+                    # strong signal. False positives are acceptable here.
+                    blob = json.dumps(ev)
+                    if "compact_summary" in blob or '"type": "compaction"' in blob:
+                        compactions_observed += 1
+    except Exception:
+        pass
+
+# --- Lessons + decisions modified since session_start --------------------
+lessons_added = 0
+decisions_added = 0
+if isinstance(started_epoch, int):
+    lessons_dir = os.path.join(root, "tasks", "lessons")
+    if os.path.isdir(lessons_dir):
+        for entry in os.listdir(lessons_dir):
+            if not entry.endswith(".md") or entry in ("_index.md", "_TEMPLATE.md"):
+                continue
+            full = os.path.join(lessons_dir, entry)
+            try:
+                if os.path.getmtime(full) >= started_epoch:
+                    lessons_added += 1
+            except OSError:
+                continue
+    decisions_path = os.path.join(root, "tasks", "decisions.md")
+    if os.path.isfile(decisions_path):
+        try:
+            if os.path.getmtime(decisions_path) >= started_epoch:
+                decisions_added = 1
+        except OSError:
+            pass
+
+# --- Emit one JSON line --------------------------------------------------
+record = {
+    "timestamp": ts,
+    "event": "SessionEnd",
+    "schema_version": 2,
+    "session_id": session_id,
+    "reason": reason,
+    "transcript_path": transcript_path,
+    "last_quality_gate": quality_gate["last_status"],
+    "metrics": {
+        "edits": edits,
+        "blocks_fired": blocks_fired,
+        "quality_gate": quality_gate,
+        "lessons_added": lessons_added,
+        "decisions_added": decisions_added,
+        "bash_token_estimate": bash_token_estimate,
+        "compactions_observed": compactions_observed,
+        "session_duration_seconds": duration,
+    },
+}
+sys.stdout.write(json.dumps(record) + "\n")
+PY
 
 exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -14,10 +14,41 @@
 
 set -euo pipefail
 
-# Consume stdin (hook protocol)
-cat > /dev/null
+INPUT=$(cat)
+
+HOOK_LIB="$(cd "$(dirname "$0")/lib" 2>/dev/null && pwd)"
+source "$HOOK_LIB/json-parse.sh"
+source "$HOOK_LIB/state-counter.sh"
 
 ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
+STATE_DIR="$ROOT/.hook-state"
+mkdir -p "$STATE_DIR" 2>/dev/null || true
+[ -f "$STATE_DIR/.gitignore" ] || printf '*\n!.gitignore\n' >"$STATE_DIR/.gitignore" 2>/dev/null || true
+
+# Reset transient session counters from any prior session. session-end.sh has
+# already consumed them (or, if the prior session crashed, the next aggregator
+# would otherwise double-count). New session starts at zero.
+reset_state "$STATE_DIR/hook-firings.json"
+reset_state "$STATE_DIR/quality-gate-history.json"
+reset_state "$STATE_DIR/bash-budget.json"
+
+# Write session metadata. session-end.sh reads it to compute
+# session_duration_seconds and propagate session_id into the scorecard.
+SESSION_ID=$(parse_json_field "session_id" 2>/dev/null || true)
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+NOW_EPOCH=$(date +%s)
+if command -v python3 &>/dev/null; then
+  python3 - "$STATE_DIR/session-meta.json" "${SESSION_ID:-}" "$NOW" "$NOW_EPOCH" <<'PY' 2>/dev/null || true
+import json, os, sys
+f, sid, now_iso, now_epoch = sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4])
+d = {"session_id": sid, "started_at": now_iso, "started_at_epoch": now_epoch}
+tmp = f + ".tmp"
+with open(tmp, "w") as fh:
+    json.dump(d, fh, indent=2)
+os.replace(tmp, f)
+PY
+fi
+
 CONTEXT=""
 
 append() { CONTEXT="${CONTEXT}${1}"; }

--- a/.claude/hooks/stop-gate.sh
+++ b/.claude/hooks/stop-gate.sh
@@ -21,14 +21,19 @@ set -euo pipefail
 # Consume stdin (hook protocol)
 cat > /dev/null
 
+HOOK_LIB="$(cd "$(dirname "$0")/lib" 2>/dev/null && pwd)"
+source "$HOOK_LIB/state-counter.sh"
+
 ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
 STATE_FILE="$ROOT/.hook-state/last_quality_gate.json"
 
 # No state → no edits happened (or hooks weren't wired) → allow stop
 [ ! -f "$STATE_FILE" ] && exit 0
 
-# Escape hatch (either name works)
+# Escape hatch (either name works). Marked in quality-gate-history.json so
+# session-end.sh can surface skip_gate_used in the scorecard.
 if [ "${CLAUDE_SKIP_QUALITY_GATE:-0}" = "1" ] || [ "${SKIP_QUALITY_GATE:-0}" = "1" ]; then
+  bump_counter "$ROOT/.hook-state/quality-gate-history.json" "skip_gate_used"
   echo "stop-gate: bypassed via SKIP_QUALITY_GATE" >&2
   exit 0
 fi
@@ -44,6 +49,7 @@ else
 fi
 
 if [ "$STATUS" = "failed" ]; then
+  bump_counter "$ROOT/.hook-state/hook-firings.json" "stop-gate"
   cat <<EOF >&2
 BLOCKED by stop-gate.sh: last quality gate did not pass.
 State: $STATE_FILE

--- a/.claude/skills/scorecard/SKILL.md
+++ b/.claude/skills/scorecard/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: scorecard
+description: Aggregate recent session scorecards from reports/session-audit.log and produce a readable per-session + windowed-summary report. Distinct from `/retro` (process review) and `/pulse` (outcome timeline) — scorecard is pure numbers, fed by the SessionEnd hook.
+user-invocable: true
+---
+
+# Scorecard
+
+## Core Rule
+
+Render facts that the SessionEnd hook already recorded. Never invent metrics — if a field is missing in the log, surface that, do not synthesize.
+
+## Kit Context
+
+Before starting this skill, ensure you have completed session boot:
+1. Read `CODEBASE_MAP.md` for project understanding
+2. Read `CLAUDE.project.md` if it exists for project-specific rules
+3. Confirm `.claude/hooks/session-end.sh` is wired and the SessionEnd profile is active — otherwise the log will be empty
+
+If these haven't been read in this session, read them now before proceeding.
+
+## When to Use
+
+Invoke with `/scorecard` when:
+
+- You want a quick view of the last N sessions (default: 7 days, override with `--window 7d` / `--window 30d` / `--window 14d`)
+- You want to see which blocking hooks fire most often (signal that the prompt rules need tightening)
+- You want to track quality-gate failure rate as a moving signal
+- You want to compare sessions before vs. after a kit upgrade
+
+Not for:
+- Process review or sentiment retrospective — that is `/retro`
+- Outcome timeline ("what shipped, what broke") — that is `/pulse`
+- One-off code metrics — those belong in `project-health-report`
+
+## Scope Rules
+
+- Reads `reports/session-audit.log` only — no other source of truth
+- Parses both v1 (`schema_version` missing or `1`) and v2 records
+- Filters by window if provided; default to the last 7 days
+- Never modifies files; output is a single markdown report
+
+## Process
+
+### Phase 1: Inventory
+
+1. Read `reports/session-audit.log` (one JSONL record per session)
+2. Parse each line as JSON; skip lines that fail to parse and surface the count
+3. Filter by window: include records whose `timestamp` is within the requested span
+4. Group by `schema_version`:
+   - v1 records carry only `last_quality_gate` + identifiers
+   - v2 records carry the full `metrics` object
+
+### Phase 2: Aggregation
+
+Compute these aggregates over the windowed set of v2 records (v1 records contribute only to "sessions counted" and "last_quality_gate distribution"):
+
+| Aggregate | How |
+|---|---|
+| **Sessions counted** | N total in window |
+| **Quality-gate pass rate** | `1 − sum(metrics.quality_gate.failures) / sum(metrics.quality_gate.runs)` (skip sessions with `runs == 0`) |
+| **Skip-gate usage** | Count of sessions where `metrics.quality_gate.skip_gate_used` is true |
+| **Blocks fired (per hook)** | Sum of `metrics.blocks_fired[hook]` across sessions, sorted desc |
+| **Edits total** | Sum of `metrics.edits` |
+| **Lessons added** | Sum of `metrics.lessons_added` |
+| **Decisions added** | Sum of `metrics.decisions_added` |
+| **Bash output (estimated tokens)** | Sum of `metrics.bash_token_estimate`; if all are zero, surface that the bash-budget hook may not be installed |
+| **Compactions** | Sum of `metrics.compactions_observed` |
+| **Median session duration** | Median of `metrics.session_duration_seconds` (skip null/zero) |
+
+### Phase 3: Render
+
+Output exactly one report. Keep it scannable. The shape is:
+
+```markdown
+# Scorecard — last <window>
+
+**Sessions counted:** <N>  (<v2_count> with full metrics, <v1_count> legacy v1 records)
+
+## Quality-gate
+
+- Runs: <total>
+- Failures: <total>  ( **pass rate <p>%** )
+- Skip-gate used in <n> session(s)
+- Most recent: <last_status> (<timestamp>)
+
+## Blocks fired (cumulative)
+
+| Hook | Count |
+|---|---:|
+| protect-files | 12 |
+| protect-changes | 4 |
+| stop-gate | 2 |
+| branch-protect | 0 |
+| block-dangerous-commands | 0 |
+
+## Activity
+
+- Edits: <total>
+- Lessons added: <total>
+- Decisions added: <total>
+- Bash output (estimated tokens): <total>  *(0 if bash-budget hook not installed)*
+- Compactions observed: <total>
+- Median session duration: <minutes>
+
+## Per-session detail (most recent first)
+
+| Date | Pass? | Edits | Blocks | Duration |
+|---|---|---:|---:|---:|
+| 2026-05-18 | ✓ | 12 | 0 | 18m |
+| 2026-05-17 | ✗ | 8 | 2 | 32m |
+...
+```
+
+If the log is empty: print exactly `No SessionEnd records found at reports/session-audit.log. The SessionEnd hook may not be wired into .claude/settings.json, or no session has ended yet.`
+
+If only v1 records exist: render a reduced report ("Quality-gate" and "Per-session detail" only — explain that the rest needs schema_version 2 from a kit that includes the scorecards hooks).
+
+### Phase 4: Helpful follow-ups (optional, only when relevant)
+
+After the table, add a single-paragraph "What this says" callout only when one of these is true:
+
+- **Quality-gate pass rate < 70%** → suggest reviewing the failing tool's last failures (point at `.hook-state/last_quality_gate.json` and `stderr_tail`)
+- **Skip-gate used in >1 session** → suggest documenting the bypass reasons in `tasks/decisions.md`
+- **One hook accounts for >70% of blocks** → suggest tightening prompt guidance around that domain or relaxing the hook if it's noisy
+
+Do not add follow-ups when nothing is notable. Silence is fine.
+
+## Arguments
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--window <span>` | `7d` | Time window: `<N>d` for days, `<N>w` for weeks, `<N>m` for months, or `all` |
+| `--json` | unset | Emit the aggregates as a single JSON object (no markdown). Useful for `/loop` or further piping. |
+| `--per-session` | shown | Include the per-session detail table. Pass `--no-per-session` to hide it. |
+
+## Run Mode
+
+This skill supports interactive (default) and headless modes — see the canonical contract in `.claude/skills/_shared/blocks/mode-detection.md`.
+
+Headless detection: presence of `mode:headless` in arguments.
+
+| Decision point | Interactive | Headless |
+|---|---|---|
+| **Follow-up callouts** | Show when thresholds tripped | Skip — log to stdout the threshold flags only |
+| **Per-session detail** | Show by default | Skip — keep output compact |
+| **Output format** | Markdown table | Markdown table (same) or `--json` if requested |
+
+## Notes
+
+- The scorecard intentionally does NOT include the failure messages or stderr from `.hook-state/last_quality_gate.json`. Use `/debug` or read the state file directly when you need the body of a failure.
+- `metrics.compactions_observed` is best-effort — the kit does not own the transcript format, so over-counts or under-counts of compaction events are possible. Treat as a trend signal, not an exact count.
+- `metrics.lessons_added` / `metrics.decisions_added` are mtime-based, so editing an existing lesson during the session counts as "added". This is intentional: the goal is "did the lesson archive evolve this session?", not strict file creation.
+- v1 records remain in the log untouched. Upgrading the kit doesn't rewrite history.

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -92,7 +92,7 @@ Developers using Claude Code and similar agents often get inconsistent results �
 │   │   ├── auto-format.sh         # PostToolUse: auto-format after edits (opt-in)
 │   │   ├── skill-compliance.sh    # PostToolUse: skill checklist compliance (opt-in)
 │   │   ├── skill-extract-reminder.sh  # UserPromptSubmit: skill extraction reminder (opt-in)
-│   │   ├── lib/                    # Shared hook library (json-parse.sh)
+│   │   ├── lib/                    # Shared hook library (json-parse.sh, state-counter.sh)
 │   │   └── project/               # Project-specific hooks (never touched by kit)
 │   └── skills/                    # Reusable knowledge
 │       ├── _shared/               # Shared template blocks
@@ -116,6 +116,7 @@ Developers using Claude Code and similar agents often get inconsistent results �
 │       ├── lesson-refresh/        # Periodic refresh of tasks/lessons/ (keep/update/encode/archive)
 │       ├── pulse/                 # Time-windowed outcome report saved to tasks/pulses/
 │       ├── ship/                  # Deployment pipeline
+│       ├── scorecard/             # Windowed scorecard from reports/session-audit.log (schema_version 2 metrics)
 │       ├── retro/                 # Sprint retrospective & analytics
 │       ├── office-hours/          # Pre-coding product validation
 │       ├── debug/                 # Root-cause debugging

--- a/agent_docs/hooks.md
+++ b/agent_docs/hooks.md
@@ -69,13 +69,18 @@ These hooks are included in the kit but **not enabled** in the standard profile.
 
 ## State Files
 
-Three hooks share state through transient files at the project root. These are **self-gitignored** (the hook writes a local `.gitignore` inside the directory the first time it creates state). You don't need to add them to your project's root `.gitignore`.
+Several hooks share state through transient files at the project root. These are **self-gitignored** (the hook writes a local `.gitignore` inside the directory the first time it creates state). You don't need to add them to your project's root `.gitignore`.
 
 | File | Written by | Read by | Purpose |
 |------|-----------|---------|---------|
 | `.hook-state/last_quality_gate.json` | `quality-gate.sh` | `stop-gate.sh`, `session-end.sh` | Most recent verification result: `{status, exit_code, tool, edited_file, duration_seconds, stderr_tail}` |
 | `.hook-state/bash-budget.json` | `bash-budget.sh` | (operator review) | Cumulative Bash output token estimate for the session: `{schema_version, cumulative_tokens, threshold, warned, since_session_start, by_command_top5}` |
-| `reports/session-audit.log` | `session-end.sh` | (operator review) | One JSON line per session: timestamp, session_id, reason, transcript_path, last_quality_gate |
+| `.hook-state/quality-gate-history.json` | `quality-gate.sh`, `stop-gate.sh` | `session-end.sh`, `/scorecard` | Per-session cumulative quality-gate metrics: `{runs, failures, last_status, last_tool, skip_gate_used}`. `skip_gate_used` is incremented by `stop-gate.sh` when the agent bypasses the gate. |
+| `.hook-state/hook-firings.json` | every blocking hook (on `exit 2`) | `session-end.sh`, `/scorecard` | Per-session block counters: `{"protect-files": N, "protect-changes": N, "branch-protect": N, "block-dangerous-commands": N, "stop-gate": N}`. Reset by `session-start.sh` on a new session. |
+| `.hook-state/session-meta.json` | `session-start.sh` | `session-end.sh` | Identity for the in-progress session: `{session_id, started_at, started_at_epoch}`. Used to compute `session_duration_seconds` and the mtime cutoff for `lessons_added` / `decisions_added`. |
+| `reports/session-audit.log` | `session-end.sh` | `/scorecard`, operator review | One JSON line per session. **schema_version 2** records contain a `metrics` object (edits, blocks_fired, quality_gate, lessons_added, decisions_added, bash_token_estimate, compactions_observed, session_duration_seconds). v1 records (just identifiers + `last_quality_gate`) remain parseable. |
+
+The transient `.hook-state/*` files are reset on every `session-start.sh` invocation so counters reflect only the current session. The audit log is append-only across sessions — `/scorecard` aggregates over the requested window.
 
 Both directories are created on demand. Delete them anytime — the next hook run re-creates them.
 

--- a/tasks/decisions.md
+++ b/tasks/decisions.md
@@ -87,6 +87,34 @@ Track important technical decisions here so they don't get lost between sessions
   - The shipped example lesson `2026-04-15-example-tsconfig.md` is migrated to use `applies_to: [scope-discipline, tooling]` as a real-world demonstration of the new schema
   - Validation warnings detect: `supersedes-target-missing`, `contradicts-target-missing`, `supersedes-cycle` (transitive), `contradicts-loop` (mutual), `top-rule-but-superseded`
 
+### ADR-007: Session scorecards — structured metrics emitted by SessionEnd, aggregated by /scorecard
+- **Date**: 2026-05-18
+- **Status**: accepted
+- **Note**: ADR numbering assumes the v1.11.0 batch merges in this order — #117 (bash-budget) → #118 (lesson graph) → this PR. If merge order changes, renumber accordingly.
+- **Context**: `session-end.sh` already writes a one-line audit record per session, but the v1 line only carries identifiers + `last_quality_gate`. The kit makes behavioral claims ("staff-engineer behavior", "disciplined process") but offers no per-session evidence — those claims remain a vibe question. Inspired by GBrain's `founder scorecard` pattern: structured assertions rolled into a stable JSON contract over time. Without per-session counts of hook fires, quality-gate runs, edits, and bypasses, there's no signal for whether the kit's discipline rules are actually firing.
+- **Options**:
+  - A) **Schema_version 2 enrichment + dedicated `/scorecard` skill** — extend session-end to aggregate `.hook-state/*` files plus the transcript into a metrics object; add a `/scorecard` skill that reads the windowed audit log and renders a markdown table. Pros: builds on the existing JSONL log (no new persistence layer), keeps v1 parsers working, surfaces a single readable summary. Cons: requires touching every blocking hook to add the counter bump.
+  - B) **Telemetry to an external endpoint** — POST per-session metrics to a hosted collector. Pros: enables cross-machine aggregation. Cons: violates the kit's "no external services, no API keys" principle; adds privacy + reliability surface.
+  - C) **Pure prompt-based reporting** — at session-end, ask the agent to summarize its own session. Pros: zero infrastructure. Cons: non-deterministic, the agent can omit/inflate, defeats the "deterministic measurement" point.
+  - D) **Skip — let users run `/retro` for narrative review** — `/retro` already exists. Pros: no work. Cons: `/retro` is narrative + qualitative; it can't answer "did stop-gate actually fire 3 times this week?" deterministically.
+- **Decision**: A (enrich + `/scorecard` skill). Rationale: the schema_version 2 record gives the kit a stable, machine-readable contract; v1 records remain valid (additive change, not breaking); the new `/scorecard` skill closes the loop with a human-readable view. The counter-bump pattern is minimal (one helper call per blocking hook, ~5 lines each); the shared `lib/state-counter.sh` keeps it DRY.
+- **Sub-decisions**:
+  - **Counter bump on `exit 2` only, not on every hook run**. The metric we want is "how often did the agent try to do something we blocked?", not "how often did the hook fire". A passing run is a non-event; a blocked run is the signal.
+  - **`/scorecard` is a skill, not a script**. Aggregation requires judgment about windowing and threshold callouts that fit the agent's natural workflow. A shell script would force users to memorize flags; the skill lets `/scorecard --window 30d` flow naturally.
+  - **`lessons_added` and `decisions_added` are mtime-based**, not git-aware. "Was the lesson archive evolved this session?" is the right question; whether the agent created a new file vs. edited an existing one is noise.
+  - **`compactions_observed` is best-effort** from transcript parsing. The kit doesn't own Claude Code's transcript wire format, so over/under-counts are acceptable as long as the trend is informative. If the schema changes upstream, this field can be dropped — it's optional.
+  - **Profile**: enabled in **standard** and **strict** (same as `quality-gate`). Observability of discipline is core, not opt-in.
+- **Consequences**:
+  - 5 blocking hooks (`protect-files`, `protect-changes`, `branch-protect`, `block-dangerous-commands`, `stop-gate`) each gain a one-line `bump_counter` call before their `exit 2`
+  - `quality-gate.sh` writes both `last_quality_gate.json` (existing) and `quality-gate-history.json` (new cumulative runs / failures / last_status)
+  - `stop-gate.sh` bumps `skip_gate_used` in the history file when the `SKIP_QUALITY_GATE` env is honored
+  - `session-start.sh` writes `.hook-state/session-meta.json` (session_id, started_at, started_at_epoch) and resets stale `.hook-state/hook-firings.json`, `quality-gate-history.json`, `bash-budget.json` from any prior session
+  - `session-end.sh` is rewritten: schema_version 2 records carry the full `metrics` object alongside the v1 top-level fields (timestamp, event, session_id, reason, transcript_path, last_quality_gate). v1 parsers continue to work because the v1 fields are preserved verbatim.
+  - New shared lib `.claude/hooks/lib/state-counter.sh` (`bump_counter`, `reset_state`)
+  - New skill `.claude/skills/scorecard/SKILL.md` — `/scorecard` invokes the aggregator (read-only against `reports/session-audit.log`)
+  - `agent_docs/hooks.md` State Files table grows from 2 rows to 5; new helper lib mentioned in `lib/` reference
+  - Backward compat: if `python3` is unavailable on the target machine, `session-end.sh` falls back to the v1 single-line shape. The block counters and quality-gate history simply don't accumulate in that environment.
+
 ### ADR-004: Adopt three skill conventions from codex-complexity-optimizer (Core Rule, Default Behavior, Phase 1 Inventory)
 - **Date**: 2026-05-18
 - **Status**: accepted


### PR DESCRIPTION
## Summary

Upgrades `reports/session-audit.log` from a flat audit line (**schema v1**) to a structured **session scorecard** (**schema v2**) and adds the `/scorecard` skill to aggregate metrics over a configurable window. Closes the credibility gap: per-session evidence replaces "vibe" assessment of whether the kit's discipline rules actually fire.

## Why this approach

Inspired by GBrain's `founder scorecard` pattern — structured assertions rolled into a stable JSON contract over time. Rejected proxy-rewrite (lossy) and external telemetry (violates kit's "no external services" principle). See `tasks/decisions.md → ADR-007` for the full rationale and 4 options considered.

## What's in scope

### New shared lib

- `.claude/hooks/lib/state-counter.sh` — `bump_counter` (atomic JSON counter increment via python3 + temp-file rename) and `reset_state` (used by session-start.sh)

### Blocking hooks bump counters on `exit 2` only

5 hooks (`protect-files`, `protect-changes`, `branch-protect`, `block-dangerous-commands`, `stop-gate`) gain a one-line call to `bump_counter` immediately before each `exit 2`. A passing run is a non-event; a blocked run is the signal.

### Quality-gate history

`quality-gate.sh` writes cumulative `runs / failures / last_status / last_tool / skip_gate_used` to `.hook-state/quality-gate-history.json` alongside the existing `last_quality_gate.json`.

`stop-gate.sh` bumps `skip_gate_used` in the history when the `SKIP_QUALITY_GATE` env is honored.

### Session boundaries

`session-start.sh` now:
- Writes `.hook-state/session-meta.json` with `{session_id, started_at, started_at_epoch}`
- Resets stale per-session counters (`hook-firings.json`, `quality-gate-history.json`, `bash-budget.json`) from any prior session

### Enriched session-end

`session-end.sh` writes one **schema_version 2** JSON line:

```json
{
  "timestamp": "...",
  "event": "SessionEnd",
  "schema_version": 2,
  "session_id": "...",
  "reason": "...",
  "transcript_path": "...",
  "last_quality_gate": "...",
  "metrics": {
    "edits": 12,
    "blocks_fired": { "protect-files": 1, "protect-changes": 0, "branch-protect": 0, "block-dangerous-commands": 0, "stop-gate": 0 },
    "quality_gate": { "runs": 8, "failures": 1, "last_status": "passed", "skip_gate_used": false },
    "lessons_added": 2,
    "decisions_added": 0,
    "bash_token_estimate": 23400,
    "compactions_observed": 0,
    "session_duration_seconds": 1830
  }
}
```

- **Backward compatible**: v1 top-level fields (timestamp/event/session_id/reason/transcript_path/last_quality_gate) are preserved verbatim, so existing v1 parsers continue to read the line correctly.
- **Falls back to v1 shape** when `python3` is unavailable.

### New `/scorecard` skill

`.claude/skills/scorecard/SKILL.md` — `/scorecard --window 7d` reads the audit log, filters by window, and renders:

- Quality-gate pass rate + skip usage
- Blocks fired per hook (sorted desc)
- Cumulative activity (edits, lessons/decisions added, bash output tokens, compactions)
- Per-session detail table

Flags: `--window <N>d/w/m/all`, `--json`, `--no-per-session`. Headless-capable. Adds "what this says" callouts only when thresholds trip (pass rate < 70%, skip used >1, dominant hook >70% of blocks).

## Smoke test results

Synthetic session simulation in a temp dir:

| Step | Expectation | Result |
|---|---|---|
| `session-start` with stale state files | meta written, prior state reset | pass |
| 3 blocking hooks fire | each counter incremented atomically | pass |
| `quality-gate` runs on valid then broken `.py` | history shows runs=2, failures=1 | pass |
| `stop-gate` with `SKIP_QUALITY_GATE=1` | `skip_gate_used` incremented | pass |
| Lesson file created during session | `lessons_added` = 1 in scorecard | pass |
| `session-end` aggregates state | schema_version 2 record with correct counts | pass |

## Acceptance criteria

- [x] All blocking hooks increment firing counters atomically (5 hooks via shared `bump_counter`)
- [x] `quality-gate.sh` writes both current state (existing) and history (new)
- [x] `session-end.sh` produces scorecard JSON with all listed fields
- [x] `/scorecard` skill exists and produces a readable summary (markdown table, not raw JSON)
- [x] Backwards compatible: v1 audit lines still parseable (top-level fields preserved + `schema_version` makes branch trivial)
- [x] Smoke test: simulated session with N hooks firing → scorecard JSON contains correct counts
- [x] ADR-007 recorded (assumes #117 + #118 merge first; renumber if order changes)

## Independence from sibling PRs

This PR does **not** depend on #117 (bash-budget) or #118 (lesson graph). When the bash-budget state file is missing, `bash_token_estimate` falls back to `0` cleanly. The only merge-time interactions are:
- `tasks/decisions.md` — adding ADR-007 between the existing marker and ADR-004. #117 / #118 add their ADRs to the same location → trivial conflict resolution at merge.
- `agent_docs/hooks.md` — both #117 (matcher column) and this PR (State Files table) edit nearby sections → may need a small rebase.

Closes #106.

Part of the v1.11.0 inspiration triad (rtk + GBrain + karpathy). Companions: #105, #107, #108, #114, #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)