### PR TITLE
feat(docs): add explicit Match Existing Style rule to Scope Discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ If something goes sideways mid-task: STOP, re-read the original goal, re-plan.
 ## Scope Discipline
 - Touch ONLY files directly required by the task
 - Never refactor opportunistically
+- **Match existing style** in any file you edit — quote style, indentation, naming convention, async/promise patterns — even if you'd write it differently from scratch. Style drift inside a touched file is an unrelated change. See `agent_docs/conventions.md → Match Existing Style`.
 - Log unrelated issues under `tasks/todo.md → ## Not Now`
 - State every assumption explicitly before acting on it
 - If 2+ valid approaches exist with real tradeoffs: present them, don't decide silently

--- a/agent_docs/conventions.md
+++ b/agent_docs/conventions.md
@@ -82,6 +82,125 @@ These are sensible defaults. Override them in `CLAUDE.project.md` if your team h
 
 ---
 
+## Match Existing Style
+
+When editing existing code, **match the style of the file you are in** — even if you'd write it differently from scratch. The rule on its own is one line, but the failure modes are subtle, so this section spells them out.
+
+Why it matters: style drift inside a file is invisible until a diff reveals it. Then reviewers spend their attention on the diff noise instead of the actual change. Formatters catch some of this (Prettier, Black, gofmt); naming/async/comment patterns slip through.
+
+This rule complements `CLAUDE.md → Scope Discipline` ("touch ONLY files directly required") — once you've decided to touch a file, the in-file style ratchets.
+
+### Quote style
+
+```ts
+// File uses single quotes throughout
+import { foo } from 'lib'
+const greeting = 'hello'
+
+// BAD — introduces double quotes that don't match the file
+const farewell = "goodbye"
+
+// GOOD — match the file
+const farewell = 'goodbye'
+```
+
+The rule applies even when the surrounding file is "wrong" by your taste. If the codebase has chosen single quotes, you use single quotes.
+
+### Indentation
+
+```py
+# File uses 4-space indentation
+def existing():
+    return 1
+
+# BAD — 2-space indent inside a 4-space file
+def added():
+  return 2
+
+# GOOD — match the file
+def added():
+    return 2
+```
+
+Same for tabs vs. spaces. The file decides, not you. (If you really think the project's choice is wrong, raise it as a separate issue under `tasks/todo.md → ## Not Now`.)
+
+### Async / promise patterns
+
+```js
+// File uses async/await throughout
+async function loadUser(id) {
+  const data = await fetch(`/api/users/${id}`)
+  return data.json()
+}
+
+// BAD — mixing in .then() chains
+function loadOrder(id) {
+  return fetch(`/api/orders/${id}`).then(r => r.json())
+}
+
+// GOOD — same shape as siblings
+async function loadOrder(id) {
+  const r = await fetch(`/api/orders/${id}`)
+  return r.json()
+}
+```
+
+If you must mix paradigms (e.g. consuming an old `.then()`-based API), wrap it locally so the rest of the file stays consistent.
+
+### Naming convention
+
+```py
+# File is snake_case throughout
+def get_user_by_id(user_id): ...
+def list_active_orders(): ...
+
+# BAD — camelCase function in a snake_case file
+def listActiveProducts(): ...
+
+# GOOD — match the file
+def list_active_products(): ...
+```
+
+This applies inside a single file. Different files within the same project may have different conventions for legitimate reasons (e.g. framework code uses `camelCase`, app code uses `snake_case`). Match what you see in the file you're editing.
+
+### Comment style
+
+```ts
+// File uses single-line `//` comments throughout
+// computes the running average over the last N samples
+function avg(samples) { ... }
+
+// BAD — switching to block comments
+/**
+ * Computes the median.
+ */
+function median(samples) { ... }
+
+// GOOD — match the file (use JSDoc only if the file already uses JSDoc)
+// computes the median over the last N samples
+function median(samples) { ... }
+```
+
+If the file uses JSDoc / docstrings / Doxygen comments on its functions, your new function gets one too. If it doesn't, you don't add one just because "they're nicer."
+
+### Quick checklist before submitting an edit
+
+- [ ] Quote style — matches the surrounding file
+- [ ] Indentation — matches the surrounding file (spaces vs. tabs, width)
+- [ ] Async pattern — `async/await` vs. `.then()` matches siblings
+- [ ] Naming — function/variable casing matches siblings in the same file
+- [ ] Comments — same style and density as the surrounding code
+
+If you genuinely cannot follow one of these (e.g. the file is empty, or you're creating a new one), follow the project's overall convention as inferred from sibling files in the same directory.
+
+### When this rule does not apply
+
+- **Whole-file rewrites** when scoped as an explicit task ("rewrite `users.service.ts` in modern style") — the rule that gets ratcheted is *project-wide* convention, not the old file's drift.
+- **New files** where there is no existing style to match — fall back to the project's overall convention.
+- **Generated files** (codegen output, vendored deps) — leave them alone, they're not "yours".
+
+---
+
 ## Git Hygiene
 
 ### Branches


### PR DESCRIPTION
## Summary

Surfaces an explicit **Match Existing Style** rule in the kit's Scope Discipline section. Closes the gap where agents silently drift quote style, indentation, async patterns, or naming convention inside the very files they touch — drift that formatters don't catch (Prettier handles quotes; nothing catches an `async/await` file with a new `.then()` chain dropped in, or a `snake_case` Python file with a `camelCase` function added).

## What's in scope

### `CLAUDE.md → Scope Discipline`

One new bullet:

> **Match existing style** in any file you edit — quote style, indentation, naming convention, async/promise patterns — even if you'd write it differently from scratch. Style drift inside a touched file is an unrelated change. See `agent_docs/conventions.md → Match Existing Style`.

### `agent_docs/conventions.md → new "Match Existing Style" section`

Expanded rationale + 5 concrete contrast examples:

1. **Quote style** — single vs. double in JS/TS
2. **Indentation** — tabs vs. spaces / 2-space vs. 4-space
3. **Async / promise patterns** — `async/await` vs. `.then()` chains
4. **Naming convention** — `snake_case` vs. `camelCase` inside a single file
5. **Comment style** — `//` vs. JSDoc/block comments

Plus a pre-submit checklist (5 items) and an explicit **"when this rule does not apply"** carve-out covering:
- Whole-file rewrites scoped as an explicit task
- New files (no existing style to match — fall back to project convention)
- Generated files (codegen output, vendored deps)

## Acceptance criteria

- [x] `CLAUDE.md` Scope Discipline has the explicit rule (one bullet, points to the expanded section)
- [x] `agent_docs/conventions.md` has expanded section with rationale + examples
- [x] At least 4 concrete examples — this PR has 5 (quote, indent, async, naming, comment)
- [x] Cross-reference from `agent_docs/conventions.md` ↔ `CLAUDE.md` (both directions)
- [ ] Optional bench scenario for KitBench (#108) — out of scope for this PR. Style-drift is genuinely hard to write as a deterministic bench scenario without a real-language formatter dependency; recommend skipping or revisiting if useful after #120 merges.

## Why no hook enforcement

The issue suggested this rule belongs in prompt-side guidance, not a hook:
- **Quote style** + **indentation** are formatters' job (Prettier, Black, gofmt). The kit already supports the opt-in `auto-format` hook.
- **Async paradigm** and **naming convention** are structural — no linter catches them without high false-positive rates ("you're allowed to mix `.then()` *here* because…").
- **Comment style** is a soft convention; over-enforcing it produces churn.

So this stays as advisory + structural pattern — same shape as `## Plan First` and `## Scope Discipline` in CLAUDE.md.

## Independence from sibling PRs

Touches only `CLAUDE.md` and `agent_docs/conventions.md`. No overlap with #117/#118/#119/#120/#121. Safe to merge in any order.

Closes #115.

Part of the v1.11.0 inspiration triad (rtk + GBrain + karpathy). Companions: #105, #106, #107, #108, #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)