### PR TITLE
feat(skills): /constitution — author golden-principles.yaml interactively

### DIFF
--- a/.claude/skills/constitution/SKILL.md
+++ b/.claude/skills/constitution/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: constitution
+description: Author or extend the project's golden-principles.yaml — interactively for new repos, or by inferring + confirming candidates from existing code. Pairs with /quality-audit which reads the file.
+user-invocable: true
+---
+
+# Constitution
+
+## Core Rule
+
+Never write a principle the user hasn't seen. Each entry in `golden-principles.yaml` lands only after the user accepts the proposed `rule`, `severity`, and `detect` together — silent insertion (even of "obvious" rules) breaks the audit contract downstream.
+
+## Kit Context
+
+Before starting this skill, ensure you have completed session boot:
+
+1. Read `CODEBASE_MAP.md` for project understanding
+2. Read `CLAUDE.project.md` if it exists for project-specific rules
+3. Read `tasks/lessons/_index.md` for accumulated corrections (Top Rules + index)
+
+If any of these haven't been read in this session, read them now before proceeding.
+
+## When to Use
+
+Invoke with `/constitution` when:
+
+- A new project doesn't have `golden-principles.yaml` yet and you want one
+- An existing project has a sparse principles file and you want to fill in gaps from category recommendations
+- You ran `/quality-audit` and got the "no principles file found" stub — this skill is what the stub points at
+- Onboarding to a project and want to capture its de-facto rules as explicit, machine-checkable ones
+
+Not for:
+
+- Editing arbitrary principles (use a text editor — this skill is for *adding* and *bootstrapping*)
+- Running the principles against the codebase — that's `/quality-audit`'s job
+- Generating coding standards prose — `golden-principles.yaml` is for *deterministic, grep-checkable* rules; verbose conventions belong in `agent_docs/conventions.md` or `docs/design-docs/core-beliefs.md`
+
+## Default Behavior
+
+When the user asks to "set up principles", "create a constitution", "bootstrap quality rules", or invokes `/constitution`, run the full Process below — read the codebase, propose principles by category, walk the user through accept/reject for each, and write the file. Default mode is **interactive**; the dialogue is the value.
+
+This skill writes a single file (`.claude/golden-principles.yaml` by default; repo-root `golden-principles.yaml` if explicitly requested). It does not modify code, settings, or any other file. CLAUDE.md is touched **only** when the file is newly created and a `## Quality Principles` pointer section is missing — and only with explicit user approval.
+
+## Inputs
+
+The skill detects:
+
+- Whether `golden-principles.yaml` already exists (root → `.claude/`) — controls merge vs. fresh-create behaviour
+- The primary language (`package.json` → JS/TS, `pyproject.toml`/`requirements.txt` → Python, `go.mod` → Go, `Cargo.toml` → Rust) — selects category candidates from the library
+- The presence of common architecture signals (Prisma/Drizzle imports, FastAPI/Django routes, monorepo workspace layout, test framework choice) — informs which categories to surface
+
+No CLI flags are required. Optional positional argument: a path override (`/constitution path:./golden-principles.yaml`).
+
+## Schema
+
+This skill writes the same schema that `/quality-audit` reads. The canonical reference lives at `.claude/skills/quality-audit/templates/golden-principles.example.yaml`. Every principle must include:
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | kebab-case string | Unique within the file |
+| `rule` | one-line string | Human-readable, what's enforced |
+| `severity` | `critical` / `major` / `minor` | Weights: 5 / 2 / 1 |
+| `detect` | object | `type: grep \| rg \| command`, plus `pattern` or `command`, optional `paths` |
+| `fix_hint` | one-line string | What the developer should do |
+| `tags` | string list | Optional, free-form |
+| `paths` | glob list | Optional, scopes detection |
+| `enabled` | boolean | Optional, default `true` |
+
+If the schema in `/quality-audit`'s template ever changes, this skill must follow — ADR-014 names that template as the source of truth.
+
+## Process
+
+### Phase 1: Inventory (first-pass leads)
+
+This pass produces **candidates**, not findings. Read the repo to decide which principle categories to surface; do not propose individual principles yet.
+
+1. Detect existing `golden-principles.yaml` (root first, then `.claude/`). Load and parse if present — `ids` already used go on the "already covered" list.
+2. Detect the primary language from package manifests at repo root. Multi-language repos pick the most prominent (most dependencies / largest source tree).
+3. Scan for architecture signals (limit one `rg` per signal, capped at 5 results each):
+   - DB clients (`prisma`, `drizzle`, `sequelize`, `sqlalchemy`, `gorm`, etc.)
+   - HTTP framework signals (`next/server`, `express`, `fastapi`, `flask`, `gin`, etc.)
+   - Test framework (`vitest`, `jest`, `pytest`, `go test`, `cargo test`)
+   - Type-safety markers (TS strict mode, mypy, pylint, golangci-lint configs)
+4. From the principles library (`templates/principles-library.yaml`), select categories where the language matches AND at least one architecture signal applies AND no existing principle in the file already covers that category.
+5. Emit a short inventory block listing: detected language, signals found, categories proposed.
+
+### Phase 2: Intake (interactive only)
+
+Skipped in headless mode — see Run Mode.
+
+If the file is **brand-new**, ask the 5 intake questions from `templates/intake-questions.md`. Answers shape which categories are emphasised (e.g. "test-first" answer → testing category gets a higher proposal severity).
+
+If the file already exists and Phase 1 found 0 uncovered categories, exit with "Already covered — no new categories to propose. Edit the existing file directly to refine rules." Do not invent rules to look busy.
+
+### Phase 3: Propose & Confirm
+
+For each selected category, propose **2–3 candidate principles** from the library, lightly adapted to the detected stack. Walk the user through each one individually:
+
+1. Show the proposed `id`, `rule`, `severity`, `detect.pattern`, `fix_hint`, and the file paths the rule would scan.
+2. Ask: `accept | edit | skip`.
+3. If `edit`, walk through which fields to change (severity, pattern, paths, fix_hint). Keep editing until the user says `accept`.
+4. If `skip`, log the skip in the run summary and move on. Skipped principles are not written.
+5. After all proposals for a category are handled, ask: "Add a custom principle for this category?" If yes, walk through the 6 fields from scratch.
+
+Never write to disk until all proposals across all categories have been confirmed (or skipped). The user must see the full set before it lands.
+
+### Phase 4: Write
+
+1. If the file is new:
+   - Default path: `.claude/golden-principles.yaml`. If the user passed `path:`, honour it.
+   - Write the file with a 4-line header (kit version, generated date, schema reference, edit-by-hand note).
+2. If the file exists:
+   - Merge: append accepted principles below the last existing entry. Preserve all comments, blank lines, and ordering of existing content.
+   - If a proposed `id` collides with an existing one (shouldn't happen if Phase 1 was honest, but guard anyway), prepend `<existing-id>-v2` and surface the rename in the report.
+3. If `docs/QUALITY_SCORE.md` exists, leave it alone — `/quality-audit` rewrites the managed block on its next run.
+4. If `CLAUDE.md` doesn't have a `## Quality Principles` section and the file was newly created, propose adding the pointer. Apply only on explicit user confirmation.
+
+### Phase 5: Report
+
+Emit the Output Format report below. Suggest running `/quality-audit` next so the user sees the first drift measurement against the new principles.
+
+## Output Format
+
+```markdown
+# Constitution run report
+
+_Run: 2026-05-18T22:30:00Z — constitution v1_
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| File | `.claude/golden-principles.yaml` (new) |
+| Detected language | TypeScript (Next.js) |
+| Architecture signals | Prisma, Next.js App Router, Vitest |
+| Categories proposed | 4 (type-safety, shared-utils, architecture, testing) |
+| Principles accepted | 6 |
+| Principles edited | 2 |
+| Principles skipped | 3 |
+| Custom principles added | 1 |
+| Existing principles preserved | 0 |
+
+## Accepted
+
+| id | severity | category |
+|---|---|---|
+| no-yolo-json-parse | critical | type-safety |
+| no-any-in-public-api | major | type-safety |
+| prefer-shared-utils | major | shared-utils |
+| no-direct-db-in-route | critical | architecture |
+| no-untyped-fetch | major | type-safety |
+| route-handlers-export-method | major | architecture |
+
+## Skipped (per user request)
+
+- `no-default-exports` (naming) — user prefers default exports
+- `no-cross-feature-imports` (architecture) — codebase already enforces this via tsconfig paths
+- `prefer-async-await` (style) — codebase mixes promises and async/await intentionally
+
+## CLAUDE.md
+
+Added `## Quality Principles` pointer section (user approved).
+
+## Next
+
+- Run `/quality-audit` to measure current drift against the new principles
+- Edit `.claude/golden-principles.yaml` by hand to refine `detect` patterns once you see the first drift report
+- Schedule `/loop weekly /quality-audit` once the principles stabilise
+```
+
+## Run Mode
+
+| Decision point | Interactive default | Headless default (`mode:headless`) |
+|---|---|---|
+| File already exists, 0 uncovered categories | Print message, exit 0 | Print message, exit 0 |
+| Per-principle accept/edit/skip | Ask for each | Auto-accept everything the library proposes for matched categories — no editing, no custom additions |
+| "Add a custom principle for this category?" | Ask | Always skip |
+| Brand-new file: 5 intake questions | Ask all 5 | Skip the questionnaire; use library defaults for the detected language |
+| `CLAUDE.md` pointer section | Ask before writing | Skip the pointer addition; never touch CLAUDE.md in headless |
+| Conflicting `id` on merge | Ask the user how to rename | Auto-rename to `<id>-v2`, log the rename |
+
+See `.claude/skills/_shared/blocks/mode-detection.md`.
+
+Headless mode is for **bootstrapping unattended** — e.g. a CI smoke test that wants a baseline file. The user is expected to review the result and edit before it sees real use.
+
+## Templates
+
+- `templates/principles-library.yaml` — category-keyed starter principles per language. The skill draws candidates from here; users extend with `.claude/principles-library.local.yaml` (gitignored) for org-specific additions.
+- `templates/intake-questions.md` — the 5-question script for new-file intake. Each question maps to a category emphasis (which proposed severities get bumped or which categories get proposed first).
+
+## Notes
+
+- **Pairs with `/quality-audit`.** That skill reads the file this skill writes. Schema source of truth: `.claude/skills/quality-audit/templates/golden-principles.example.yaml` (referenced from ADR-011 and ADR-014).
+- **Pairs with `/harness-init`.** `/harness-init` scaffolds the `docs/` tree (including the placeholder `docs/QUALITY_SCORE.md`); `/constitution` populates the rule set that `/quality-audit` will use to update that score on the next run.
+- **Additive, never destructive.** Re-running on an existing file only proposes new categories. It never edits, removes, or reorders existing entries. Refining is a hand-edit job — this skill is for *adding*.
+- **Library, not invention.** Proposed principles come from `templates/principles-library.yaml` and are lightly adapted. The skill does not synthesise novel `detect` patterns from the codebase; it pattern-matches against known categories. Reason: a brittle `detect` rule that fires on the wrong lines is worse than no rule.
+- **Default file location is `.claude/`.** `/quality-audit` resolves root first, then `.claude/`. Putting the file in `.claude/` keeps the project root clean and signals that the rule set is part of the kit-managed surface. Users who prefer the root can pass `path:./golden-principles.yaml`.
+- **No two-way sync with Linear.** Skipped principles are not turned into Linear issues automatically. If the user wants to backlog a deferred principle, use `/tasks-to-linear` on a manual TaskList after the run.

--- a/.claude/skills/constitution/templates/intake-questions.md
+++ b/.claude/skills/constitution/templates/intake-questions.md
@@ -1,0 +1,71 @@
+# Intake Questions
+
+These are the 5 questions `/constitution` asks when bootstrapping a brand-new `golden-principles.yaml`. Each answer shapes which library categories get proposed (and at what severity) in Phase 3.
+
+Ask one at a time. Wait for the user to answer before continuing. Push back on vague answers with one specific follow-up; do not accept "we'll figure it out later" for any of these.
+
+---
+
+## 1. Type safety vs. velocity
+
+> How strict do you want type safety? Pick one:
+>
+> - **Strict** — `any` is a build error; every boundary (HTTP, DB, env, FS) is schema-validated; the audit will surface every `JSON.parse` without a schema wrapper.
+> - **Pragmatic** — `any` is allowed in internal helpers; boundaries are validated but in-flight types may be inferred; the audit flags `any` only in public exports.
+> - **Lenient** — type safety is a target, not a gate; the audit flags only the most dangerous patterns (raw `JSON.parse` of network payloads).
+
+**Maps to:** type-safety category. *Strict* → all type-safety principles proposed at `critical`. *Pragmatic* → `no-yolo-json-parse` at `critical`, others at `major`. *Lenient* → only `no-yolo-json-parse` at `critical`, drop the rest.
+
+---
+
+## 2. Architecture boundaries
+
+> Does your codebase enforce a layer model (e.g. routes → services → repositories → DB) where direct cross-layer access is forbidden? Pick one:
+>
+> - **Yes, strictly** — handlers must never import DB clients; cross-feature imports must go through a public surface; a violation should fail review.
+> - **Yes, loosely** — the layers exist but are convention-only; occasional shortcuts happen and that's fine.
+> - **No / not yet** — the codebase is small enough that the question doesn't matter yet.
+
+**Maps to:** architecture category. *Strictly* → all architecture principles at `critical`. *Loosely* → architecture principles at `major`. *No / not yet* → skip the architecture category entirely (don't propose anything; revisit later).
+
+---
+
+## 3. Testing discipline
+
+> What's the testing posture? Pick one:
+>
+> - **Test-first** — every change ships with a regression test; coverage gaps are fixed, not waived.
+> - **Tests-as-spec** — tests describe expected behaviour; coverage is checked but waivers exist for hard-to-test code paths.
+> - **Smoke-test-only** — only the happy paths are tested; new features may ship without tests if the risk is low.
+
+**Maps to:** testing category. *Test-first* → propose `no-skip-in-suites`, `no-fdescribe`, `assertion-density-floor` at `critical`. *Tests-as-spec* → same set at `major`. *Smoke-test-only* → skip this category (don't propose anything).
+
+---
+
+## 4. Shared utilities vs. local helpers
+
+> Where do small utilities live? Pick one:
+>
+> - **Shared package** — debounce / throttle / clamp / deepClone are imported from a workspace `utils` package; hand-rolling them is a smell.
+> - **Per-feature** — each feature owns its own helpers; duplication is preferred over coupling.
+> - **Mixed / no policy** — both happen; we haven't decided.
+
+**Maps to:** shared-utils category. *Shared package* → propose `prefer-shared-utils` at `major`. *Per-feature* → skip the category. *Mixed* → propose `prefer-shared-utils` at `minor` so the audit flags drift as awareness rather than failure.
+
+---
+
+## 5. Error handling shape
+
+> How does error handling work today? Pick one:
+>
+> - **Typed errors at the boundary** — every external call returns a typed `Result` / `Either` / discriminated union; raw `throw` is reserved for programmer errors.
+> - **Exceptions with global handler** — exceptions bubble up to a single boundary handler; everything in between can throw freely.
+> - **Mixed / informal** — both happen depending on the file.
+
+**Maps to:** error-handling category. *Typed errors* → propose `no-swallowed-catch`, `no-throw-non-error`, `result-or-throw-not-both` at `critical`. *Exceptions with global handler* → propose `no-swallowed-catch` at `critical`, others at `major`. *Mixed / informal* → propose `no-swallowed-catch` only, at `major`.
+
+---
+
+## After the answers
+
+The skill prints a one-paragraph summary mapping the answers to the proposed category set, then continues to Phase 3 (Propose & Confirm). The user can still accept / edit / skip each individual principle in Phase 3 — the intake just shapes which ones surface in what order, with what severity.

--- a/.claude/skills/constitution/templates/principles-library.yaml
+++ b/.claude/skills/constitution/templates/principles-library.yaml
@@ -1,0 +1,256 @@
+# principles-library.yaml — category-keyed starter principles for /constitution
+#
+# Source of truth for the candidates /constitution proposes in Phase 3.
+# Each entry follows the same schema /quality-audit reads
+# (.claude/skills/quality-audit/templates/golden-principles.example.yaml).
+#
+# Per-language sections: js (covers TS too), python, go.
+# Categories within each language: type-safety, architecture, testing,
+# shared-utils, error-handling, naming.
+#
+# When a language is missing or thin, the skill warns and falls back to a
+# language-agnostic subset (the `common` block at the bottom).
+
+version: 1
+
+# ─── JavaScript / TypeScript ──────────────────────────────────────────────
+
+js:
+  type-safety:
+    - id: no-yolo-json-parse
+      rule: "Don't JSON.parse without schema validation at the boundary"
+      severity: critical
+      detect:
+        type: rg
+        pattern: "JSON\\.parse\\("
+        paths: ["src/**/*.ts", "src/**/*.tsx"]
+      fix_hint: "Wrap with a Zod/Valibot schema parse() — see src/schemas/."
+      tags: [type-safety, boundary]
+
+    - id: no-any-in-public-api
+      rule: "Public exports must not use the `any` type"
+      severity: major
+      detect:
+        type: rg
+        pattern: "export (function|const|type|interface).*: any\\b"
+        paths: ["src/**/*.ts", "src/**/*.tsx"]
+      fix_hint: "Narrow to `unknown` and parse, or define a precise type in src/types/."
+      tags: [type-safety]
+
+    - id: no-untyped-fetch
+      rule: "fetch() callers must type the response before consuming"
+      severity: major
+      detect:
+        type: rg
+        pattern: "await fetch\\([^)]+\\)\\.json\\(\\)"
+        paths: ["src/**/*.ts", "src/**/*.tsx"]
+      fix_hint: "Wrap the JSON body with a schema parse before destructuring."
+      tags: [type-safety, boundary]
+
+  architecture:
+    - id: no-direct-db-in-route
+      rule: "Route handlers must not import database clients directly"
+      severity: critical
+      detect:
+        type: rg
+        pattern: "(from ['\"]@?prisma|from ['\"]drizzle-orm|from ['\"]sequelize)"
+        paths: ["src/app/api/**/*.ts", "pages/api/**/*.ts"]
+      fix_hint: "Move queries to src/repositories/ and inject through a service layer."
+      tags: [architecture, boundary]
+
+    - id: no-cross-feature-imports
+      rule: "Features must not import from sibling features directly"
+      severity: major
+      detect:
+        type: command
+        command: "rg --no-heading -l \"from ['\\\"]@?features/[^/]+/internal\" src/features/ 2>/dev/null | head -25"
+      fix_hint: "Re-export the public surface from features/<name>/index.ts and import from there."
+      tags: [architecture, boundary]
+
+    - id: route-handlers-export-method
+      rule: "Next.js route handlers must export named methods (GET/POST/...), not a default export"
+      severity: major
+      detect:
+        type: rg
+        pattern: "export default (async )?function"
+        paths: ["src/app/api/**/route.ts", "app/api/**/route.ts"]
+      fix_hint: "Use `export async function GET(req: Request) { ... }` — Next.js requires named methods."
+      tags: [architecture, framework]
+
+  testing:
+    - id: no-fdescribe
+      rule: "No focused tests committed to main"
+      severity: critical
+      detect:
+        type: rg
+        pattern: "(fdescribe|fit|describe\\.only|it\\.only|test\\.only)\\("
+        paths: ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts"]
+      fix_hint: "Remove the .only / fdescribe / fit before merging — these silently disable the rest of the suite."
+      tags: [testing]
+
+    - id: no-skip-in-suites
+      rule: "Skipped tests need a written reason"
+      severity: major
+      detect:
+        type: command
+        command: "rg --no-heading -n '(it|test|describe)\\.skip\\(' --glob '**/*.test.*' --glob '**/*.spec.*' | rg -v '// skip:' | head -25"
+      fix_hint: "Either fix the test or add a `// skip: <reason>` comment on the same line."
+      tags: [testing]
+
+    - id: assertion-density-floor
+      rule: "Every test file must have at least one assertion"
+      severity: major
+      detect:
+        type: command
+        command: "rg --files-without-match -e 'expect\\(|assert\\.|should\\.' --glob '**/*.test.ts' --glob '**/*.test.tsx' | head -25"
+      fix_hint: "If the file is a setup/utility module, rename to *.helpers.ts; otherwise add real assertions."
+      tags: [testing]
+
+  shared-utils:
+    - id: prefer-shared-utils
+      rule: "Hand-rolled helpers should be replaced with shared util packages"
+      severity: major
+      detect:
+        type: rg
+        pattern: "function (debounce|throttle|deepClone|clamp|uniqueBy|sleep)\\b"
+        paths: ["src/**/*.ts", "src/**/*.tsx"]
+      fix_hint: "Use the shared utils package — see src/utils/index.ts for exports."
+      tags: [refactor, utils]
+
+  error-handling:
+    - id: no-swallowed-catch
+      rule: "Empty catch blocks must include `// noqa: <reason>` or escalate"
+      severity: critical
+      detect:
+        type: rg
+        pattern: "catch \\(.*\\) \\{\\s*\\}"
+        paths: ["src/**/*.ts", "src/**/*.tsx"]
+      fix_hint: "Either rethrow, log with structured context, or add `// noqa: <reason>` justifying the swallow."
+      tags: [error-handling]
+
+    - id: no-throw-non-error
+      rule: "`throw` payload must be an Error subclass"
+      severity: major
+      detect:
+        type: rg
+        pattern: "throw ['\"`]"
+        paths: ["src/**/*.ts", "src/**/*.tsx"]
+      fix_hint: "Construct an Error subclass with a message and (optional) cause — `throw new MyError(...)`"
+      tags: [error-handling]
+
+    - id: result-or-throw-not-both
+      rule: "A function either returns a Result or throws — not both"
+      severity: major
+      detect:
+        type: command
+        command: "rg --no-heading -l 'Result<' src/ 2>/dev/null | xargs -I{} rg -l 'throw new' {} 2>/dev/null | head -25"
+      fix_hint: "Pick one: convert thrown errors to `Result.err(...)` or remove the Result wrapper."
+      tags: [error-handling, type-safety]
+
+
+# ─── Python ───────────────────────────────────────────────────────────────
+
+python:
+  type-safety:
+    - id: no-bare-dict-in-public-api
+      rule: "Public function signatures must not use bare `dict` / `list` return types"
+      severity: major
+      detect:
+        type: rg
+        pattern: "^def [a-zA-Z_].*-> (dict|list)( |:)"
+        paths: ["src/**/*.py", "app/**/*.py"]
+      fix_hint: "Use a TypedDict, dataclass, or Pydantic model — `dict` hides the shape."
+      tags: [type-safety]
+
+    - id: no-yolo-json-loads
+      rule: "json.loads without schema validation at the boundary"
+      severity: critical
+      detect:
+        type: rg
+        pattern: "json\\.loads\\("
+        paths: ["src/**/*.py", "app/**/*.py"]
+      fix_hint: "Validate with Pydantic or dataclass-json — see app/schemas/."
+      tags: [type-safety, boundary]
+
+  architecture:
+    - id: no-direct-orm-in-route
+      rule: "View functions must not import ORM models directly"
+      severity: critical
+      detect:
+        type: rg
+        pattern: "from (app\\.)?models import"
+        paths: ["src/app/routes/**/*.py", "app/api/**/*.py"]
+      fix_hint: "Move queries to app/repositories/ and inject through a service."
+      tags: [architecture, boundary]
+
+  testing:
+    - id: no-pytest-skip-without-reason
+      rule: "@pytest.mark.skip must include a written reason"
+      severity: major
+      detect:
+        type: command
+        command: "rg --no-heading -n '@pytest\\.mark\\.skip\\(\\s*\\)' --glob 'tests/**/*.py' | head -25"
+      fix_hint: "Use `@pytest.mark.skip(reason='...')` so the reason survives the next maintainer."
+      tags: [testing]
+
+  error-handling:
+    - id: no-bare-except
+      rule: "`except:` without a type is forbidden"
+      severity: critical
+      detect:
+        type: rg
+        pattern: "^\\s+except\\s*:\\s*$"
+        paths: ["src/**/*.py", "app/**/*.py"]
+      fix_hint: "Catch a specific exception or `except Exception:` if you really mean any exception."
+      tags: [error-handling]
+
+
+# ─── Go ───────────────────────────────────────────────────────────────────
+
+go:
+  type-safety:
+    - id: no-empty-interface
+      rule: "Public exports must not use `interface{}` as a parameter or return type"
+      severity: major
+      detect:
+        type: rg
+        pattern: "^func [A-Z].*interface\\{\\}"
+        paths: ["**/*.go"]
+      fix_hint: "Define a concrete interface or struct — `any` hides the contract."
+      tags: [type-safety]
+
+  error-handling:
+    - id: no-error-discard
+      rule: "Don't discard errors with `_`"
+      severity: critical
+      detect:
+        type: rg
+        pattern: "_, _ := |_, _ = "
+        paths: ["**/*.go"]
+      fix_hint: "Handle the error or log it; explicit discards must be commented with rationale."
+      tags: [error-handling]
+
+  testing:
+    - id: no-t-fatal-in-subtest
+      rule: "Use t.Errorf in t.Run sub-tests, not t.Fatal (Fatal kills sibling sub-tests)"
+      severity: major
+      detect:
+        type: command
+        command: "rg --no-heading -n 'func.*\\*testing\\.T' --glob '*_test.go' | head -25"
+      fix_hint: "Inside `t.Run(...)`, prefer `t.Errorf` so other sub-tests still report."
+      tags: [testing]
+
+
+# ─── Language-agnostic fallback ───────────────────────────────────────────
+
+common:
+  shared-utils:
+    - id: no-duplicate-todo-fixme
+      rule: "TODO / FIXME comments must include an issue link or owner"
+      severity: minor
+      detect:
+        type: rg
+        pattern: "(TODO|FIXME)(?!\\(.*\\)|.*#\\d|.*CLA-)"
+        paths: ["**/*"]
+      fix_hint: "Annotate as `TODO(owner): ...` or `FIXME(#issue): ...` so the next reader knows where to ask."
+      tags: [convention]

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -117,6 +117,8 @@ Developers using Claude Code and similar agents often get inconsistent results �
 │       ├── quality-audit/         # golden-principles.yaml drift audit → docs/QUALITY_SCORE.md
 │       ├── references-sync/       # Sync llms.txt-style dependency refs into docs/references/
 │       ├── tasks-to-linear/       # Sync agent TaskList → Linear issues (one issue per task, idempotent by title)
+
+│       ├── constitution/          # Author/extend golden-principles.yaml interactively (pairs with /quality-audit)
 │       ├── project-health-report/ # Comprehensive health report (breadth-first, scoring)
 │       ├── review-pipeline/       # Parallel multi-audit review with dedupe (PR-scope)
 │       ├── lesson-refresh/        # Periodic refresh of tasks/lessons/ (keep/update/encode/archive)

--- a/tasks/decisions.md
+++ b/tasks/decisions.md
@@ -290,6 +290,43 @@ Track important technical decisions here so they don't get lost between sessions
   - When MCPs gain `blockedBy` on `create_issue`, Phase 3 in the SKILL.md swaps the blockquote write for a relation set. Existing issues with blockquotes are left as-is — no migration script.
   - **NOTE on numbering**: ADR-005..012 are reserved by PRs #117..#126. If merge order shifts, renumber to next free slot.
 
+### ADR-014: `/constitution` is interactive-first, additive-only, library-backed (no rule invention)
+- **Date**: 2026-05-18
+- **Status**: accepted
+- **Context**: CLA-17 asked for a "constitution" skill that produces a project-tailored `golden-principles.yaml` — the "Golden Principles" pattern from OpenAI's harness-engineering article applied to the kit's audit pipeline. `/quality-audit` (CLA-13, ADR-011) reads the file; this new skill writes it. Three contract questions had to be settled, because they determine whether the audit pipeline downstream is trustworthy:
+
+  1. **Authoring stance.** Interactive (dialogue per principle) or non-interactive (codebase-only inference)?
+  2. **Re-run behaviour.** What happens when the file already exists?
+  3. **Where do proposed `detect` rules come from?** Synthesised from codebase patterns, or drawn from a curated library?
+
+- **Options**:
+  - **Authoring stance**
+    - A) Interactive-first (default), headless as an explicit `mode:headless` escape hatch
+    - B) Non-interactive by default (infer everything), interactive only on flag
+  - **Re-run behaviour**
+    - C) Additive merge — propose only new categories, never edit existing entries
+    - D) Replace — regenerate the file on each run, dropping hand-edited principles
+    - E) Interactive replace — show diff, ask which entries to keep
+  - **`detect` rule source**
+    - F) Curated `principles-library.yaml` per language, lightly adapted to the detected stack
+    - G) Synthesised from codebase scan — "I see this pattern, here's a `detect` rule for it"
+    - H) Hybrid — library for known categories, synthesis for novel ones
+- **Decision**: A + C + F.
+  - **A (interactive-first)** — Following the principle from `office-hours` and the Core Rule pattern in CLA-13/14/16: the agent must never write a rule the user hasn't seen. Quality rules drive audit-class skills downstream; silent invention propagates errors at scale. Headless mode exists for CI bootstrapping but accepts everything the library proposes — no judgment is delegated.
+  - **C (additive merge)** — D would let the skill clobber hand-tuned principles, which is the worst possible failure mode for a file users will iterate on. E sounds good but creates a coupling problem: the user has to re-evaluate every existing entry on every run, turning a 30-second additive operation into a 10-minute review. C aligns with the "do one thing" principle — this skill *adds*; refining is a hand-edit job.
+  - **F (curated library)** — G is tempting but identical in shape to the failure mode ADR-012 (the `/references-sync` curated-vs-heuristic-vs-summarisation decision) rejected for the same reason: synthesised `detect` patterns are brittle and fire on the wrong lines. H sounds balanced but introduces the synthesis failure mode through the back door. F gives the skill a stable, kit-maintained surface to draw from; users extend with `.claude/principles-library.local.yaml` (per-project) or upstream PRs to grow the shared library.
+- **Sub-decisions**:
+  - **Schema source of truth is `.claude/skills/quality-audit/templates/golden-principles.example.yaml`.** If the schema changes there, `/constitution`'s output must follow. The skill's docstring explicitly references that path; a future CI lint can reject schema drift between the two skills.
+  - **Default file path is `.claude/golden-principles.yaml`**, not the repo root. `/quality-audit` resolves both, but `.claude/` is the kit-managed surface and avoids cluttering the project root. Users who prefer root can pass `path:./golden-principles.yaml`.
+  - **5-question intake** (in `templates/intake-questions.md`) shapes *severity emphasis* in Phase 3, not the principle set itself. Selected principles still come from the library; the intake just tunes which ones surface and how harshly.
+  - **CLAUDE.md pointer addition is opt-in.** On a brand-new file, the skill proposes adding a `## Quality Principles` section to CLAUDE.md — only with explicit user approval, never in headless mode. Following the same kit-managed-file discipline as `/harness-init`.
+- **Consequences**:
+  - 1 new skill: `.claude/skills/constitution/SKILL.md`
+  - 2 templates: `templates/principles-library.yaml` (3 languages × 4–6 categories), `templates/intake-questions.md` (5 questions + severity-mapping)
+  - `CODEBASE_MAP.md` lists the new skill
+  - **Skill family is now closed**: `/harness-init` (CLA-12 — scaffold `docs/`) → `/constitution` (CLA-17 — write `golden-principles.yaml`) → `/quality-audit` (CLA-13 — measure drift) → `/doc-gardening` (CLA-13 — flag stale docs) → `/references-sync` (CLA-14 — populate `docs/references/`) → `/tasks-to-linear` (CLA-16 — mirror plans to tracker). Each link in the chain has one job; future improvements stay localised.
+  - **NOTE on numbering**: ADR-005..013 are reserved by PRs #117..#127. If merge order shifts, renumber to next free slot.
+
 ### ADR-012: `/references-sync` skill ships curated known-sources list; refuses to auto-summarise READMEs
 - **Date**: 2026-05-18
 - **Status**: accepted

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -82,6 +82,46 @@ Linear: [CLA-16](https://linear.app/claudecodekit/issue/CLA-16/tasks-to-linear-c
 - Project-milestone auto-creation when missing
 - A `/linear-to-tasks` reverse skill
 
+### CLA-17 — `/constitution` skill (v1.12.0 candidate)
+
+**Goal**: A user-invocable skill that produces a project-tailored `golden-principles.yaml` — either by walking the user through a 5-question intake (empty project) or by inferring candidate principles from the codebase and asking the user to accept/reject each (existing project). Verification: invoke `/constitution` in a fresh repo, answer the prompts, and confirm a runnable `golden-principles.yaml` lands at `.claude/golden-principles.yaml` that `/quality-audit` accepts without warnings.
+
+**Context**: OpenAI's harness-engineering article calls this the "Golden Principles" pattern — establish governing rules before specifying or implementing. CLA-13 shipped `/quality-audit` which **reads** `golden-principles.yaml`; this skill **writes** it. Together they close the principles loop: author → enforce → measure.
+
+Linear: [CLA-17](https://linear.app/claudecodekit/issue/CLA-17/constitution-golden-principles-as-the-front-door-step)
+
+#### Approach
+1. Author `.claude/skills/constitution/SKILL.md` — interactive-first; supports `mode:headless` only when invoked with a codebase to infer from and a path to write to (no question loop).
+2. Two phases: **inventory** (read the repo to detect stack + idioms) → **draft** (propose 5–7 principles using categories: type-safety / shared-utils / architecture / testing / error-handling / naming). Each proposal includes the `detect` rule so the output is immediately runnable.
+3. Output format compatible with the schema shipped at `.claude/skills/quality-audit/templates/golden-principles.example.yaml` (version 1; required fields: id, rule, severity, detect, fix_hint).
+4. Idempotent: if `golden-principles.yaml` already exists, the skill reads it, proposes additions only for uncovered categories, and never overwrites existing rules without explicit user approval.
+5. Templates: a category-keyed library of starter principles per common stack (Node/TS, Python, Go) so the skill has concrete material to propose rather than inventing from thin air.
+6. Update `CODEBASE_MAP.md` to list the new skill.
+7. ADR-014 — document the interactive-first contract, the additive-merge invariant, and the category library decision.
+8. Run `scripts/validate-skills.sh` and resolve any warnings.
+
+#### Files to Touch
+- `.claude/skills/constitution/SKILL.md` — new file
+- `.claude/skills/constitution/templates/principles-library.yaml` — new (category-keyed starter principles)
+- `.claude/skills/constitution/templates/intake-questions.md` — new (the 5-question script)
+- `CODEBASE_MAP.md` — add the new skill in the inventory
+- `tasks/decisions.md` — ADR-014
+
+#### Open Questions
+- File location: repo root (`golden-principles.yaml`) or `.claude/golden-principles.yaml`? **Default to `.claude/`** — `/quality-audit` reads either, but `.claude/` is the kit-managed location and avoids cluttering the project root. Document the override.
+- Re-run behaviour: replace, merge, or read-only? **Merge** — additive only, surface conflicts as a dialog (interactive) or warning (headless).
+- How aggressive should the codebase inference be? **Conservative** — propose only when a clear signal exists (e.g. presence of `prisma`/`drizzle` imports → suggest `no-direct-db-in-route`). Never invent rules from thin signals.
+
+#### Risks
+- A bad starter principle set is worse than none — users will copy-paste and ignore the warnings. Mitigation: the library uses *common, well-validated* patterns (the existing example file is the baseline) and every proposed principle includes a verifiable `detect` rule the user can sanity-check before accepting.
+- Drift between this skill's output and `/quality-audit`'s schema would be silent and corrosive. Mitigation: ADR-014 names the schema source of truth (`.claude/skills/quality-audit/templates/golden-principles.example.yaml`); a follow-up CI lint can reject schema drift between the two.
+
+#### Not Now
+- Auto-running `/quality-audit` after the principles file is written (the user might want to review before measuring)
+- Multi-language detection beyond JS/TS/Python/Go (Ruby, Rust, Java) — add as users open issues
+- A `/constitution-refresh` skill that proposes new principles based on patterns that surfaced since the last write — extract to a separate issue if interest emerges
+- Importing principles from an external org-wide registry — interesting but premature
+
 ---
 
 ### v1.11.0 batch — Inspiration triad (rtk + GBrain + karpathy)


### PR DESCRIPTION
## Summary

Adds `/constitution` — a user-invocable skill that writes the project's `golden-principles.yaml`. Pairs with `/quality-audit` (which reads the file). Interactive-first (the dialogue is the value); detects the stack, proposes principles per applicable category from a curated library, walks the user through accept/edit/skip on each, writes one merged file. Additive on re-runs — never edits or removes existing entries.

Closes **CLA-17**.

## What's in this PR

- `.claude/skills/constitution/SKILL.md` (244 lines) — orchestrator following the kit's skill conventions (Core Rule + Kit Context + Default Behavior + Process phases + Run Mode + Output Format).
- `templates/principles-library.yaml` — curated starter principles, keyed by language (JS/TS, Python, Go) and category (type-safety, architecture, testing, shared-utils, error-handling). Plus a `common` fallback.
- `templates/intake-questions.md` — 5 questions asked when bootstrapping a brand-new file, each mapped to a severity-emphasis decision.
- `CODEBASE_MAP.md` — lists the new skill.
- `tasks/decisions.md` — **ADR-014** documents the contract.

## Design contract (see ADR-014)

| Choice | Decision | Why |
|---|---|---|
| Authoring stance | Interactive-first; headless accepts everything | Quality rules drive audits downstream — never write a rule the user hasn't seen |
| Re-run behaviour | Additive merge | The skill *adds*; refining existing entries is a hand-edit job |
| `detect` rule source | Curated library, lightly adapted | Synthesised `detect` patterns are brittle — same failure mode ADR-012 rejected for /references-sync |
| Default file location | `.claude/golden-principles.yaml` | Kit-managed surface; `/quality-audit` resolves root first then `.claude/` |
| Schema source of truth | `.claude/skills/quality-audit/templates/golden-principles.example.yaml` | One file owns the schema; this skill follows |

## Test plan

- [ ] Invoke `/constitution` in a fresh repo with no `golden-principles.yaml` — confirm the 5 intake questions surface, then category proposals are walked one by one, and the final file lands at `.claude/golden-principles.yaml`
- [ ] Invoke `/constitution` in a repo that already has 2 principles — confirm Phase 1 detects them, only uncovered categories are proposed, and the file is merged additively
- [ ] Invoke with `mode:headless` in a Node/TS repo — confirm zero questions, library defaults auto-accepted, file written
- [ ] Confirm the written file passes `/quality-audit` without schema warnings
- [ ] Validator (`scripts/validate-skills.sh`) shows zero new warnings for `constitution`

## Skill family is now closed

`/harness-init` (CLA-12) → `/constitution` (this PR) → `/quality-audit` (CLA-13) → `/doc-gardening` (CLA-13) → `/references-sync` (CLA-14) → `/tasks-to-linear` (CLA-16). Each link in the chain has one job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)