### PR TITLE
feat(skills): /tasks-to-linear — sync agent TaskList → Linear issues

### DIFF
--- a/.claude/skills/tasks-to-linear/SKILL.md
+++ b/.claude/skills/tasks-to-linear/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: tasks-to-linear
+description: Sync the agent's TaskList into Linear issues — one issue per task, idempotent by title, defaults to Todo. Use when you've planned with TaskCreate and want each task tracked in Linear.
+user-invocable: true
+---
+
+# Tasks → Linear
+
+## Core Rule
+
+One Linear issue per task — match by title within the configured team, never create duplicates. Existing issues are reported as "skipped", never silently overwritten.
+
+## Kit Context
+
+Before starting this skill, ensure you have completed session boot:
+
+1. Read `CODEBASE_MAP.md` for project understanding
+2. Read `CLAUDE.project.md` if it exists for project-specific rules
+3. Read `tasks/lessons/_index.md` for accumulated corrections (Top Rules + index)
+
+If any of these haven't been read in this session, read them now before proceeding.
+
+## When to Use
+
+Invoke with `/tasks-to-linear` when:
+
+- You've used `TaskCreate` to plan multi-step work and want each task tracked in Linear for the team
+- A planning skill (e.g. `/shape-spec`, `/office-hours`, `/planner` subagent) produced a task list you want to externalise
+- Onboarding work that already lives in the TaskList into a project tracker
+- As the final step of `/loop` or `/schedule` runs that produce actionable findings (e.g. `/quality-audit` drift → Linear backlog)
+
+Not for:
+
+- Single ad-hoc tasks — open them directly in Linear UI, the round trip isn't worth a skill
+- Tasks under 60 seconds of work — keep them in TaskList only
+- Two-way sync — this skill is **one-way**: TaskList → Linear, never the reverse
+
+## Default Behavior
+
+When the user asks to "push tasks to linear", "sync the plan", "open issues for this", or invokes `/tasks-to-linear`, produce the full sync workflow automatically using the Process and Output Format sections below. Do not ask the user to specify which tasks — the skill reads the active TaskList itself.
+
+This skill **writes external state** by design — it creates Linear issues. Idempotency (title-based dedupe) is the safety net, not user confirmation per task.
+
+## Inputs
+
+### TaskList (always)
+
+The skill reads the **current** TaskList. Tasks with status `completed` or `deleted` are skipped — only `pending` and `in_progress` make it to Linear. Use the agent's TaskList tooling to read the full list including `blocks`, `blockedBy`, descriptions, and metadata.
+
+### `.claude/linear.config.yaml` (optional)
+
+If present at the repo root, this file pre-commits the routing decisions. Example:
+
+```yaml
+# .claude/linear.config.yaml — defaults for /tasks-to-linear
+version: 1
+
+# Which team to write to. Resolved by key (e.g. "CLA") or name.
+team: CLA
+
+# Optional project / milestone for newly created issues.
+project: null
+milestone: null
+
+# Default state for new issues. Must be a state name in the target team.
+default_state: Todo
+
+# Label(s) applied to every new issue. Names are case-sensitive.
+default_labels:
+  - Feature
+
+# Map TaskList metadata.label → Linear label name. Optional override per task.
+label_map:
+  bug: Bug
+  feature: Feature
+  improvement: Improvement
+
+# Title prefix for issues created by this skill (helps the dedupe scan).
+# Leave empty to match raw task subjects.
+title_prefix: ""
+
+# Dedupe scope:
+#   team       — search the whole team for matching titles (default)
+#   project    — restrict the search to `project` above
+#   none       — never dedupe; always create. NOT recommended.
+dedupe: team
+```
+
+If the file is missing, the skill falls back to interactive prompts in interactive mode and to documented defaults in headless mode (see Run Mode).
+
+### Memory hints
+
+The skill honours these memory entries when present:
+
+- `feedback_linear_workspace.md` → forces the team scope. If config disagrees, the memory wins and the skill reports the conflict.
+- `feedback_linear_issue_state.md` → forces `default_state` (typically `Todo`).
+- `reference_linear_mcp_limitations.md` → reminds the skill to express `blockedBy` as an inline blockquote rather than via a relation field (no MCP exposes the relation today).
+
+## Required Tools
+
+Before any write, confirm these MCP tools are available:
+
+- `linear_search_issues` (idempotency check)
+- `linear_create_issue` (write path)
+- `linear_get_teams` (team / state / label resolution)
+- `linear_edit_issue` or `linear_bulk_update_issues` (post-create state change to Todo)
+
+If the Linear MCP is not connected, exit with this message:
+
+> Linear MCP unavailable. Connect a Linear MCP server (see `.mcp.json`) and rerun. No issues were created.
+
+## Process
+
+### Phase 1: Inventory (first-pass leads)
+
+This pass produces **candidates**, not findings. Treat the TaskList as the source of truth and validate routing before writing anything.
+
+1. Read the active TaskList. Filter to tasks with status `pending` or `in_progress`. Preserve `blocks` / `blockedBy` edges between tasks.
+2. Resolve the target team:
+   - If config exists → use `team` from config
+   - Else if `feedback_linear_workspace.md` memory exists → use that workspace
+   - Else (interactive) → list available teams via `linear_get_teams` and ask the user to pick
+   - Else (headless) → exit non-zero with "no team configured"
+3. Resolve the target state UUID:
+   - Default: state named `Todo` in the target team
+   - Verify it exists via `linear_get_teams`; if not, error out with the available state names
+4. Resolve the label UUIDs for `default_labels` against the team's labels. Skip unknown labels with a warning row in the report.
+5. Build the candidate set — one entry per filtered task, with `title`, `description`, `priority`, `labels`, `blockedBy` (resolved to other task subjects).
+
+### Phase 2: Dedupe
+
+For each candidate:
+
+1. Run `linear_search_issues` with `teamIds: [<team>]` and a `query` set to the task's title.
+2. From the results, look for an **exact title match** (case-sensitive). If found, mark the candidate as `skipped` and capture the existing issue's identifier + URL.
+3. De-duplicate within the candidate set itself (same title appearing twice in the TaskList → keep the first, mark the rest as `skipped_intra_batch`).
+
+After Phase 2 the candidate set is split into:
+
+- `to_create` — title not present in Linear
+- `skipped` — duplicates in Linear or within the batch
+
+### Phase 3: Create
+
+For each `to_create` candidate, in TaskList order (so blockers are created before the issues they block):
+
+1. Build the description from the task description, plus a `**Blocked by:**` blockquote at the top if the task has `blockedBy` edges that point at other tasks already created in this run. Use the format from [[reference-linear-mcp-limitations]]:
+   ```markdown
+   > **Blocked by:** [CLA-XX](url) — short reason from the dependency edge.
+
+   ---
+
+   (the original task description goes here verbatim)
+   ```
+   For tasks blocked by tasks not in this batch (e.g. already-completed or deleted), omit the blockquote.
+2. Call `linear_create_issue` with:
+   - `title`: optional `title_prefix` + task subject
+   - `description`: built above
+   - `teamId`: resolved team UUID
+   - `labelIds`: resolved label UUIDs (skip silently if none)
+   - `priority`: from task metadata if present, else `0` (no priority)
+3. Capture the returned issue ID + identifier + URL.
+4. After all issues are created, run `linear_bulk_update_issues` once with the resolved Todo `stateId` and the list of issue UUIDs created in this run. (Linear's create endpoint doesn't accept a state arg; this batch update is the documented Todo-default workaround per [[feedback-linear-issue-state]].)
+
+If any single `create` call fails, log the failure and continue with the next candidate. Do not abort the whole batch.
+
+### Phase 4: Report
+
+Emit the Output Format report (see below). Then, for each created issue, leave the corresponding TaskList task **unchanged** — this skill does not mark tasks as in_progress or completed. The TaskList remains the working surface; Linear is the durable mirror.
+
+## Output Format
+
+```markdown
+# Tasks → Linear sync report
+
+_Run: 2026-05-18T22:30:00Z — tasks-to-linear v1_
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Tasks scanned | 8 |
+| Tasks eligible (pending / in_progress) | 6 |
+| Issues created | 4 |
+| Skipped (already in Linear) | 1 |
+| Skipped (intra-batch dupe) | 1 |
+| Failed | 0 |
+| Target team | ClaudeCodeKit (CLA) |
+| Default state | Todo |
+| Default labels | Feature |
+
+## Created
+
+| Task # | Linear | Title |
+|--------|--------|-------|
+| 4 | [CLA-18](https://linear.app/claudecodekit/issue/CLA-18/...) | Wire the audit hook to PostToolUse |
+| 5 | [CLA-19](https://linear.app/claudecodekit/issue/CLA-19/...) | Add ADR-014 for the audit cadence |
+| 6 | [CLA-20](https://linear.app/claudecodekit/issue/CLA-20/...) | Backfill manifest entries for `.kit-state/` |
+| 7 | [CLA-21](https://linear.app/claudecodekit/issue/CLA-21/...) | Update `CODEBASE_MAP.md` |
+
+## Skipped
+
+| Task # | Reason | Existing |
+|--------|--------|----------|
+| 2 | duplicate title in Linear | [CLA-12](https://linear.app/claudecodekit/issue/CLA-12) |
+| 3 | duplicate title in this batch | (same subject as task 2) |
+
+## Failed
+
+_None._
+
+## Notes
+
+- 1 task carried a `blockedBy` edge to another task in this batch — expressed as an inline blockquote at the top of CLA-19's description.
+- Default state applied via post-create bulk update (Linear's create endpoint does not accept a state argument).
+```
+
+## Run Mode
+
+| Decision point | Interactive default | Headless default (`mode:headless`) |
+|---|---|---|
+| Missing `.claude/linear.config.yaml` | Walk the user through team / project / labels and offer to save the file | Exit non-zero with "no config and headless mode — set up `.claude/linear.config.yaml`" |
+| Multiple teams returned and no memory hint | Ask the user to choose | Exit non-zero |
+| Unknown label name | Warn, skip the label, continue | Warn in the report, skip the label, continue |
+| Linear MCP not connected | Print the connection hint, exit 0 (no destructive side effects) | Print the connection hint, exit 1 |
+| Task subject is empty / placeholder (`"TODO"`, `"."`) | Skip with a warning in the report | Skip with a warning |
+| Dedupe finds a matching title with different description | Report as `skipped`; do not update the existing issue | Same — never update existing issues from this skill |
+
+See `.claude/skills/_shared/blocks/mode-detection.md`.
+
+## Loop / Schedule Integration
+
+Useful pairings:
+
+```text
+/quality-audit mode:headless          # produces drift candidates in tasks/todo.md → Drift Alerts
+/tasks-to-linear mode:headless        # syncs those candidates to Linear once the human triages
+
+/shape-spec <feature>                  # produces a structured task list
+/tasks-to-linear                       # immediately mirror the plan to the project tracker
+```
+
+For a recurring "drift → tracker" pipeline:
+
+```text
+/loop weekly /quality-audit mode:headless
+# Triage tasks/todo.md → Drift Alerts manually, then:
+/tasks-to-linear mode:headless
+```
+
+The skill does **not** auto-run after `/quality-audit` — drift findings need a human triage step before they become tracker entries.
+
+## Templates
+
+- `templates/linear.config.example.yaml` — copy to `.claude/linear.config.yaml` and tailor.
+- `templates/report.md.tmpl` — the snapshot format used to write a copy of each run report to `tasks/reports/tasks-to-linear-<timestamp>.md` (optional; only written when the user passes `--save-report`).
+
+## Notes
+
+- **One-way by design.** This skill writes TaskList → Linear and never the reverse. A future `/linear-to-tasks` skill would close that loop; today, the agent or the human pulls Linear state by hand.
+- **Title-based dedupe is fragile.** A task renamed between two runs will be created twice. Rename either the task or the existing Linear issue before re-running, or accept the duplicate and close it in the Linear UI. A future iteration may track a `linear_id` field in TaskList metadata to make this robust.
+- **`blockedBy` is encoded as a blockquote, not a relation.** Neither Linear MCP currently exposes the relation field for ClaudeCodeKit's workspace — see [[reference-linear-mcp-limitations]] for the up-to-date workaround. When the MCP gains the field, swap the blockquote write for a `relatedTo`/`blockedBy` set during Phase 3.
+- **Defaults respect memory.** The skill reads `feedback_linear_workspace.md`, `feedback_linear_issue_state.md`, and `reference_linear_mcp_limitations.md` when present and treats them as overrides on `.claude/linear.config.yaml`.
+- **No auto-labelling.** v1 applies `default_labels` uniformly. Per-task AI labelling is intentionally deferred — it injects judgment under the dedupe contract and makes the run non-deterministic.
+- **Pairs with `/shape-spec`.** That skill scaffolds a feature spec folder including a task list; this skill pushes the list to the tracker. Use them back-to-back when starting a multi-session feature.

--- a/.claude/skills/tasks-to-linear/templates/linear.config.example.yaml
+++ b/.claude/skills/tasks-to-linear/templates/linear.config.example.yaml
@@ -1,0 +1,44 @@
+# .claude/linear.config.yaml — defaults for /tasks-to-linear
+#
+# Copy this file to `.claude/linear.config.yaml` at the repo root and tailor.
+# Without this file, the skill prompts for routing in interactive mode and
+# exits non-zero in headless mode.
+
+version: 1
+
+# Target team. Resolved by team key (preferred) or name.
+# Run `mcp__<linear-mcp>__linear_get_teams` to see the options.
+team: CLA
+
+# Optional. Limit the dedupe scan and (if set) tag new issues with this project.
+# Use null to omit. Project must already exist in Linear.
+project: null
+
+# Optional. Tag new issues with this milestone. Requires `project` to be set.
+milestone: null
+
+# State to apply to newly created issues. Must match a state name in `team`.
+# Defaults to Todo per kit memory rules (feedback_linear_issue_state.md).
+default_state: Todo
+
+# Labels applied to every issue created in a run. Case-sensitive.
+# Leave empty (`[]`) to skip labelling.
+default_labels:
+  - Feature
+
+# Map TaskList metadata.label (lowercase) → Linear label name.
+# Optional; only consulted when a task has a `label` field in its metadata.
+label_map:
+  bug: Bug
+  feature: Feature
+  improvement: Improvement
+
+# Title prefix prepended to every created issue title. Useful when many tasks
+# share a parent epic (e.g. `[v1.12.0] `). Leave empty to use raw task subjects.
+title_prefix: ""
+
+# Dedupe scope:
+#   team       — search every issue in the team for matching titles (default)
+#   project    — restrict the dedupe scan to `project` above
+#   none       — never dedupe; always create new issues. Use with care.
+dedupe: team

--- a/.claude/skills/tasks-to-linear/templates/report.md.tmpl
+++ b/.claude/skills/tasks-to-linear/templates/report.md.tmpl
@@ -1,0 +1,33 @@
+# Tasks → Linear sync report
+
+_Run: {{TIMESTAMP}} — tasks-to-linear v1_
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Tasks scanned | {{TASKS_SCANNED}} |
+| Tasks eligible (pending / in_progress) | {{TASKS_ELIGIBLE}} |
+| Issues created | {{CREATED_COUNT}} |
+| Skipped (already in Linear) | {{SKIPPED_DUPE_COUNT}} |
+| Skipped (intra-batch dupe) | {{SKIPPED_INTRA_COUNT}} |
+| Failed | {{FAILED_COUNT}} |
+| Target team | {{TEAM_NAME}} ({{TEAM_KEY}}) |
+| Default state | {{DEFAULT_STATE}} |
+| Default labels | {{DEFAULT_LABELS}} |
+
+## Created
+
+{{CREATED_TABLE}}
+
+## Skipped
+
+{{SKIPPED_TABLE}}
+
+## Failed
+
+{{FAILED_TABLE}}
+
+## Notes
+
+{{NOTES}}

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -116,6 +116,7 @@ Developers using Claude Code and similar agents often get inconsistent results �
 │       ├── doc-gardening/         # Drift detection between docs/ and current code
 │       ├── quality-audit/         # golden-principles.yaml drift audit → docs/QUALITY_SCORE.md
 │       ├── references-sync/       # Sync llms.txt-style dependency refs into docs/references/
+│       ├── tasks-to-linear/       # Sync agent TaskList → Linear issues (one issue per task, idempotent by title)
 │       ├── project-health-report/ # Comprehensive health report (breadth-first, scoring)
 │       ├── review-pipeline/       # Parallel multi-audit review with dedupe (PR-scope)
 │       ├── lesson-refresh/        # Periodic refresh of tasks/lessons/ (keep/update/encode/archive)

--- a/tasks/decisions.md
+++ b/tasks/decisions.md
@@ -257,7 +257,7 @@ Track important technical decisions here so they don't get lost between sessions
 ### ADR-013: `/tasks-to-linear` is one-way, dedupes by exact title, encodes blocked-by as a description blockquote
 - **Date**: 2026-05-18
 - **Status**: accepted
-- **Context**: CLA-16 asked for a Linear analogue of Spec Kit's `/speckit.taskstoissues` — push the agent's TaskList to the project tracker as discrete issues. Three contract questions had to be settled before writing the skill, because they shape every other detail:
+- **Context**: CLA-16 asked for a skill that pushes the agent's TaskList to Linear as discrete issues — turning the in-session plan into durable project-tracker entries without a manual round trip. Three contract questions had to be settled before writing the skill, because they shape every other detail:
 
   1. **Direction.** One-way (TaskList → Linear) or bidirectional (also pull Linear state back into TaskList)?
   2. **Dedupe.** How does the second run of the skill avoid recreating the same issue?

--- a/tasks/decisions.md
+++ b/tasks/decisions.md
@@ -254,6 +254,42 @@ Track important technical decisions here so they don't get lost between sessions
   - **Not now**: a registry / catalog of community extensions, a CLI for installing them. Both are deferred until demand surfaces.
   - **NOTE on numbering**: ADR-005..014 are reserved by PRs #117..#128. If merge order shifts, renumber to next free slot.
 
+### ADR-013: `/tasks-to-linear` is one-way, dedupes by exact title, encodes blocked-by as a description blockquote
+- **Date**: 2026-05-18
+- **Status**: accepted
+- **Context**: CLA-16 asked for a Linear analogue of Spec Kit's `/speckit.taskstoissues` — push the agent's TaskList to the project tracker as discrete issues. Three contract questions had to be settled before writing the skill, because they shape every other detail:
+
+  1. **Direction.** One-way (TaskList → Linear) or bidirectional (also pull Linear state back into TaskList)?
+  2. **Dedupe.** How does the second run of the skill avoid recreating the same issue?
+  3. **Relations.** Linear supports `blockedBy`/`blocks`/`relatedTo`, but the MCPs available in the ClaudeCodeKit workspace today do not expose those fields on create or edit. How is the dependency edge represented?
+
+- **Options**:
+  - **Direction**
+    - A) One-way (TaskList → Linear), no reverse sync
+    - B) Bidirectional with a tracked `linear_id` per task
+  - **Dedupe**
+    - C) Exact title match within the configured team
+    - D) Track `linear_id` in task metadata and look up by ID
+    - E) Hash of `title + first 200 chars of description`
+  - **Relations**
+    - F) Skip — drop the edge, since neither MCP exposes it
+    - G) Encode as a Markdown blockquote prepended to the issue description (`> **Blocked by:** [CLA-XX](url) — reason.`)
+    - H) Use a custom Linear label per relation (e.g. `blocked-by:CLA-12`)
+- **Decision**: A + C + G.
+  - **A (one-way)** — Bidirectional sync is a different skill with different invariants (state reconciliation, conflict resolution, ordering). Bundling it would balloon the contract. A future `/linear-to-tasks` skill can close the loop without renegotiating this one.
+  - **C (title match)** — D is correct in theory but requires writing into TaskList metadata, which the agent's task tool does not expose for arbitrary keys today. E is more robust against renames but unfriendly to debug ("why was this skipped?"). C is the simplest contract a human can verify by reading the report. Renames are documented as a known v1 limitation.
+  - **G (blockquote)** — F drops information the user explicitly cares about. H clutters the label vocabulary and gives no visual cue in the issue itself. G shows the dependency at the top of every blocked issue, makes the edge visible everywhere in the Linear UI, and is automatically replaced once an MCP gains the relation field (the skill diff is local).
+- **Sub-decisions**:
+  - **State is applied via post-create bulk update.** Linear's `create` endpoint does not accept a state argument; the skill creates issues, then runs one `linear_bulk_update_issues` call to move them to the configured state (Todo by default per ADR-relevant memory entry).
+  - **No per-task AI labelling in v1.** A single `default_labels` set applies to every issue in a run. Per-task labelling injects model judgment under the dedupe contract, makes runs non-deterministic, and obscures the report. Revisit if users request it.
+  - **Memory entries override `.claude/linear.config.yaml`.** `feedback_linear_workspace.md` (workspace scope), `feedback_linear_issue_state.md` (Todo default), and `reference_linear_mcp_limitations.md` (relation workaround) are read at runtime and treated as overrides. The skill reports the conflict when config and memory disagree.
+- **Consequences**:
+  - 1 new skill: `.claude/skills/tasks-to-linear/SKILL.md`
+  - 2 templates: `linear.config.example.yaml`, `report.md.tmpl`
+  - `CODEBASE_MAP.md` lists the new skill
+  - When MCPs gain `blockedBy` on `create_issue`, Phase 3 in the SKILL.md swaps the blockquote write for a relation set. Existing issues with blockquotes are left as-is — no migration script.
+  - **NOTE on numbering**: ADR-005..012 are reserved by PRs #117..#126. If merge order shifts, renumber to next free slot.
+
 ### ADR-012: `/references-sync` skill ships curated known-sources list; refuses to auto-summarise READMEs
 - **Date**: 2026-05-18
 - **Status**: accepted

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -14,7 +14,7 @@ Track current and upcoming tasks here. The agent updates this file as work progr
 
 Linear: [CLA-15](https://linear.app/claudecodekit/issue/CLA-15/adopt-spec-kit-style-extensions-presets-architecture-for-skill-catalog)
 
-### Decision (see ADR-015)
+#### Decision (see ADR-015)
 
 Document a four-layer resolution order using existing kit primitives plus one new sibling directory.
 
@@ -24,19 +24,19 @@ Layers:
 3. Project-overlay slot — `.claude/skills/<name>/project/` (additive, kit-aware)
 4. Kit core — `.claude/skills/<name>/SKILL.md` (default)
 
-### Approach
+#### Approach
 1. Author ADR-015 (done in this PR) documenting the existing mechanisms, the gap, the options, and the decision.
 2. Author the "Extending the Kit (Resolution Order)" section in `agent_docs/skills.md` (done in this PR).
 3. Open one follow-up Linear issue for the runtime + tooling pieces:
    - **CLA-22** (Improvement, Todo): create the `.claude/extensions/` placeholder + README; wire `install.sh` to preserve it across upgrades; teach `scripts/validate-skills.sh` to warn on Layer 1 vs Layer 4 name collisions.
 4. Mark CLA-15 done after the follow-up issue opens.
 
-### Files to Touch (this PR)
+#### Files to Touch (this PR)
 - `agent_docs/skills.md` — new `## Extending the Kit (Resolution Order)` section (between Headless Mode Contract and Skill Lifecycle)
 - `tasks/decisions.md` — ADR-015
 - `tasks/todo.md` — this plan
 
-### Not Now
+#### Not Now
 - A registry / catalog of community extensions
 - A `kit extension add <name>` CLI
 
@@ -50,7 +50,7 @@ Layers:
 
 Linear: [CLA-16](https://linear.app/claudecodekit/issue/CLA-16/tasks-to-linear-claude-code-task-list-linear-issues-skill)
 
-### Approach
+#### Approach
 1. Author `.claude/skills/tasks-to-linear/SKILL.md` following the existing skill conventions (Core Rule, Kit Context, When to Use, Default Behavior, Process phases, Run Mode, Output Format).
 2. Configuration loader: read `.claude/linear.config.yaml` (new file, optional) for default team, project, milestone, and label mapping. Fall back to interactive prompts.
 3. Idempotency: dedupe by issue title within the configured team (use `linear_search_issues` with the team filter, exact-title match).
@@ -60,23 +60,23 @@ Linear: [CLA-16](https://linear.app/claudecodekit/issue/CLA-16/tasks-to-linear-c
 7. ADR-013 documenting (a) the inline blocked-by workaround, (b) the title-based dedupe choice, (c) why the skill defers labels to a single batch decision rather than per-task AI labeling.
 8. Run `scripts/validate-skills.sh` and resolve any warnings.
 
-### Files to Touch
+#### Files to Touch
 - `.claude/skills/tasks-to-linear/SKILL.md` — new file
 - `.claude/skills/tasks-to-linear/templates/linear.config.example.yaml` — new
 - `.claude/skills/tasks-to-linear/templates/report.md.tmpl` — new (output snapshot template)
 - `CODEBASE_MAP.md` — add the new skill in the inventory
 - `tasks/decisions.md` — ADR-013
 
-### Open Questions
+#### Open Questions
 - Two-way sync (close Linear issue → mark TaskList completed)? **Defer to a follow-up issue** — this PR is one-way only.
 - Per-task AI labeling vs one-shot batch labeling? **Choose batch** for v1; revisit if users ask for per-task.
 - What identifier do we use to dedupe across renames? Title is fragile but simplest. **Document as v1 limitation; revisit if it bites.**
 
-### Risks
+#### Risks
 - The `linear-claudecodekit` MCP doesn't expose `blockedBy`. The skill writes the relationship as a blockquote — this is documented as a known limitation, not a workaround we expect to outlive. If/when the MCP gains the field, the skill switches over.
 - The skill calls Linear MCPs that may not exist in every install. Detect tool availability before any write. If absent, exit with a configuration hint pointing at `.mcp.json` setup.
 
-### Not Now
+#### Not Now
 - Two-way sync from Linear back into TaskList
 - Bulk move/edit of existing Linear issues
 - Project-milestone auto-creation when missing

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -42,6 +42,48 @@ Layers:
 
 ---
 
+### CLA-16 — `/tasks-to-linear` skill (v1.12.0 candidate)
+
+**Goal**: A user-invocable skill that reads the agent's current TaskList and creates one Linear issue per task in the configured workspace, with proper state (Todo), labels, and an idempotency check that prevents duplicate issues. Verification: invoke `/tasks-to-linear` against a known TaskList, confirm the expected issue count appears in Linear with the right metadata, and rerun to confirm the second invocation reports "0 created, N skipped (duplicates)".
+
+**Context**: ClaudeCodeKit is Linear-first; until now the agent has had to call Linear MCP tools by hand whenever a TaskList plan needed to land in the tracker. This packages the recurring move into a single skill.
+
+Linear: [CLA-16](https://linear.app/claudecodekit/issue/CLA-16/tasks-to-linear-claude-code-task-list-linear-issues-skill)
+
+### Approach
+1. Author `.claude/skills/tasks-to-linear/SKILL.md` following the existing skill conventions (Core Rule, Kit Context, When to Use, Default Behavior, Process phases, Run Mode, Output Format).
+2. Configuration loader: read `.claude/linear.config.yaml` (new file, optional) for default team, project, milestone, and label mapping. Fall back to interactive prompts.
+3. Idempotency: dedupe by issue title within the configured team (use `linear_search_issues` with the team filter, exact-title match).
+4. Default state: Todo (per [[feedback-linear-issue-state]]); blockedBy relationships expressed as a prepended `**Blocked by:** [CLA-XX](url)` blockquote (per [[reference-linear-mcp-limitations]] — neither MCP exposes the relation directly).
+5. Templates: a Markdown report template + the YAML config schema example.
+6. Update `CODEBASE_MAP.md` to list the new skill.
+7. ADR-013 documenting (a) the inline blocked-by workaround, (b) the title-based dedupe choice, (c) why the skill defers labels to a single batch decision rather than per-task AI labeling.
+8. Run `scripts/validate-skills.sh` and resolve any warnings.
+
+### Files to Touch
+- `.claude/skills/tasks-to-linear/SKILL.md` — new file
+- `.claude/skills/tasks-to-linear/templates/linear.config.example.yaml` — new
+- `.claude/skills/tasks-to-linear/templates/report.md.tmpl` — new (output snapshot template)
+- `CODEBASE_MAP.md` — add the new skill in the inventory
+- `tasks/decisions.md` — ADR-013
+
+### Open Questions
+- Two-way sync (close Linear issue → mark TaskList completed)? **Defer to a follow-up issue** — this PR is one-way only.
+- Per-task AI labeling vs one-shot batch labeling? **Choose batch** for v1; revisit if users ask for per-task.
+- What identifier do we use to dedupe across renames? Title is fragile but simplest. **Document as v1 limitation; revisit if it bites.**
+
+### Risks
+- The `linear-claudecodekit` MCP doesn't expose `blockedBy`. The skill writes the relationship as a blockquote — this is documented as a known limitation, not a workaround we expect to outlive. If/when the MCP gains the field, the skill switches over.
+- The skill calls Linear MCPs that may not exist in every install. Detect tool availability before any write. If absent, exit with a configuration hint pointing at `.mcp.json` setup.
+
+### Not Now
+- Two-way sync from Linear back into TaskList
+- Bulk move/edit of existing Linear issues
+- Project-milestone auto-creation when missing
+- A `/linear-to-tasks` reverse skill
+
+---
+
 ### v1.11.0 batch — Inspiration triad (rtk + GBrain + karpathy)
 
 Imported from GitHub #105–#116 into Linear (CLA-5 → CLA-11). Single batch, branch per issue, deploy on completion.


### PR DESCRIPTION
## Summary

Adds `/tasks-to-linear` — a user-invocable skill that mirrors the agent's active TaskList into Linear as one issue per task. One-way (TaskList → Linear), idempotent by title within the configured team, defaults to **Todo** state per kit memory rules.

Closes **CLA-16**.

## What's in this PR

- `.claude/skills/tasks-to-linear/SKILL.md` (265 lines) — orchestrator following the kit's skill conventions (Core Rule + Kit Context + Default Behavior + Process phases + Run Mode + Output Format).
- `templates/linear.config.example.yaml` — optional `.claude/linear.config.yaml` schema with team / state / labels / dedupe knobs. Memory entries (`feedback_linear_workspace.md`, `feedback_linear_issue_state.md`, `reference_linear_mcp_limitations.md`) override config when present.
- `templates/report.md.tmpl` — snapshot format saved to `tasks/reports/tasks-to-linear-<timestamp>.md` when `--save-report` is passed.
- `CODEBASE_MAP.md` — lists the new skill.
- `tasks/decisions.md` — **ADR-013** documents the contract: one-way sync, exact-title dedupe, blockquote-encoded blocked-by.

## Design contract (see ADR-013)

| Choice | Decision | Why |
|---|---|---|
| Direction | One-way TaskList → Linear | Bidirectional is a separate skill with separate invariants |
| Dedupe | Exact title within team | Simplest contract a human can verify by reading the report; rename = duplicate (documented limitation) |
| Relations | Inline blocked-by blockquote | Neither MCP exposes the relation field today; blockquote is replaceable |
| State | Post-create bulk update to Todo | Linear's create endpoint doesn't accept a state arg |
| Labels | One default_labels set per run | Per-task AI labelling is non-deterministic; defer |

## Test plan

- [ ] Drop a small TaskList (3-4 tasks with one blockedBy edge) and invoke /tasks-to-linear — confirm one Linear issue per task in Todo state with the correct labels and the blockquote on the blocked issue
- [ ] Rerun immediately — confirm report shows 0 created, N skipped (already in Linear)
- [ ] Invoke with mode:headless and no .claude/linear.config.yaml — confirm exit non-zero with a clear setup message
- [ ] Confirm the validator (scripts/validate-skills.sh) shows zero new warnings for tasks-to-linear

## Related

- Pairs with /shape-spec (plan → tracker) and /quality-audit (drift → tracker after human triage).
- Future /linear-to-tasks closes the reverse direction (not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)