### PR TITLE
feat(bench): KitBench — reproducible eval harness for the kit's claims

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -84,3 +84,19 @@ jobs:
             echo ""
             echo "All templates structurally valid."
           fi
+
+  kitbench:
+    name: KitBench (hook scenarios)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Run all bench scenarios
+        run: |
+          chmod +x .claude/hooks/*.sh scripts/run-bench.sh
+          ./scripts/run-bench.sh

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -137,7 +137,12 @@ Developers using Claude Code and similar agents often get inconsistent results �
 │   ├── gen-skill-docs.sh          # Generates web MDX docs from SKILL.md files
 │   ├── gen-agents-md.sh           # Generates cross-tool AGENTS.md from kit sources
 │   ├── build-skills.sh            # Builds SKILL.md from .tmpl templates + shared blocks
-│   └── lesson-graph.sh            # Parses typed lesson frontmatter (supersedes/applies_to/contradicts/related_decisions); validates the graph and rewrites the auto sections in tasks/lessons/_index.md
+│   ├── lesson-graph.sh            # Parses typed lesson frontmatter (supersedes/applies_to/contradicts/related_decisions); validates the graph and rewrites the auto sections in tasks/lessons/_index.md
+│   └── run-bench.sh               # KitBench runner — executes every scenario in bench/scenarios/ in an isolated temp dir
+│
+├── bench/                         # KitBench — reproducible eval harness for the kit's deterministic-enforcement claims
+│   ├── README.md                  # Corpus overview, how to add scenarios
+│   └── scenarios/                 # JSON scenarios (one per file: name, hook, setup_files, env, payload, expect)
 │
 └── examples/                      # Stack-specific templates
     ├── nextjs/                    # Next.js 16 + App Router

--- a/README.md
+++ b/README.md
@@ -189,6 +189,21 @@ Hooks are shell scripts that run automatically — unlike CLAUDE.md rules (advis
 
 Opt-in hooks are not enabled by default — they can be slow or conflict with project configs. See `agent_docs/hooks.md` for how to enable them and write your own.
 
+### KitBench — hooks are tested
+
+The hooks above aren't documentation, they're a contract. The kit ships [`bench/`](bench/README.md): a reproducible eval harness with 15 scenarios covering every blocking hook plus regression tests for past bugs (composer.lock slip-through, `EXIT_CODE=$?` after `|| true`, `.github/workflows/ci.yml` basename-with-slash miss, word-boundary regex rejecting "authentication"). Run it any time with `./scripts/run-bench.sh`; CI runs it on every PR.
+
+```
+KitBench
+========================================
+  s01-protect-files-blocks-env                      PASS
+  s02-protect-files-blocks-composer-lock            PASS
+  s03-protect-changes-blocks-package-json           PASS
+  ...                                               PASS
+========================================
+  15/15 PASS  0 FAIL
+```
+
 ## Agents
 
 Built-in agents for code review, planning, and maintenance:

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Opt-in hooks are not enabled by default — they can be slow or conflict with pr
 
 The hooks above aren't documentation, they're a contract. The kit ships [`bench/`](bench/README.md): a reproducible eval harness with 15 scenarios covering every blocking hook plus regression tests for past bugs (composer.lock slip-through, `EXIT_CODE=$?` after `|| true`, `.github/workflows/ci.yml` basename-with-slash miss, word-boundary regex rejecting "authentication"). Run it any time with `./scripts/run-bench.sh`; CI runs it on every PR.
 
-```
+```text
 KitBench
 ========================================
   s01-protect-files-blocks-env                      PASS

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,91 @@
+# KitBench
+
+Reproducible eval harness for the kit's behavioural claims.
+
+The kit makes deterministic-enforcement promises (e.g. *"protected changes are blocked"*, *"completion is gated on quality"*, *"Tier 1 boot context is injected"*). KitBench turns those promises into pass/fail scenarios so they can be verified on every PR — no LLM, no network, no hand-waving.
+
+## Run it
+
+```bash
+./scripts/run-bench.sh                  # all scenarios
+./scripts/run-bench.sh --scenario s01   # one
+./scripts/run-bench.sh --filter protect # name contains
+./scripts/run-bench.sh --verbose        # print stdout/stderr per scenario
+./scripts/run-bench.sh --json           # machine-readable summary
+```
+
+Exit codes: `0` all pass, `1` one or more fail, `2` runner error.
+
+Each scenario runs in a **fresh temp directory** — no shared state between scenarios.
+
+## What's covered
+
+| # | Scenario | What it asserts |
+|---|---|---|
+| s01 | `protect-files-blocks-env` | Edit to `.env` → exit 2 |
+| s02 | `protect-files-blocks-composer-lock` | Edit to `composer.lock` → exit 2 *(regression: lock-file bug from v1.10.0 review)* |
+| s03 | `protect-changes-blocks-package-json` | Edit to `package.json` → exit 2 |
+| s04 | `protect-changes-allows-with-claude-approved` | `CLAUDE_APPROVED=1` + edit `package.json` → exit 0 |
+| s05 | `protect-changes-blocks-ci-workflow` | Edit `.github/workflows/ci.yml` → exit 2 *(regression: basename-with-slash bug)* |
+| s06 | `protect-changes-blocks-auth-path` | Edit `src/auth/login.ts` → exit 2 |
+| s07 | `quality-gate-passes-on-good-py` | Valid `.py` → state status `passed` |
+| s08 | `quality-gate-fails-on-broken-py` | Syntax-error `.py` → state status `failed` *(regression: `EXIT_CODE=$?` after `\|\| true` bug)* |
+| s09 | `stop-gate-blocks-on-failed-state` | Failed state → exit 2 |
+| s10 | `stop-gate-allows-on-passed-state` | Passed state → exit 0 |
+| s11 | `stop-gate-bypassed-with-skip-env` | `SKIP_QUALITY_GATE=1` + failed state → exit 0 |
+| s12 | `prompt-router-injects-on-auth-inflection` | "authentication" → `additionalContext` non-empty *(regression: word-boundary bug)* |
+| s13 | `prompt-router-quiet-on-neutral` | Neutral prompt → empty stdout |
+| s14 | `session-start-injects-tier1` | Outputs valid JSON with `additionalContext` referencing `CODEBASE_MAP.md` |
+| s15 | `session-end-writes-audit-line` | Appends one line to `reports/session-audit.log` |
+
+## Add a scenario
+
+Drop a JSON file in `bench/scenarios/sNN-<name>.json`:
+
+```json
+{
+  "name": "sNN-short-descriptive-slug",
+  "hook": ".claude/hooks/<your-hook>.sh",
+  "setup_files": {
+    "<relpath inside temp dir>": "<file content>"
+  },
+  "env": { "VAR": "value" },
+  "payload": { "tool_name": "Edit", "tool_input": { "file_path": "{TMPROOT}/x" } },
+  "expect": {
+    "exit_code": 2,
+    "stderr_contains": ["BLOCKED"],
+    "stdout_contains": [],
+    "stdout_empty": false,
+    "stderr_not_contains": [],
+    "state": [
+      { "file": ".hook-state/<state>.json", "field": "status", "equals": "failed" }
+    ],
+    "file_grew": ["reports/session-audit.log"]
+  },
+  "notes": "Optional human-readable context — especially useful for regression scenarios."
+}
+```
+
+Variables in string values:
+- `{TMPROOT}` — the per-scenario temp directory (e.g. for absolute paths inside payload)
+- `{KIT_ROOT}` — the kit checkout root
+
+All `expect.*` keys are optional. The minimum useful assertion is `exit_code`.
+
+## What it deliberately does not do
+
+- **No LLM-graded evals.** Hooks are deterministic shell scripts; their behaviour is grounded in exit codes and state-file content. LLM grading would re-introduce non-determinism.
+- **No session replay.** The harness invokes one hook at a time, not a full Claude Code session.
+- **No cross-tool coverage.** Adapters for Cursor/Codex/Devin are out of scope.
+- **No remote scoreboard.** The bench prints results to stdout; CI's check status is the scoreboard.
+
+## Why this exists
+
+The kit's commitment is *"deterministic enforcement"* (ADR-003). Without a bench, that commitment is a vibe. KitBench turns the commitment into a contract — and every PR that touches a hook re-asserts it.
+
+Past bugs that KitBench would have caught (and that several scenarios above directly regression-cover):
+
+- v1.10.0: `composer.lock` slipped through `protect-files` (s02)
+- v1.10.0: `EXIT_CODE=$?` after `|| true` always reported "passed" (s08)
+- v1.10.0: basename-only match missed `.github/workflows/ci.yml` (s05)
+- v1.10.0: word-boundary regex in `prompt-router.sh` rejected "authentication" (s12)

--- a/bench/scenarios/s01-protect-files-blocks-env.json
+++ b/bench/scenarios/s01-protect-files-blocks-env.json
@@ -1,0 +1,13 @@
+{
+  "name": "s01-protect-files-blocks-env",
+  "hook": ".claude/hooks/protect-files.sh",
+  "payload": {
+    "tool_name": "Edit",
+    "tool_input": { "file_path": "{TMPROOT}/.env" }
+  },
+  "expect": {
+    "exit_code": 2,
+    "stderr_contains": [],
+    "stdout_contains": ["BLOCKED"]
+  }
+}

--- a/bench/scenarios/s02-protect-files-blocks-composer-lock.json
+++ b/bench/scenarios/s02-protect-files-blocks-composer-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "s02-protect-files-blocks-composer-lock",
+  "hook": ".claude/hooks/protect-files.sh",
+  "payload": {
+    "tool_name": "Edit",
+    "tool_input": { "file_path": "{TMPROOT}/composer.lock" }
+  },
+  "expect": {
+    "exit_code": 2,
+    "stdout_contains": ["BLOCKED"]
+  },
+  "notes": "Regression: composer.lock historically slipped through the lock-file BLOCKED case (v1.10.0 review)."
+}

--- a/bench/scenarios/s03-protect-changes-blocks-package-json.json
+++ b/bench/scenarios/s03-protect-changes-blocks-package-json.json
@@ -1,0 +1,12 @@
+{
+  "name": "s03-protect-changes-blocks-package-json",
+  "hook": ".claude/hooks/protect-changes.sh",
+  "payload": {
+    "tool_name": "Edit",
+    "tool_input": { "file_path": "{TMPROOT}/package.json" }
+  },
+  "expect": {
+    "exit_code": 2,
+    "stderr_contains": ["BLOCKED", "package.json"]
+  }
+}

--- a/bench/scenarios/s04-protect-changes-allows-with-claude-approved.json
+++ b/bench/scenarios/s04-protect-changes-allows-with-claude-approved.json
@@ -1,0 +1,12 @@
+{
+  "name": "s04-protect-changes-allows-with-claude-approved",
+  "hook": ".claude/hooks/protect-changes.sh",
+  "env": { "CLAUDE_APPROVED": "1" },
+  "payload": {
+    "tool_name": "Edit",
+    "tool_input": { "file_path": "{TMPROOT}/package.json" }
+  },
+  "expect": {
+    "exit_code": 0
+  }
+}

--- a/bench/scenarios/s05-protect-changes-blocks-ci-workflow.json
+++ b/bench/scenarios/s05-protect-changes-blocks-ci-workflow.json
@@ -1,0 +1,13 @@
+{
+  "name": "s05-protect-changes-blocks-ci-workflow",
+  "hook": ".claude/hooks/protect-changes.sh",
+  "payload": {
+    "tool_name": "Edit",
+    "tool_input": { "file_path": "{TMPROOT}/.github/workflows/ci.yml" }
+  },
+  "expect": {
+    "exit_code": 2,
+    "stderr_contains": ["BLOCKED", "CI workflow"]
+  },
+  "notes": "Regression: basename-with-slash bug — .github/workflows/ci.yml has a slash in the path so the basename-only match missed it. Now path-matched."
+}

--- a/bench/scenarios/s06-protect-changes-blocks-auth-path.json
+++ b/bench/scenarios/s06-protect-changes-blocks-auth-path.json
@@ -1,0 +1,12 @@
+{
+  "name": "s06-protect-changes-blocks-auth-path",
+  "hook": ".claude/hooks/protect-changes.sh",
+  "payload": {
+    "tool_name": "Edit",
+    "tool_input": { "file_path": "{TMPROOT}/src/auth/login.ts" }
+  },
+  "expect": {
+    "exit_code": 2,
+    "stderr_contains": ["BLOCKED", "auth"]
+  }
+}

--- a/bench/scenarios/s07-quality-gate-passes-on-good-py.json
+++ b/bench/scenarios/s07-quality-gate-passes-on-good-py.json
@@ -1,0 +1,17 @@
+{
+  "name": "s07-quality-gate-passes-on-good-py",
+  "hook": ".claude/hooks/quality-gate.sh",
+  "setup_files": {
+    "src/valid.py": "def hello():\n    return 1\n"
+  },
+  "payload": {
+    "tool_name": "Edit",
+    "tool_input": { "file_path": "{TMPROOT}/src/valid.py" }
+  },
+  "expect": {
+    "exit_code": 0,
+    "state": [
+      { "file": ".hook-state/last_quality_gate.json", "field": "status", "equals": "passed" }
+    ]
+  }
+}

--- a/bench/scenarios/s08-quality-gate-fails-on-broken-py.json
+++ b/bench/scenarios/s08-quality-gate-fails-on-broken-py.json
@@ -1,0 +1,18 @@
+{
+  "name": "s08-quality-gate-fails-on-broken-py",
+  "hook": ".claude/hooks/quality-gate.sh",
+  "setup_files": {
+    "src/broken.py": "def hello(\n    return 1\n"
+  },
+  "payload": {
+    "tool_name": "Edit",
+    "tool_input": { "file_path": "{TMPROOT}/src/broken.py" }
+  },
+  "expect": {
+    "exit_code": 0,
+    "state": [
+      { "file": ".hook-state/last_quality_gate.json", "field": "status", "equals": "failed" }
+    ]
+  },
+  "notes": "Regression: `EXIT_CODE=$?` was placed after `|| true`, so the captured code was always 0 → status always 'passed'. Catches that bug."
+}

--- a/bench/scenarios/s09-stop-gate-blocks-on-failed-state.json
+++ b/bench/scenarios/s09-stop-gate-blocks-on-failed-state.json
@@ -1,0 +1,12 @@
+{
+  "name": "s09-stop-gate-blocks-on-failed-state",
+  "hook": ".claude/hooks/stop-gate.sh",
+  "setup_files": {
+    ".hook-state/last_quality_gate.json": "{\"status\":\"failed\",\"exit_code\":1,\"tool\":\"ruff\",\"edited_file\":\"x.py\",\"duration_seconds\":0,\"stderr_tail\":\"E\"}\n"
+  },
+  "payload": {},
+  "expect": {
+    "exit_code": 2,
+    "stderr_contains": ["BLOCKED", "stop-gate"]
+  }
+}

--- a/bench/scenarios/s10-stop-gate-allows-on-passed-state.json
+++ b/bench/scenarios/s10-stop-gate-allows-on-passed-state.json
@@ -1,0 +1,11 @@
+{
+  "name": "s10-stop-gate-allows-on-passed-state",
+  "hook": ".claude/hooks/stop-gate.sh",
+  "setup_files": {
+    ".hook-state/last_quality_gate.json": "{\"status\":\"passed\",\"exit_code\":0,\"tool\":\"ruff\",\"edited_file\":\"x.py\",\"duration_seconds\":0,\"stderr_tail\":\"\"}\n"
+  },
+  "payload": {},
+  "expect": {
+    "exit_code": 0
+  }
+}

--- a/bench/scenarios/s11-stop-gate-bypassed-with-skip-env.json
+++ b/bench/scenarios/s11-stop-gate-bypassed-with-skip-env.json
@@ -1,0 +1,13 @@
+{
+  "name": "s11-stop-gate-bypassed-with-skip-env",
+  "hook": ".claude/hooks/stop-gate.sh",
+  "env": { "SKIP_QUALITY_GATE": "1" },
+  "setup_files": {
+    ".hook-state/last_quality_gate.json": "{\"status\":\"failed\",\"exit_code\":1,\"tool\":\"ruff\",\"edited_file\":\"x.py\",\"duration_seconds\":0,\"stderr_tail\":\"E\"}\n"
+  },
+  "payload": {},
+  "expect": {
+    "exit_code": 0,
+    "stderr_contains": ["bypassed"]
+  }
+}

--- a/bench/scenarios/s12-prompt-router-injects-on-auth-inflection.json
+++ b/bench/scenarios/s12-prompt-router-injects-on-auth-inflection.json
@@ -1,0 +1,12 @@
+{
+  "name": "s12-prompt-router-injects-on-auth-inflection",
+  "hook": ".claude/hooks/prompt-router.sh",
+  "payload": {
+    "prompt": "Help me debug the authentication flow"
+  },
+  "expect": {
+    "exit_code": 0,
+    "stdout_contains": ["additionalContext", "Auth/security"]
+  },
+  "notes": "Regression: previous word-boundary regex `\\b...\\b` rejected inflections like 'authentication'. The stem-only match catches them."
+}

--- a/bench/scenarios/s13-prompt-router-quiet-on-neutral.json
+++ b/bench/scenarios/s13-prompt-router-quiet-on-neutral.json
@@ -1,0 +1,11 @@
+{
+  "name": "s13-prompt-router-quiet-on-neutral",
+  "hook": ".claude/hooks/prompt-router.sh",
+  "payload": {
+    "prompt": "What does this function return when the input is empty"
+  },
+  "expect": {
+    "exit_code": 0,
+    "stdout_empty": true
+  }
+}

--- a/bench/scenarios/s14-session-start-injects-tier1.json
+++ b/bench/scenarios/s14-session-start-injects-tier1.json
@@ -1,0 +1,15 @@
+{
+  "name": "s14-session-start-injects-tier1",
+  "hook": ".claude/hooks/session-start.sh",
+  "setup_files": {
+    "CODEBASE_MAP.md": "# CODEBASE_MAP\nPresent so session-start has something to point at.\n",
+    "CLAUDE.project.md": "# CLAUDE.project.md\nPresent so session-start mentions the overlay.\n"
+  },
+  "payload": {
+    "session_id": "kitbench-test"
+  },
+  "expect": {
+    "exit_code": 0,
+    "stdout_contains": ["additionalContext", "CODEBASE_MAP.md"]
+  }
+}

--- a/bench/scenarios/s15-session-end-writes-audit-line.json
+++ b/bench/scenarios/s15-session-end-writes-audit-line.json
@@ -1,0 +1,13 @@
+{
+  "name": "s15-session-end-writes-audit-line",
+  "hook": ".claude/hooks/session-end.sh",
+  "payload": {
+    "session_id": "kitbench-test",
+    "reason": "clean",
+    "transcript_path": ""
+  },
+  "expect": {
+    "exit_code": 0,
+    "file_grew": ["reports/session-audit.log"]
+  }
+}

--- a/scripts/run-bench.sh
+++ b/scripts/run-bench.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+#
+# run-bench.sh — KitBench runner
+#
+# Reads every scenario in bench/scenarios/*.json, runs the named hook with
+# the scenario's stdin payload + env, and asserts the result matches.
+# Pure-determinism eval — no LLM, no network, no shared state between scenarios
+# (each runs in a fresh temp dir).
+#
+# Usage:
+#   ./scripts/run-bench.sh                     # run all scenarios
+#   ./scripts/run-bench.sh --scenario s01      # run one
+#   ./scripts/run-bench.sh --filter protect    # name contains
+#   ./scripts/run-bench.sh --verbose           # print stdout/stderr per scenario
+#   ./scripts/run-bench.sh --json              # emit machine-readable summary
+#
+# Exit codes:
+#   0  all scenarios passed
+#   1  one or more scenarios failed
+#   2  runner error (bad scenario file, missing python3, etc.)
+#
+
+set -uo pipefail
+
+KIT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCENARIOS_DIR="$KIT_ROOT/bench/scenarios"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "run-bench: python3 is required (deterministic JSON handling)" >&2
+  exit 2
+fi
+
+if [ ! -d "$SCENARIOS_DIR" ]; then
+  echo "run-bench: $SCENARIOS_DIR does not exist" >&2
+  exit 2
+fi
+
+SCENARIO_FILTER=""
+NAME_FILTER=""
+VERBOSE=0
+JSON_OUT=0
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --scenario|-s) SCENARIO_FILTER="$2"; shift 2 ;;
+    --filter|-f) NAME_FILTER="$2"; shift 2 ;;
+    --verbose|-v) VERBOSE=1; shift ;;
+    --json) JSON_OUT=1; shift ;;
+    --help|-h)
+      sed -n '1,/^set -uo pipefail/p' "$0" | head -n -1 | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+KIT_ROOT="$KIT_ROOT" \
+SCENARIOS_DIR="$SCENARIOS_DIR" \
+SCENARIO_FILTER="$SCENARIO_FILTER" \
+NAME_FILTER="$NAME_FILTER" \
+VERBOSE="$VERBOSE" \
+JSON_OUT="$JSON_OUT" \
+exec python3 - <<'PY'
+import json, os, sys, subprocess, tempfile, shutil
+
+KIT_ROOT = os.environ["KIT_ROOT"]
+SCENARIOS_DIR = os.environ["SCENARIOS_DIR"]
+SCENARIO_FILTER = os.environ.get("SCENARIO_FILTER", "") or ""
+NAME_FILTER = os.environ.get("NAME_FILTER", "") or ""
+VERBOSE = os.environ.get("VERBOSE") == "1"
+JSON_OUT = os.environ.get("JSON_OUT") == "1"
+
+def load_scenarios():
+    out = []
+    for name in sorted(os.listdir(SCENARIOS_DIR)):
+        if not name.endswith(".json"):
+            continue
+        path = os.path.join(SCENARIOS_DIR, name)
+        with open(path) as f:
+            try:
+                data = json.load(f)
+            except json.JSONDecodeError as e:
+                raise SystemExit(f"run-bench: malformed scenario {name}: {e}")
+        # Each scenario file may contain one scenario (dict) or many (list)
+        items = data if isinstance(data, list) else [data]
+        for s in items:
+            if "name" not in s:
+                raise SystemExit(f"run-bench: scenario in {name} is missing 'name'")
+            out.append((path, s))
+    return out
+
+def apply_filter(scenarios):
+    if SCENARIO_FILTER:
+        scenarios = [(p, s) for p, s in scenarios if s["name"] == SCENARIO_FILTER]
+    if NAME_FILTER:
+        scenarios = [(p, s) for p, s in scenarios if NAME_FILTER in s["name"]]
+    return scenarios
+
+def write_setup_files(workdir, files):
+    for relpath, content in (files or {}).items():
+        full = os.path.join(workdir, relpath)
+        os.makedirs(os.path.dirname(full) or ".", exist_ok=True)
+        with open(full, "w") as f:
+            f.write(content if content is not None else "")
+
+def substitute(value, workdir):
+    if isinstance(value, str):
+        return value.replace("{TMPROOT}", workdir).replace("{KIT_ROOT}", KIT_ROOT)
+    if isinstance(value, dict):
+        return {k: substitute(v, workdir) for k, v in value.items()}
+    if isinstance(value, list):
+        return [substitute(v, workdir) for v in value]
+    return value
+
+def load_state_field(workdir, path, field):
+    full = os.path.join(workdir, path)
+    if not os.path.isfile(full):
+        return None, f"state file missing: {path}"
+    try:
+        with open(full) as f:
+            d = json.load(f)
+    except Exception as e:
+        return None, f"state file unreadable: {e}"
+    cur = d
+    for part in field.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return None, f"state field {field!r} not present"
+        cur = cur[part]
+    return cur, None
+
+def run_scenario(scenario):
+    name = scenario["name"]
+    hook_rel = scenario["hook"]
+    hook_path = os.path.join(KIT_ROOT, hook_rel)
+    if not os.path.isfile(hook_path):
+        return False, [f"hook not found at {hook_rel}"], "", ""
+
+    workdir = tempfile.mkdtemp(prefix=f"kitbench-{name}-")
+    # Provide a "project root" marker so hooks that walk up to find one stop here
+    open(os.path.join(workdir, "package.json"), "w").close()
+
+    try:
+        write_setup_files(workdir, scenario.get("setup_files"))
+        payload = substitute(scenario.get("payload", {}), workdir)
+
+        env = os.environ.copy()
+        # Ensure hooks resolve project root to our workdir
+        env["CLAUDE_PROJECT_DIR"] = workdir
+        # Apply scenario env overrides
+        for k, v in (scenario.get("env") or {}).items():
+            env[k] = str(v)
+
+        # Run hook with payload as stdin
+        proc = subprocess.run(
+            ["bash", hook_path],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            cwd=workdir,
+            env=env,
+        )
+
+        failures = []
+
+        # exit_code
+        if "exit_code" in scenario.get("expect", {}):
+            want = scenario["expect"]["exit_code"]
+            if proc.returncode != want:
+                failures.append(f"exit_code: want {want}, got {proc.returncode}")
+
+        # stderr_contains
+        for needle in scenario.get("expect", {}).get("stderr_contains", []):
+            if needle not in (proc.stderr or ""):
+                failures.append(f"stderr missing substring {needle!r}")
+
+        # stderr_not_contains
+        for needle in scenario.get("expect", {}).get("stderr_not_contains", []):
+            if needle in (proc.stderr or ""):
+                failures.append(f"stderr unexpectedly contains {needle!r}")
+
+        # stdout_contains
+        for needle in scenario.get("expect", {}).get("stdout_contains", []):
+            if needle not in (proc.stdout or ""):
+                failures.append(f"stdout missing substring {needle!r}")
+
+        # stdout_empty
+        if scenario.get("expect", {}).get("stdout_empty", False):
+            if (proc.stdout or "").strip() != "":
+                failures.append(f"stdout expected empty, got {len(proc.stdout)} chars")
+
+        # state_assertions (list of {file, field, value})
+        for assertion in scenario.get("expect", {}).get("state", []):
+            value, err = load_state_field(
+                workdir, assertion["file"], assertion["field"]
+            )
+            if err:
+                failures.append(f"state {assertion['file']}.{assertion['field']}: {err}")
+                continue
+            if "equals" in assertion and value != assertion["equals"]:
+                failures.append(
+                    f"state {assertion['file']}.{assertion['field']}: want {assertion['equals']!r}, got {value!r}"
+                )
+            if "gte" in assertion and not (isinstance(value, int) and value >= assertion["gte"]):
+                failures.append(
+                    f"state {assertion['file']}.{assertion['field']}: want >= {assertion['gte']}, got {value!r}"
+                )
+
+        # file_grew (audit log line added)
+        for fg in scenario.get("expect", {}).get("file_grew", []):
+            full = os.path.join(workdir, fg)
+            if not os.path.isfile(full):
+                failures.append(f"file expected to exist: {fg}")
+                continue
+            if os.path.getsize(full) == 0:
+                failures.append(f"file expected non-empty: {fg}")
+
+        return (not failures), failures, proc.stdout, proc.stderr
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+scenarios = apply_filter(load_scenarios())
+if not scenarios:
+    msg = "no scenarios matched"
+    if SCENARIO_FILTER or NAME_FILTER:
+        msg += f" (filter: scenario={SCENARIO_FILTER!r} name={NAME_FILTER!r})"
+    print(msg, file=sys.stderr)
+    sys.exit(2)
+
+results = []
+for path, scenario in scenarios:
+    ok, failures, out, err = run_scenario(scenario)
+    results.append({
+        "name": scenario["name"],
+        "ok": ok,
+        "failures": failures,
+        "stdout": out,
+        "stderr": err,
+    })
+
+pad = max(len(r["name"]) for r in results) + 2
+
+if JSON_OUT:
+    summary = {
+        "total": len(results),
+        "passed": sum(1 for r in results if r["ok"]),
+        "failed": sum(1 for r in results if not r["ok"]),
+        "results": [{k: v for k, v in r.items() if k != "stdout" and k != "stderr"} for r in results],
+    }
+    print(json.dumps(summary, indent=2))
+else:
+    print("KitBench")
+    print("=" * 40)
+    for r in results:
+        status = "PASS" if r["ok"] else "FAIL"
+        print(f"  {r['name']:<{pad}} {status}")
+        if not r["ok"]:
+            for line in r["failures"]:
+                print(f"    - {line}")
+            if VERBOSE:
+                if r["stdout"]:
+                    print("    stdout:", r["stdout"].rstrip())
+                if r["stderr"]:
+                    print("    stderr:", r["stderr"].rstrip())
+        elif VERBOSE and (r["stdout"] or r["stderr"]):
+            if r["stdout"]:
+                print("    stdout:", r["stdout"].rstrip())
+            if r["stderr"]:
+                print("    stderr:", r["stderr"].rstrip())
+    print("=" * 40)
+    passed = sum(1 for r in results if r["ok"])
+    failed = sum(1 for r in results if not r["ok"])
+    print(f"  {passed}/{len(results)} PASS  {failed} FAIL")
+
+sys.exit(0 if all(r["ok"] for r in results) else 1)
+PY

--- a/tasks/decisions.md
+++ b/tasks/decisions.md
@@ -115,6 +115,34 @@ Track important technical decisions here so they don't get lost between sessions
   - `agent_docs/hooks.md` State Files table grows from 2 rows to 5; new helper lib mentioned in `lib/` reference
   - Backward compat: if `python3` is unavailable on the target machine, `session-end.sh` falls back to the v1 single-line shape. The block counters and quality-gate history simply don't accumulate in that environment.
 
+### ADR-008: KitBench — reproducible eval harness for the kit's deterministic-enforcement claims
+- **Date**: 2026-05-18
+- **Status**: accepted
+- **Note**: ADR numbering assumes the v1.11.0 batch merges in this order — #117 (bash-budget, ADR-005) → #118 (lesson graph, ADR-006) → #119 (session scorecards, ADR-007) → this PR. Renumber on merge order changes.
+- **Context**: The kit promises *deterministic enforcement* (ADR-003) and ships 18+ hooks. But hooks are bash scripts whose correctness depends on hard-to-test regex/grep semantics — and the v1.10.0 review caught multiple specific bugs (composer.lock slip-through in `protect-files`, `EXIT_CODE=$?` after `|| true` in `quality-gate`, basename-with-slash miss on `.github/workflows/ci.yml` in `protect-changes`, word-boundary regex rejecting "authentication" in `prompt-router`). Without a regression bench, those bugs were found by accident; the next analogous bug will be found by accident too. Inspired by [GBrain's BrainBench](https://github.com/garrytan/gbrain-evals) — *kits that make behavioural claims should ship benchmarks for those claims*.
+- **Options**:
+  - A) **Deterministic JSON-scenario harness** — each scenario is a single JSON file in `bench/scenarios/`: hook to run, setup files, stdin payload, env overrides, and expected assertions (exit code, stderr/stdout substrings, state-file fields, file existence). A runner (`scripts/run-bench.sh`) iterates them in isolated temp dirs and prints pass/fail. Pros: zero LLM, zero deps beyond `python3 + bash`, fast (<5s for 15 scenarios), trivial to add regression cases. Cons: doesn't cover end-to-end session behaviour — only the individual hook contracts.
+  - B) **LLM-graded end-to-end evals** — drive a real Claude Code session, score the output. Pros: tests the whole stack. Cons: non-deterministic, slow, expensive, and the failure modes the kit cares about (a regex bug missing `.env.production`) don't show up as model-output differences.
+  - C) **Per-hook unit tests in bash** — write `bats` or `shunit2` tests next to each hook. Pros: idiomatic for shell. Cons: adds a test framework dependency, harder to express "the state file must contain field X with value Y", harder to make scenarios self-contained portable JSON.
+  - D) **Skip — rely on manual smoke testing per PR** — the status quo. Pros: no work. Cons: doesn't catch regressions, doesn't surface as a credibility marker, doesn't scale with the hook count.
+- **Decision**: A (JSON-scenario harness). Rationale: matches the kit's existing tooling shape (bash scripts + python3 stdlib for JSON, no third-party deps), produces clear pass/fail output suitable for CI, and the scenario file format is friendly enough that adding a regression case takes <5 minutes (one JSON file, no boilerplate). The deliberate non-coverage of end-to-end Claude Code behaviour is intentional — the bench validates the *kit's deterministic surface*, not model behaviour.
+- **Sub-decisions**:
+  - **One scenario per file, one assertion bundle per scenario.** Scenarios as a flat list in `bench/scenarios/*.json` (alphabetical by filename = run order). One file per scenario is easier to grep, diff, and review than a multi-document `scenarios.json`.
+  - **Each scenario runs in a fresh temp dir.** No shared state between scenarios. `setup_files` provides the initial state. The hook's writes (e.g. `.hook-state/last_quality_gate.json`) stay scoped to that temp dir, then it's deleted.
+  - **`{TMPROOT}` / `{KIT_ROOT}` template substitution in string values** lets payloads reference absolute paths inside the per-scenario temp dir.
+  - **Runner is `scripts/run-bench.sh`** — bash wrapper around python3, follows the same pattern as `scripts/lesson-graph.sh`. `--scenario`, `--filter`, `--verbose`, `--json` flags. Exit codes: 0 all pass / 1 some failed / 2 runner error.
+  - **CI integration via `.github/workflows/validate.yml`** — a new `kitbench` job runs every PR. Failure blocks merge.
+  - **`bench/` is kit-internal**, not user-facing. Users running `install.sh` don't get `bench/` — it's only meaningful for kit maintainers running tests on the kit itself. The shipped `scripts/run-bench.sh` exits 2 with a clear message when invoked outside the kit checkout (no `bench/scenarios/` present).
+  - **Initial corpus of 15 scenarios** seeded from: (a) the lifecycle hook surface — one happy-path + one failure path per hook contract, and (b) every bug caught during the v1.10.0 code review, converted into a regression scenario. Notably, scenarios s02, s05, s08, s12 are all direct regression coverage of known historical bugs.
+- **Consequences**:
+  - New top-level `bench/` directory containing `README.md` + `scenarios/sNN-*.json` files
+  - New script `scripts/run-bench.sh` (bash wrapper + python3 runner)
+  - CI gains a `kitbench` job in `.github/workflows/validate.yml`
+  - All 15 initial scenarios pass on the current kit (verified locally on this branch)
+  - Adding a regression case is now a single-JSON-file change — no boilerplate, no test framework setup
+  - Bench surfaces in `bench/README.md` as a credibility marker; future README work can reference it
+  - The bench is local-only, no external services, no API keys
+
 ### ADR-004: Adopt three skill conventions from codex-complexity-optimizer (Core Rule, Default Behavior, Phase 1 Inventory)
 - **Date**: 2026-05-18
 - **Status**: accepted


### PR DESCRIPTION
## Summary

Builds **KitBench** — a reproducible eval harness that turns the kit's deterministic-enforcement claims into pass/fail scenarios. 15 initial scenarios cover every blocking hook plus direct regression coverage of bugs caught during the v1.10.0 review.

**All 15 scenarios pass on this branch.**

## Why this approach

Inspired by [GBrain's BrainBench](https://github.com/garrytan/gbrain-evals) — *kits that make behavioural claims should ship benchmarks for those claims*. The kit promises "deterministic enforcement" (ADR-003) but, prior to this PR, that promise lived only in markdown. Now it lives in CI: every PR re-asserts the contract.

See `tasks/decisions.md → ADR-008` for the 4 options considered and full rationale.

## What's in scope

### Runner

`scripts/run-bench.sh` — bash wrapper around a python3 stdlib body. Each scenario runs in an isolated `mktemp -d` workdir; no shared state. Flags:

| Flag | Effect |
|---|---|
| `--scenario s01` | Run a single scenario by name |
| `--filter protect` | Run scenarios whose name contains the string |
| `--verbose` | Print captured stdout/stderr per scenario |
| `--json` | Emit machine-readable summary |

Exit codes: 0 all pass / 1 some failed / 2 runner error (e.g. missing python3).

### Scenarios (15)

Each is a single JSON file in `bench/scenarios/sNN-*.json` with: `hook`, optional `setup_files`, optional `env`, `payload`, `expect` (any of `exit_code`, `stdout_contains`, `stderr_contains`, `stdout_empty`, `state` field assertions, `file_grew`).

Coverage matrix:

| Hook | Scenarios | Regression bug covered |
|---|---|---|
| `protect-files` | s01 (.env), s02 (composer.lock) | s02 — historical lock-file slip-through |
| `protect-changes` | s03 (package.json), s04 (`CLAUDE_APPROVED` bypass), s05 (CI workflow), s06 (auth path) | s05 — basename-with-slash miss |
| `quality-gate` | s07 (good .py), s08 (broken .py) | s08 — `EXIT_CODE=$?` after `\|\| true` always reported "passed" |
| `stop-gate` | s09 (failed state), s10 (passed state), s11 (SKIP_QUALITY_GATE) | — |
| `prompt-router` | s12 ("authentication" → inject), s13 (neutral → silent) | s12 — word-boundary regex rejected inflections |
| `session-start` | s14 (Tier 1 context inject) | — |
| `session-end` | s15 (audit log line appended) | — |

### CI

New `kitbench` job in `.github/workflows/validate.yml` runs on every push and PR. Failure blocks merge.

### Docs

- `bench/README.md` — corpus overview + how to add a regression scenario (single JSON file, no framework setup)
- `README.md` — new "KitBench — hooks are tested" subsection under the Hooks section with sample output
- `CODEBASE_MAP.md` — `bench/` listed alongside `scripts/`
- `tasks/decisions.md` — ADR-008 with options analysis

## Smoke test output (local)

```
KitBench
========================================
  s01-protect-files-blocks-env                      PASS
  s02-protect-files-blocks-composer-lock            PASS
  s03-protect-changes-blocks-package-json           PASS
  s04-protect-changes-allows-with-claude-approved   PASS
  s05-protect-changes-blocks-ci-workflow            PASS
  s06-protect-changes-blocks-auth-path              PASS
  s07-quality-gate-passes-on-good-py                PASS
  s08-quality-gate-fails-on-broken-py               PASS
  s09-stop-gate-blocks-on-failed-state              PASS
  s10-stop-gate-allows-on-passed-state              PASS
  s11-stop-gate-bypassed-with-skip-env              PASS
  s12-prompt-router-injects-on-auth-inflection      PASS
  s13-prompt-router-quiet-on-neutral                PASS
  s14-session-start-injects-tier1                   PASS
  s15-session-end-writes-audit-line                 PASS
========================================
  15/15 PASS  0 FAIL
```

## Acceptance criteria

- [x] `bench/` directory with corpus + README
- [x] `scripts/run-bench.sh` runs all 15 scenarios; produces pass/fail per scenario + summary
- [x] All 15 scenarios pass on current kit (v1.11.0)
- [x] CI runs the bench on every PR; failures block merge
- [x] Bench surfaces in main README as credibility marker
- [x] Local-only — no external services, no API keys
- [x] Scenario format documented with template in `bench/README.md`
- [x] ADR-008 recorded

## Independence from sibling PRs

This PR does **not** depend on #117 (bash-budget), #118 (lesson graph), or #119 (session scorecards). It exercises only the hook contracts that already exist on `main`. When sibling PRs add new hooks/state files, follow-up bench scenarios can be added in their PRs (or a follow-up patch).

Closes #108.

Part of the v1.11.0 inspiration triad (rtk + GBrain + karpathy). Companions: #105, #106, #107, #114, #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)