### PR TITLE
feat(skills): /quality-audit + /doc-gardening — golden-principles drift detection

### DIFF
--- a/.claude/skills/doc-gardening/SKILL.md
+++ b/.claude/skills/doc-gardening/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: doc-gardening
+description: Cross-checks docs/ against current code — flags stale file paths, broken cross-references, removed APIs, and outdated examples
+user-invocable: true
+---
+
+# Doc Gardening
+
+## Core Rule
+
+Flag drift, never silently rewrite. A doc may be intentionally aspirational; the human decides whether to update the doc or the code. This skill produces a punch list — the human applies the fix.
+
+## Kit Context
+
+Before starting this skill, ensure you have completed session boot:
+1. Read `CODEBASE_MAP.md` for project understanding
+2. Read `CLAUDE.project.md` if it exists for project-specific rules
+3. Read `tasks/lessons/_index.md` for accumulated corrections (Top Rules + index)
+
+If any of these haven't been read in this session, read them now before proceeding.
+
+## When to Use
+
+Invoke with `/doc-gardening` when:
+
+- The codebase has shifted (rename, refactor, feature removal) and you suspect docs lag behind
+- After a major release, to sweep `docs/` and `README.md` for stale references
+- As a scheduled background task (`/loop weekly /doc-gardening`) to keep drift bounded
+- Before publishing a release or onboarding a new contributor
+
+## Default Behavior
+
+When the user asks to audit, scan, review, or "give me a report" for doc drift, produce the full doc-gardening report automatically using the Process and Output Format sections below. Do not require the user to specify fields.
+
+Only modify files when the user explicitly requests implement / fix / apply / refactor. By default, this skill is **report-only**.
+
+## Scope
+
+This skill covers:
+
+- `docs/` (all `*.md` files)
+- `README.md` at repo root
+- `CODEBASE_MAP.md` at repo root
+- `tasks/lessons/_index.md` (only the Top Rules section — checks if rule references still exist)
+- `agent_docs/*.md` (kit-only) — checks the per-doc directory listing in `CLAUDE.md`
+
+It does NOT cover:
+
+- Inline code comments (use `/documentation-audit` for that)
+- Git history, changelogs, or release notes (intentionally retrospective)
+- Files under `docs/archive/` or `docs/legacy/` (assume intentional)
+
+## Process
+
+### Phase 1: Inventory (first-pass leads)
+
+This pass produces **candidates**, not findings. Treat counts as leads for deeper inspection in later phases. Do not report Phase 1 raw output as the final result.
+
+1. List all markdown files in scope.
+2. For each, extract: file path references, code symbols in backticks, fenced code blocks with import/require lines, cross-doc links (`[...](...)`).
+3. Hold the lists; do not classify yet.
+
+### Phase 2: Drift Detection
+
+For each extracted reference, classify into one of these categories:
+
+**File path references** (e.g., `src/lib/foo.ts`, `.claude/hooks/bar.sh`)
+- ✅ Exists at the referenced path → OK
+- ❌ Does not exist → **stale path** (HIGH)
+- ⚠️ Exists but was renamed/moved (path different than current `git log --follow`) → **moved** (MEDIUM)
+
+**Symbols in backticks** that look like functions/classes (e.g., `useAuth()`, `validatePayload`)
+- For each, grep the codebase for definition. If 0 hits → **missing symbol** (MEDIUM). If ≥1 hit → OK.
+- This is intentionally lossy — backticks can hold non-code things. Phase 3 triage filters false positives.
+
+**Cross-doc links** (relative `[...](path)` links)
+- ❌ Target does not exist → **broken link** (HIGH)
+- ⚠️ Target exists but anchor (`#section`) does not match any heading in the target → **broken anchor** (LOW)
+
+**Fenced code blocks with import paths**
+- For each `import ... from "..."` or `require("...")`, resolve the path against repo. Missing → **stale example** (MEDIUM).
+
+**Versions in prose** (regex: `v\d+\.\d+\.\d+`)
+- Compare against the latest version in the repo (`package.json` → `version`, or `CHANGELOG.md` first heading).
+- If the doc cites a version older than the latest by 2+ minor versions → **stale version** (LOW). Skip changelog entries themselves.
+
+### Phase 3: Triage
+
+For each candidate finding:
+
+1. **Suppress** if the file is in `docs/archive/`, `docs/legacy/`, or matches `.doc-gardening-ignore` glob list.
+2. **Suppress** if the markdown line is inside a triple-fence comment (` ``` ` to ` ``` `) tagged as `text` or `example` — those are intentional samples.
+3. **De-duplicate** by `(file, line, kind)`.
+
+### Phase 4: Report
+
+Group findings by severity (HIGH > MEDIUM > LOW), then by source doc.
+
+## Output Format
+
+```markdown
+# Doc Gardening Report
+
+_Last run: 2026-05-18T14:23:00Z — doc-gardening v1_
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Docs scanned | 24 |
+| Findings | 11 |
+| HIGH | 2 |
+| MEDIUM | 6 |
+| LOW | 3 |
+
+## HIGH — Likely broken
+
+### `docs/getting-started.md`
+
+| # | Line | Kind | Reference | Suggestion |
+|---|------|------|-----------|------------|
+| 1 | 42 | stale path | `src/lib/auth-old.ts` | File removed in 1.10.0. Update to `src/lib/auth.ts` or remove section. |
+| 2 | 87 | broken link | `[Architecture](./arch.md)` | Target missing. Did you mean `docs/architecture.md`? |
+
+## MEDIUM — Worth a closer look
+
+### `README.md`
+
+| # | Line | Kind | Reference | Suggestion |
+|---|------|------|-----------|------------|
+| 1 | 12 | moved | `bin/cli.js` | Was renamed to `bin/index.js` in commit a1b2c3d. |
+
+### `docs/api.md`
+
+| # | Line | Kind | Reference | Suggestion |
+|---|------|------|-----------|------------|
+| 1 | 33 | missing symbol | `validatePayload()` | No definition found. Renamed to `parsePayload()`? |
+| 2 | 68 | stale example | `import { LegacyClient } from '../sdk'` | Module removed. Update example. |
+
+## LOW — Cosmetic
+
+### `docs/changelog.md`
+
+| # | Line | Kind | Reference | Suggestion |
+|---|------|------|-----------|------------|
+| 1 | 5 | broken anchor | `[#core-rule](./rules.md#core-rule)` | Section was renamed to `## The Core Rule`. |
+
+## Suggested actions
+
+- `docs/getting-started.md` has the most drift — review next.
+- 4 findings reference paths that moved during the auth refactor (commits a1b2c3d..d4e5f6a) — bulk-fix candidate.
+- Consider adding `docs/legacy/v0/` to `.doc-gardening-ignore` if those files are intentionally frozen.
+```
+
+## Run Mode
+
+| Decision point | Interactive default | Headless default (`mode:headless`) |
+|---|---|---|
+| Auto-fix obvious renames | Ask | Never — report only |
+| Add finding to `tasks/todo.md` | Ask | Always append to `tasks/todo.md → ## Doc Drift` |
+| Open follow-up PR | Ask | Never |
+
+See `.claude/skills/_shared/blocks/mode-detection.md`.
+
+## Loop / Schedule Integration
+
+```text
+/loop weekly /doc-gardening mode:headless
+/schedule monthly /doc-gardening mode:headless
+```
+
+In headless mode, findings are appended to `tasks/todo.md → ## Doc Drift` so the next human session sees them.
+
+## Notes
+
+- This skill is **complementary** to `/documentation-audit`. The latter assesses *completeness and clarity*; this skill watches for *drift between docs and code*.
+- The detection is intentionally heuristic — false positives are expected. The triage phase suppresses obvious ones; the rest are leads for human review.
+- If a kind of finding has 10+ false positives across runs, propose adding it to `.doc-gardening-ignore` rather than tweaking the detector.
+- Doc-gardening complements `/quality-audit` — together they form the "Friday cleanup" recipe inspired by OpenAI's harness engineering pattern.

--- a/.claude/skills/quality-audit/SKILL.md
+++ b/.claude/skills/quality-audit/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: quality-audit
+description: Audits codebase against project-defined golden-principles.yaml — runs deterministic detection rules and updates docs/QUALITY_SCORE.md
+user-invocable: true
+---
+
+# Quality Audit
+
+## Core Rule
+
+Only report drift that a `golden-principles.yaml` rule can detect deterministically. Never invent rules during the audit — if it's not in the YAML, it doesn't appear in the report.
+
+## Kit Context
+
+Before starting this skill, ensure you have completed session boot:
+1. Read `CODEBASE_MAP.md` for project understanding
+2. Read `CLAUDE.project.md` if it exists for project-specific rules
+3. Read `tasks/lessons/_index.md` for accumulated corrections (Top Rules + index)
+
+If any of these haven't been read in this session, read them now before proceeding.
+
+## When to Use
+
+Invoke with `/quality-audit` when:
+
+- The project has (or should have) a `golden-principles.yaml` and you want to measure drift
+- Onboarding to a project and want to see where the codebase deviates from documented principles
+- Running as a scheduled background task (`/loop daily /quality-audit`) to track quality trends
+- Preparing for a refactoring sprint — turn drift findings into a backlog
+
+## Default Behavior
+
+When the user asks to audit, scan, review, or "give me a report" for golden-principles drift, produce the full quality-audit report automatically using the Process and Output Format sections below. Do not require the user to specify fields.
+
+Only modify files when the user explicitly requests implement / fix / apply / refactor. By default, this skill is **report-only** (with one exception: it updates `docs/QUALITY_SCORE.md` because that file is the report's destination).
+
+## Inputs
+
+The skill looks for `golden-principles.yaml` in this order:
+
+1. `golden-principles.yaml` (repo root)
+2. `.claude/golden-principles.yaml`
+
+If neither exists, the skill emits a stub and a one-paragraph guide pointing at `.claude/skills/quality-audit/templates/golden-principles.example.yaml`. It does not invent rules.
+
+## Schema: golden-principles.yaml
+
+```yaml
+# golden-principles.yaml — deterministic, machine-checkable project rules
+# Each principle must have an id, rule, severity, detect, and fix_hint.
+# Optional: tags, paths, enabled.
+
+version: 1
+
+principles:
+  - id: prefer-shared-utils
+    rule: "Hand-rolled helpers should be replaced with shared util packages"
+    severity: major            # critical | major | minor
+    detect:
+      type: grep               # grep | rg | command
+      pattern: "function (debounce|throttle|deepClone)\\b"
+      paths:                   # optional — defaults to repo root excluding vendor/build dirs
+        - "src/**/*.ts"
+        - "src/**/*.tsx"
+    fix_hint: "Use @workspace/utils/{debounce,throttle,deepClone} instead."
+    tags: [refactor, utils]
+    enabled: true
+
+  - id: no-yolo-data
+    rule: "Don't traverse data structures without validation at the boundary"
+    severity: critical
+    detect:
+      type: rg
+      pattern: "JSON\\.parse\\("
+      paths: ["src/**/*.ts"]
+    fix_hint: "Wrap with Zod schema parse() — see src/schemas/."
+    tags: [type-safety, boundary]
+
+  - id: no-direct-db-in-route
+    rule: "Route handlers must not import database clients directly"
+    severity: critical
+    detect:
+      type: command
+      command: "rg -l 'from .prisma|from .drizzle' src/app/api/ | head -20"
+      # 'command' shells out exactly as written. Output lines = matches.
+    fix_hint: "Move queries to src/repositories/ and inject through a service."
+```
+
+**Detection types:**
+
+- `grep` — `grep -RnE "<pattern>" <paths>`. Portable, slowest.
+- `rg` — `rg --column -e "<pattern>" <paths>`. Fast, requires ripgrep. Falls back to grep if `rg` is absent.
+- `command` — shell out exactly as written. Each output line is one match. Use sparingly — harder to audit.
+
+**Severity → weight (for the score):**
+
+| Severity | Weight |
+|----------|--------|
+| critical | 5 per match |
+| major | 2 per match |
+| minor | 1 per match |
+
+**Score formula:** `score = max(0, 100 - sum(weight × matches))`. Clamped to `[0, 100]`. Reported alongside per-principle counts so a single noisy rule doesn't hide the picture.
+
+## Process
+
+### Phase 1: Inventory (first-pass leads)
+
+This pass produces **candidates**, not findings. Treat counts as leads for deeper inspection in later phases. Do not report Phase 1 raw output as the final result.
+
+1. Resolve `golden-principles.yaml` (root → `.claude/`). If missing, emit the stub guide and stop.
+2. Parse the YAML. Skip principles with `enabled: false`.
+3. Validate each principle has `id`, `rule`, `severity`, `detect`, `fix_hint`. Skip malformed entries with a warning line in the report.
+4. For each enabled principle, run its `detect` rule and collect raw matches. **These are candidates, not confirmed violations.**
+
+### Phase 2: Triage
+
+For each principle's candidates:
+
+1. **Suppress false positives.** Skip matches inside comments, test fixtures (`**/*.test.*`, `**/__fixtures__/**`), and any path matching the principle's own implementation (use `.quality-audit-ignore` glob list if present).
+2. **De-duplicate** by file:line.
+3. Keep top 25 matches per principle (full count is preserved in the metrics row).
+
+### Phase 3: Score & Report
+
+1. Compute the score using the formula above.
+2. Group findings by severity → critical / major / minor.
+3. For each finding, include: `file:line`, the matched snippet (trimmed to 80 chars), and the principle's `fix_hint`.
+
+### Phase 4: Write `docs/QUALITY_SCORE.md`
+
+If `docs/` does not exist, skip the file write and print the report to stdout. Do NOT create `docs/` from this skill — that's `/harness-init`'s job.
+
+If `docs/QUALITY_SCORE.md` exists:
+
+1. Preserve any section above the `<!-- quality-audit:start -->` marker.
+2. Replace content between `<!-- quality-audit:start -->` and `<!-- quality-audit:end -->` with the new report.
+3. If markers are absent, append the report and add markers around it.
+
+This keeps the file safe to edit by hand outside the managed block.
+
+## Output Format
+
+```markdown
+# Quality Score
+
+<!-- quality-audit:start -->
+_Last run: 2026-05-18T14:23:00Z — quality-audit v1_
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Score | 87 / 100 |
+| Principles enabled | 6 |
+| Principles violated | 3 |
+| Critical findings | 1 |
+| Major findings | 4 |
+| Minor findings | 7 |
+
+## Findings
+
+### Critical
+
+#### `no-yolo-data` — Don't traverse data structures without validation at the boundary
+
+| # | Location | Match | Fix |
+|---|----------|-------|-----|
+| 1 | `src/app/api/orders/route.ts:42` | `JSON.parse(body)` | Wrap with Zod schema parse() — see src/schemas/. |
+
+### Major
+
+#### `prefer-shared-utils` — Hand-rolled helpers should be replaced with shared util packages
+
+| # | Location | Match | Fix |
+|---|----------|-------|-----|
+| 1 | `src/lib/format.ts:12` | `function debounce(fn, ms)` | Use @workspace/utils/{debounce,...} instead. |
+
+### Minor
+
+_None._
+
+## Trend
+
+| Run | Score | Δ |
+|-----|-------|---|
+| 2026-05-18 | 87 | — |
+| 2026-05-11 | 85 | +2 |
+| 2026-05-04 | 82 | +3 |
+
+_(Trend is only emitted when previous runs are present in the managed block.)_
+
+<!-- quality-audit:end -->
+```
+
+## Run Mode
+
+| Decision point | Interactive default | Headless default (`mode:headless`) |
+|---|---|---|
+| Missing `golden-principles.yaml` | Print stub guide, ask user if they want a starter copied in | Print stub guide and exit code 0 — never write files unprompted |
+| `docs/` missing | Print to stdout, ask before creating | Print to stdout, exit 0 (never create `docs/`) |
+| Confirm refactor PR | Ask | Never open PRs in headless mode — drift report only |
+
+See `.claude/skills/_shared/blocks/mode-detection.md`.
+
+## Loop / Schedule Integration
+
+The skill is designed for unattended runs:
+
+```text
+/loop daily /quality-audit mode:headless
+/schedule weekly /quality-audit mode:headless
+```
+
+When fired by a loop or schedule, the report is appended to `docs/QUALITY_SCORE.md`'s managed block and (if score drops by more than 5 points week-over-week) a follow-up task is added to `tasks/todo.md → ## Drift Alerts` — the human handles the refactor decision.
+
+## Templates
+
+A starter `golden-principles.yaml` ships at `.claude/skills/quality-audit/templates/golden-principles.example.yaml`. Copy it to the repo root and tailor for your stack.
+
+## Notes
+
+- This skill is **complementary** to `/code-quality-audit`. The latter checks generic code smells (long functions, swallowed errors). `/quality-audit` enforces *your* project's rules.
+- If a principle becomes universally adopted (zero matches for 3+ runs), consider removing it — the YAML is a living document, not a graveyard.
+- The detection layer is intentionally simple (grep/rg/command). For AST-level checks, write a custom `command:` that shells out to your project's existing linter (ESLint custom rule, Semgrep, etc.) — this skill is the orchestrator, not the analyzer.

--- a/.claude/skills/quality-audit/templates/golden-principles.example.yaml
+++ b/.claude/skills/quality-audit/templates/golden-principles.example.yaml
@@ -1,0 +1,105 @@
+# golden-principles.yaml — project-specific, machine-checkable rules
+#
+# Copy this file to your repo root (or .claude/golden-principles.yaml) and
+# tailor for your stack. /quality-audit reads this file, runs the `detect`
+# rule for each principle, and updates docs/QUALITY_SCORE.md with the
+# drift report.
+#
+# Schema:
+#   id        unique kebab-case identifier
+#   rule      one-line human-readable description
+#   severity  critical | major | minor   (weights: 5 / 2 / 1)
+#   detect    type + pattern (or command) — see options below
+#   fix_hint  one-line action the developer should take
+#   paths     (optional) glob list to scope detection
+#   tags      (optional) free-form categorisation
+#   enabled   (optional, default true) toggle without deleting
+#
+# Detection types:
+#   grep:    portable, slowest — uses `grep -RnE`
+#   rg:      fast, requires ripgrep — falls back to grep if missing
+#   command: shells out exactly as written; each output line is one match
+#
+# Start small (3–5 principles). Add more as patterns emerge in code review.
+# A principle with zero matches for 3+ runs is a candidate for removal —
+# either the rule was never violated or the codebase has converged.
+
+version: 1
+
+principles:
+
+  # ── Type safety / boundary validation ──────────────────────────────────
+  - id: no-yolo-json-parse
+    rule: "Don't JSON.parse without schema validation at the boundary"
+    severity: critical
+    detect:
+      type: rg
+      pattern: "JSON\\.parse\\("
+      paths:
+        - "src/**/*.ts"
+        - "src/**/*.tsx"
+    fix_hint: "Wrap with a Zod/Valibot schema parse() — see src/schemas/."
+    tags: [type-safety, boundary]
+
+  - id: no-any-in-public-api
+    rule: "Public exports must not use the `any` type"
+    severity: major
+    detect:
+      type: rg
+      pattern: "export (function|const|type|interface).*: any\\b"
+      paths: ["src/**/*.ts", "src/**/*.tsx"]
+    fix_hint: "Narrow to `unknown` and parse, or define a precise type in src/types/."
+    tags: [type-safety]
+
+  # ── Shared utility adoption ────────────────────────────────────────────
+  - id: prefer-shared-utils
+    rule: "Hand-rolled helpers should be replaced with shared util packages"
+    severity: major
+    detect:
+      type: rg
+      pattern: "function (debounce|throttle|deepClone|clamp|uniqueBy)\\b"
+      paths: ["src/**/*.ts", "src/**/*.tsx"]
+    fix_hint: "Use the shared utils package — see src/utils/index.ts for exports."
+    tags: [refactor, utils]
+
+  # ── Architecture boundaries ────────────────────────────────────────────
+  - id: no-direct-db-in-route
+    rule: "Route handlers must not import database clients directly"
+    severity: critical
+    detect:
+      type: rg
+      pattern: "(from ['\"]@?prisma|from ['\"]drizzle-orm)"
+      paths: ["src/app/api/**/*.ts"]
+    fix_hint: "Move queries to src/repositories/ and inject through a service layer."
+    tags: [architecture, boundary]
+
+  - id: no-cross-feature-imports
+    rule: "Features must not import from sibling features directly"
+    severity: major
+    detect:
+      type: command
+      # Each line is one violation. Adjust paths for your structure.
+      command: "rg -l '../(?!shared|core)' src/features/ 2>/dev/null | head -25"
+    fix_hint: "Promote shared logic to src/features/shared/ or src/core/."
+    tags: [architecture]
+
+  # ── Error handling ─────────────────────────────────────────────────────
+  - id: no-swallowed-errors
+    rule: "Catch blocks must not be empty"
+    severity: major
+    detect:
+      type: rg
+      pattern: "catch\\s*\\([^)]*\\)\\s*\\{\\s*\\}"
+      paths: ["src/**/*.ts", "src/**/*.tsx"]
+    fix_hint: "Log the error or rethrow — silent failures cause production incidents."
+    tags: [error-handling]
+
+  # ── Disabled example (kept for reference) ──────────────────────────────
+  - id: example-disabled-rule
+    rule: "Example showing how to keep a rule definition but skip detection"
+    severity: minor
+    detect:
+      type: grep
+      pattern: "TODO"
+    fix_hint: "N/A — this rule is disabled."
+    enabled: false

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -111,6 +111,8 @@ Developers using Claude Code and similar agents often get inconsistent results �
 │       ├── accessibility-audit/   # WCAG 2.1 AA compliance
 │       ├── dependency-audit/      # Vulnerability & license checks
 │       ├── documentation-audit/   # Doc quality & sync audit
+│       ├── doc-gardening/         # Drift detection between docs/ and current code
+│       ├── quality-audit/         # golden-principles.yaml drift audit → docs/QUALITY_SCORE.md
 │       ├── project-health-report/ # Comprehensive health report (breadth-first, scoring)
 │       ├── review-pipeline/       # Parallel multi-audit review with dedupe (PR-scope)
 │       ├── lesson-refresh/        # Periodic refresh of tasks/lessons/ (keep/update/encode/archive)

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -162,7 +162,7 @@ for skill_dir in "$SKILLS_DIR"/*/; do
   # Other skills with Output Format (review-pipeline, deepening-review, pulse, retro)
   # are meta or interactive and don't need the same patterns.
   case "$skill_name" in
-    code-quality-audit|performance-audit|architecture-review|accessibility-audit|testing-audit|dependency-audit|documentation-audit|design-review|project-health-report|dead-code-audit)
+    code-quality-audit|performance-audit|architecture-review|accessibility-audit|testing-audit|dependency-audit|documentation-audit|design-review|project-health-report|dead-code-audit|quality-audit|doc-gardening)
       if echo "$CONTENT" | grep -q "^## Default Behavior$"; then
         pass "Has Default Behavior (audit skill)"
       else

--- a/tasks/decisions.md
+++ b/tasks/decisions.md
@@ -197,6 +197,30 @@ Track important technical decisions here so they don't get lost between sessions
   - Zero effect on users who don't invoke `/harness-init` — the section in CLAUDE.md is inert until they scaffold
   - **Follow-up (v1.12.0 candidate)**: CI cross-link freshness check between `docs/` and `CLAUDE.md`; also an `install.sh --harness` flag that auto-scaffolds on install for users who want it from day one.
 
+### ADR-011: Quality drift audit via `golden-principles.yaml` + separate `/doc-gardening` skill
+- **Date**: 2026-05-18
+- **Status**: accepted
+- **Context**: OpenAI's harness-engineering writeup describes "Fridays for AI cleanup" — periodic background tasks that scan for drift from golden principles, update quality scores, and propose refactors. The pattern doesn't scale at OpenAI when run as one-off rituals; codifying the principles into a YAML and running a deterministic checker does. The kit already has `/code-quality-audit` (generic smells) and `/documentation-audit` (completeness/clarity), but no skill for **project-specific** rules that change per repo, and no skill watching for **doc-vs-code drift** as opposed to doc quality.
+- **Options**:
+  - A) **Two new skills + YAML schema** — `/quality-audit` reads `golden-principles.yaml` and writes `docs/QUALITY_SCORE.md`; `/doc-gardening` cross-checks docs/ against the codebase. Clean separation of concerns. Each can run on its own `/loop` schedule.
+  - B) **Extend `/code-quality-audit`** — add a `golden-principles.yaml` mode to the existing skill. Less surface area but conflates two ideas (generic smells vs project-specific rules) and the report shape differs.
+  - C) **One mega-skill** — combine quality drift + doc drift into `/audit-drift`. Single entry point but the YAML schema only applies to half of it, making the skill awkward to extend.
+- **Decision**: A (two new skills + YAML). Rationale: the two concerns have different inputs (YAML vs filesystem), different outputs (`docs/QUALITY_SCORE.md` vs `tasks/todo.md → ## Doc Drift`), and different cadences (daily vs weekly per OpenAI's recipe). Separation also lets either skill be turned off without affecting the other.
+- **Sub-decisions**:
+  - **YAML schema is deliberately minimal** — `id / rule / severity / detect / fix_hint` plus optional `paths / tags / enabled`. No AST queries built in; instead, the `command:` detect type lets users shell out to their own linter/Semgrep/etc. Keeps the skill an orchestrator, not an analyzer.
+  - **Severity weights are fixed** (critical=5, major=2, minor=1). Score formula: `max(0, 100 - sum(weight × matches))`. Tunable later if needed, but starting opinionated.
+  - **QUALITY_SCORE.md uses managed-block markers** — `<!-- quality-audit:start -->` / `<!-- quality-audit:end -->`. Content outside the block is preserved across runs so users can hand-edit context, trend annotations, etc.
+  - **Quality-audit never creates `docs/`** — that's `/harness-init`'s job. Missing `docs/` → print to stdout, never auto-scaffold. Avoids a confusing surprise when a non-harness project runs the skill.
+  - **Doc-gardening is heuristic** — false positives are expected. The `.doc-gardening-ignore` glob list + `docs/archive/` suppression keep the noise floor down. Findings are leads for human review, not auto-fixes.
+  - **Both skills support `mode:headless`** for `/loop` and `/schedule` integration. Headless mode never opens PRs, never writes files outside the managed block, never asks questions — appends to `tasks/todo.md` instead so humans see results in the next session.
+- **Consequences**:
+  - 2 new skills: `.claude/skills/quality-audit/SKILL.md`, `.claude/skills/doc-gardening/SKILL.md`
+  - 1 template: `.claude/skills/quality-audit/templates/golden-principles.example.yaml` (6 example principles covering type-safety, utils, architecture boundaries, error handling)
+  - `CODEBASE_MAP.md` lists both new skills
+  - No code outside `.claude/skills/` — both skills are pure markdown instructions; the agent executes detection rules at runtime
+  - Pairs naturally with `/harness-init` (ADR-010 in PR #124) — that skill scaffolds `docs/QUALITY_SCORE.md`; this skill maintains it
+  - **NOTE on numbering**: ADR-005..010 are reserved by PRs #117..#124 (assumed merge order). If merge order changes, renumber to next free slot at merge time.
+
 ### ADR-004: Adopt three skill conventions from codex-complexity-optimizer (Core Rule, Default Behavior, Phase 1 Inventory)
 - **Date**: 2026-05-18
 - **Status**: accepted


### PR DESCRIPTION
## Summary

Closes **CLA-13**. Adds two audit-class skills inspired by OpenAI's harness-engineering writeup ("Fridays for AI cleanup"):

- **`/quality-audit`** — reads `golden-principles.yaml` (deterministic, machine-checkable project rules), runs detection (grep / rg / shell command), and updates `docs/QUALITY_SCORE.md` via a managed-block marker.
- **`/doc-gardening`** — cross-checks `docs/`, `README.md`, `CODEBASE_MAP.md`, `agent_docs/` against the current codebase. Flags stale paths, broken cross-references, missing symbols, stale examples, version drift.

Pairs naturally with `/harness-init` (PR #124) which scaffolds the `docs/` directory `/quality-audit` writes into.

## What's in this PR

| File | Purpose |
|---|---|
| `.claude/skills/quality-audit/SKILL.md` | New skill — orchestrates drift detection against `golden-principles.yaml` |
| `.claude/skills/quality-audit/templates/golden-principles.example.yaml` | Starter template (6 example principles: type-safety, utils, architecture boundaries, error handling) |
| `.claude/skills/doc-gardening/SKILL.md` | New skill — cross-checks docs/ against current code |
| `scripts/validate-skills.sh` | Adds both new skills to the audit-class allowlist |
| `CODEBASE_MAP.md` | Lists both new skills |
| `tasks/decisions.md` | ADR-011 — design rationale (two skills vs one; YAML schema choices; managed-block strategy) |

## Design highlights

**Schema is deliberately minimal** — `id / rule / severity / detect / fix_hint` plus optional `paths / tags / enabled`. No AST queries built in; the `command:` detect type lets users shell out to their own linter/Semgrep/etc. The skill is an orchestrator, not an analyzer.

**Score formula** — `max(0, 100 - sum(weight × matches))` with critical=5, major=2, minor=1. Tunable later; starting opinionated.

**Managed-block strategy** — `docs/QUALITY_SCORE.md` uses `<!-- quality-audit:start -->` / `<!-- quality-audit:end -->` markers so users can hand-edit context outside the block without losing it across runs.

**Never auto-creates `docs/`** — that's `/harness-init`'s job. Missing `docs/` → print to stdout, never scaffold.

**Headless mode** — both skills support `mode:headless` for `/loop` and `/schedule` integration. Headless runs never open PRs, never write files outside the managed block; findings are appended to `tasks/todo.md` so humans see them next session.

**Conventions compliance** — both skills follow the three v1.11.0 patterns (Core Rule, Default Behavior, Phase 1 Inventory). Validator updated to recognise them as audit-class:

```text
25 skill(s) checked
252 passed, 0 failed, 0 warnings
```

## Loop / Schedule example

```text
/loop daily   /quality-audit  mode:headless
/loop weekly  /doc-gardening  mode:headless
```

## ADR numbering note

This PR claims **ADR-011** assuming PRs #117..#124 land ADRs 005..010 in order. If merge order differs, renumber to the next free slot at merge time.

## Test plan

- [x] `bash scripts/validate-skills.sh` passes (252/252)
- [x] Both skills recognised as audit-class
- [x] Both have Core Rule, Default Behavior, Phase 1 Inventory sections
- [ ] Manual: copy `golden-principles.example.yaml` to a sample repo, invoke `/quality-audit`, verify output shape
- [ ] Manual: invoke `/doc-gardening` on this kit repo, sanity-check findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)