### PR TITLE
feat(docs): add Goal-Driven Task Reframing pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ This is the single most important rule for long sessions.
 
 ## Plan First
 For any task touching 3+ files, architectural decisions, new dependencies, or workflow changes:
+- Before researching or planning, restate the request as a **verifiable goal** (see `agent_docs/workflow.md → Goal-Driven Task Reframing`). "Fix the bug" → "Write a test that reproduces it, then make it pass."
 - Write a plan to `tasks/todo.md` using the template in `agent_docs/workflow.md`
 - Do not implement until the plan is confirmed
 

--- a/agent_docs/workflow.md
+++ b/agent_docs/workflow.md
@@ -10,6 +10,45 @@ Every task follows this flow. Never skip steps.
 
 ---
 
+## Goal-Driven Task Reframing
+
+Imperative tasks ("fix the bug", "add validation", "refactor X") are ambiguous in two directions: it's unclear what counts as *done*, and it's unclear what to do *first*. Before researching or planning, restate the request as a **verifiable goal** — something whose completion can be checked deterministically.
+
+This complements `## Verification (Mandatory Order)` in `CLAUDE.md`: verification answers *"is the change correct after we built it?"*; goal-driven reframing answers *"what would a correct change even look like?"* before any code is written. Together they bracket the lifecycle.
+
+Inspired by [karpathy-skills](https://github.com/multica-ai/andrej-karpathy-skills) — *transform tasks into verifiable goals*.
+
+### The transformation table
+
+When the user gives you an imperative, restate it as a verifiable goal before doing anything else:
+
+| User says | Restate as |
+|---|---|
+| "Add validation to the signup form" | "Write failing tests for the invalid-input cases (empty email, short password, malformed phone, duplicate username). Make the form behavior cause them to pass." |
+| "Fix the bug where users can't reset their password" | "Write a regression test that reproduces the failure on `main`. Make the fix turn it green. Keep the test in the suite." |
+| "Refactor the `OrderService` to be cleaner" | "Confirm the current test suite passes. Apply the refactor. Confirm the same suite still passes — same inputs, same outputs, no new assertions added." |
+| "Make the dashboard faster" | "Write a measurement: page render to interactive on the slowest dashboard route, on the same hardware, same dataset. Beat that number by X% in the same script." |
+| "Improve the error messages" | "Pick the top N error sites by frequency (from logs / sentry). For each, write a test asserting the new message shape. Make them pass." |
+| "Document the API" | "List every public endpoint. Generate an OpenAPI doc / Markdown page that covers them. Verify by curl'ing each documented example and matching the response shape." |
+| "Clean up the codebase" | **Push back.** This is not a goal; it's a sentiment. Ask the user to point at the specific smell, file, or pattern they want addressed, and then restate that. |
+
+### How to apply
+
+1. After reading the request and **before** loading additional context, write the restated goal in your reply — one short paragraph.
+2. If a verifiable form genuinely does not exist (pure exploration, design review, advisory), say so explicitly and continue without inventing one.
+3. If the restated goal is ambiguous or seems wrong, ask **one** clarifying question before proceeding. Don't ladder up clarifications — pick the highest-impact one.
+4. The restated goal becomes the **acceptance line** in `tasks/todo.md` if you go on to write a plan (see "Plan Template" below).
+
+### Why this matters
+
+- It surfaces the test/measurement up front, so the rest of the work has a target.
+- It deflects sentiment-shaped requests ("make it cleaner") before they balloon into scope drift.
+- It makes the *end* of the task agree with the *start* of the task — `stop-gate.sh` checks verification; this section checks intent.
+
+This is a prompt-side rule (no hook enforces it). The reminder is in `CLAUDE.md → Plan First`; for a deterministic regression scenario covering the reframing behavior, see `bench/scenarios/` (KitBench).
+
+---
+
 ## Separate Research from Implementation
 
 **This is one of the most impactful practices.** When research and implementation happen in the same context, the agent accumulates irrelevant details from alternatives it explored but didn't choose.


### PR DESCRIPTION
## Summary

Adds an explicit **Goal-Driven Task Reframing** section to `agent_docs/workflow.md` (with a 1-line pointer from `CLAUDE.md → Plan First`). Surfaces the "restate the imperative as a verifiable goal" step at the top of the task lifecycle, closing the gap where vague directives ("fix the bug", "make it cleaner", "refactor X") let scope drift in before any code is written.

## What's in scope

### `agent_docs/workflow.md` → new section after `## Task Lifecycle`

A 7-row transformation table covering:

| User says | Restate as |
|---|---|
| "Add validation to the signup form" | Write failing tests for invalid-input cases, then make them pass |
| "Fix the bug…" | Write a regression test that reproduces, then make it pass |
| "Refactor X to be cleaner" | Confirm test suite green → refactor → confirm same suite still green |
| "Make the dashboard faster" | Measure on hardware/dataset → beat the number in the same script |
| "Improve the error messages" | Top-N error sites → tests for new shape → make them pass |
| "Document the API" | List endpoints → generate doc → verify by curling each example |
| "Clean up the codebase" | **Push back** — sentiment, not a goal. Ask for a specific smell. |

Plus a four-step "How to apply" guide and a "Why this matters" note that connects this section to `stop-gate.sh` (verification at the end of the lifecycle).

### `CLAUDE.md → Plan First`

One added bullet:

> Before researching or planning, restate the request as a **verifiable goal** (see `agent_docs/workflow.md → Goal-Driven Task Reframing`). "Fix the bug" → "Write a test that reproduces it, then make it pass."

That's the entire change. The rest of Plan First, Scope Discipline, and Verification are untouched.

## Why this approach

Pure prompt-side rule — no hook can enforce "restate the goal", so adding a PreToolUse check would be the wrong shape. The reframing pattern is meant to land **before** any tool is used.

Inspired by [karpathy-skills](https://github.com/multica-ai/andrej-karpathy-skills) — *transform tasks into verifiable goals*. The kit already had verification (Mandatory Order) and Plan First; this fills the missing intent-shaping step at the front of the lifecycle.

## Acceptance criteria

- [x] `agent_docs/workflow.md` has a "Goal-Driven Task Reframing" section with table + rationale
- [x] `CLAUDE.md` mentions the pattern (1 line) under Plan First
- [x] At least 5 verifiable-goal examples (the table has 7, covering add-feature, fix-bug, refactor, performance, error-messages, docs, and the cleanup push-back case)
- [ ] Optional bench scenario for KitBench (#108) — out of scope for this PR. Can be added in a follow-up once #120 merges if useful.

## Independence from sibling PRs

This PR touches only `CLAUDE.md` and `agent_docs/workflow.md` — no overlap with #117, #118, #119, or #120. Safe to merge in any order.

Closes #114.

Part of the v1.11.0 inspiration triad (rtk + GBrain + karpathy). Companions: #105, #106, #107, #108, #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)