### PR TITLE
feat(skills): /ui-component-builder — production-ready UI component generator

### DIFF
--- a/.claude/skills/ui-component-builder/SKILL.md
+++ b/.claude/skills/ui-component-builder/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: ui-component-builder
+description: Build production-ready UI components with accessibility, loading/empty/error states, responsive behavior, and reusable prop design — not retrofitted polish
+user-invocable: true
+---
+
+# UI Component Builder
+
+## Core Rule
+
+Production-ready means accessibility, states (loading/empty/error), edge cases, and responsive behavior are designed first — not retrofitted after the happy path ships.
+
+## Kit Context
+
+Before starting:
+
+1. Read `CODEBASE_MAP.md` to identify the project's UI stack and component conventions
+2. Read `DESIGN.md` if it exists — it is the source of truth for tokens, colors, typography, spacing
+3. Read `CLAUDE.project.md` if it exists — project-specific UI rules override kit defaults
+4. Read any framework-specific docs in `agent_docs/project/` (e.g., Next.js conventions, design system docs)
+
+If a component library is already in use (shadcn, MUI, Chakra, Radix, custom), build on top of it — do not introduce a parallel system.
+
+## When to Use
+
+Invoke with `/ui-component-builder <component-name>` when:
+
+- A new reusable UI component is needed (button, modal, table, form field, card, etc.)
+- An existing one-off piece of UI needs to be extracted into a reusable component
+- A component needs to be redesigned to meet production standards (accessibility, states, responsive)
+- You want a component-architecture review *before* writing the implementation
+
+## When NOT to Use
+
+- For pages, routes, or layouts — those are application composition, not component design
+- For trivial wrappers (a 5-line styling div) — inline is fine
+- For full app scaffolding — combine `/shape-spec` with stack-specific tooling
+- For pure visual review of existing components — use `/design-review`
+- For pure accessibility audit of existing components — use `/accessibility-audit`
+
+## Hard Rules
+
+- **No new design tokens without DESIGN.md.** If colors, spacing, or typography need extending, stop and ask. New tokens are a Protected Change.
+- **Accessibility is not optional.** Every interactive component must be keyboard-navigable, have correct ARIA semantics, and pass WCAG 2.1 AA contrast.
+- **States are required, not optional.** Loading, empty, error, and disabled states must be considered before the component is "done." Skipping them is shipping a demo, not a component.
+- **Match existing style.** If the project uses controlled inputs, do not introduce uncontrolled ones. If it uses Tailwind, do not introduce CSS modules.
+- **No props soup.** If a component grows past ~8 props, split it or use composition (slots/children). The skill must surface this trade-off explicitly.
+
+## Process
+
+### Phase 1: Context Gathering
+
+Establish what the component must fit into:
+
+1. **Identify the stack** — React/Vue/Svelte/Solid? TypeScript? Styling system (Tailwind, CSS-in-JS, modules)?
+2. **Locate the component library** — shadcn, MUI, Radix, Chakra, custom? Where do components live (`components/ui/`, `app/_components/`, etc.)?
+3. **Find similar existing components** — pattern-match: is there a `Button` you should mirror? An existing `Modal` whose API you should follow?
+4. **Check design tokens** — extract from `DESIGN.md`, Tailwind config, theme files
+5. **Note the consumers** — who will use this component? Forms? Lists? Modals?
+
+Output of this phase: a short brief showing what you found. Do not skip — building components without locating prior art produces duplication.
+
+### Phase 2: Component Architecture
+
+Before writing code, design the shape:
+
+**API surface**
+- Name (clear, domain-appropriate, not generic like `Wrapper`)
+- Props — required vs optional, controlled vs uncontrolled
+- Slots / children patterns — for composition
+- Imperative API (refs, methods) — only if absolutely needed
+- Events / callbacks — naming convention from the project (`onChange` vs `onValueChange`)
+
+**Composition strategy**
+- Single component vs compound components (e.g., `<Select>`, `<Select.Item>`)
+- Headless logic + styled wrapper (when reuse across themes matters)
+- Single source of truth for state (controlled by default in form inputs)
+
+**States to enumerate**
+
+| State | Required? | Notes |
+|---|---|---|
+| Default | Always | The happy path |
+| Hover / Focus | Interactive components | Visual + keyboard |
+| Active / Pressed | Interactive components | Tactile feedback |
+| Disabled | If component can be disabled | `aria-disabled` + style |
+| Loading | If async work happens | Spinner / skeleton / shimmer |
+| Empty | If component renders a collection | Helpful message + action |
+| Error | If component can fail | Clear message + recovery path |
+| Read-only | If editing can be locked | Visually distinct from disabled |
+
+### Phase 3: Edge Cases & Responsive
+
+Enumerate before implementation:
+
+**Edge cases**
+- Long content (overflow, truncation, wrap)
+- No content (empty array, null, undefined)
+- Many items (virtualization threshold? pagination?)
+- Slow network (loading state visible?)
+- Failed network (error state visible?)
+- RTL languages (if i18n applies)
+- Very long strings without spaces (`overflow-wrap: anywhere`)
+
+**Responsive**
+- Mobile (320-480px) — touch targets ≥44px, single column, no horizontal scroll
+- Tablet (768-1024px) — adapt layout, not just shrink desktop
+- Desktop (1280+) — readable line lengths (45-75 chars)
+- Container queries when the component lives in variable-width slots
+
+**Accessibility**
+- Semantic HTML first (`<button>` not `<div onClick>`)
+- Keyboard: Tab, Shift+Tab, Enter, Space, Esc — all must work
+- ARIA: `role`, `aria-label`, `aria-describedby`, `aria-expanded`, etc. — only when semantic HTML doesn't cover it
+- Focus management — visible focus ring, focus trap in modals, focus return on close
+- Screen reader — labels, live regions for dynamic content, announcement of state changes
+- Contrast — WCAG AA: 4.5:1 normal text, 3:1 large text and UI components
+
+### Phase 4: Implementation
+
+Now write the component. Order matters:
+
+1. **Types / interfaces first** — define the contract before the body
+2. **Semantic markup** — start with the right HTML element
+3. **Accessibility wiring** — ARIA, keyboard handlers, focus management
+4. **Styling** — using the project's system (Tailwind classes, CSS variables, etc.)
+5. **States** — implement each enumerated state, not just the default
+6. **Composition hooks** — `children`, slots, render props as appropriate
+7. **Tests** — at minimum: renders, handles primary interaction, respects disabled state
+
+Code example (React + TypeScript + Tailwind, adapt to your stack):
+
+```tsx
+type ButtonProps = {
+  variant?: 'primary' | 'secondary' | 'ghost'
+  size?: 'sm' | 'md' | 'lg'
+  loading?: boolean
+  disabled?: boolean
+  leftIcon?: React.ReactNode
+  rightIcon?: React.ReactNode
+  children: React.ReactNode
+} & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children'>
+
+export function Button({
+  variant = 'primary',
+  size = 'md',
+  loading = false,
+  disabled = false,
+  leftIcon,
+  rightIcon,
+  children,
+  className,
+  ...rest
+}: ButtonProps) {
+  const isDisabled = disabled || loading
+
+  return (
+    <button
+      type="button"
+      aria-busy={loading || undefined}
+      aria-disabled={isDisabled || undefined}
+      disabled={isDisabled}
+      className={cn(buttonStyles({ variant, size }), className)}
+      {...rest}
+    >
+      {loading ? <Spinner aria-hidden="true" /> : leftIcon}
+      <span>{children}</span>
+      {!loading && rightIcon}
+    </button>
+  )
+}
+```
+
+### Phase 5: Documentation
+
+Every reusable component ships with:
+
+- **Props table** — name, type, default, description
+- **Usage examples** — at least three: minimal, common, advanced
+- **Accessibility notes** — keyboard shortcuts, ARIA roles in use, known limitations
+- **Visual states** — list each state with when it appears
+
+If the project has Storybook, MDX, or a docs site, add a story / page. Otherwise, put usage examples in a comment block at the top of the file.
+
+## Output Format
+
+When the skill runs, deliver the component as a structured package:
+
+```markdown
+# Component: <Name>
+
+## Architecture Brief
+
+- **Stack:** <framework + styling + types>
+- **Library context:** <existing components mirrored / extended>
+- **Composition pattern:** <single / compound / headless>
+- **Why this shape:** <one paragraph rationale>
+
+## Props API
+
+| Prop | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| ... | ... | ... | ... | ... |
+
+## States Enumerated
+
+| State | Visual treatment | Interaction |
+|---|---|---|
+| Default | ... | ... |
+| Loading | ... | ... |
+| Empty | ... | ... |
+| Error | ... | ... |
+| Disabled | ... | ... |
+
+## Edge Cases Handled
+
+- Overflow: <strategy>
+- No content: <empty state design>
+- Failed load: <error recovery>
+- Long strings: <wrap behavior>
+- RTL: <handled / not applicable>
+
+## Responsive Behavior
+
+| Breakpoint | Adaptation |
+|---|---|
+| Mobile (320-480px) | ... |
+| Tablet (768-1024px) | ... |
+| Desktop (1280+) | ... |
+
+## Accessibility
+
+- **Semantic HTML:** <element + reason>
+- **Keyboard:** Tab / Enter / Space / Esc — what each does
+- **ARIA:** <attributes used and why>
+- **Focus management:** <strategy>
+- **Contrast:** <ratios met>
+
+## Implementation
+
+<code, in the project's conventions>
+
+## Usage Examples
+
+### Minimal
+<code>
+
+### Common case
+<code>
+
+### Advanced / composed
+<code>
+
+## Tests
+
+<test file or test outline>
+
+## Open Questions
+
+<anything that requires user input — design tokens to add, ambiguous behavior, scope to confirm>
+```
+
+## Notes
+
+- This skill **produces** components, unlike `/design-review` and `/accessibility-audit` which **review** them. Use those after this skill ships a component to catch what slipped through.
+- If the user asks for "a quick button" — push back gently. Either it is a one-off (then inline it, no skill needed) or it is reusable (then states and accessibility are not optional).
+- For component **libraries** (10+ components with shared system), invoke `/shape-spec` first to capture the system-level decisions, then run this skill per component.
+- When a component is being **refactored**, also run `/refactoring-guide` to plan the migration of existing call sites.
+- If the project lacks a `DESIGN.md`, surface this as an open question — building production components without tokens is a recipe for inconsistency.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ ClaudeCodeKit is not a runtime application — it's a **configuration system** t
 
 1. **Advisory rules** (`CLAUDE.md` → `agent_docs/`) — instructions the agent reads and follows. Can be conditionally loaded based on task type. Enforced by agent compliance, not technically.
 
-2. **Deterministic hooks** (`.claude/hooks/`) — shell scripts that execute at specific lifecycle points (PreToolUse, PostToolUse, Stop). These **cannot be bypassed** by the agent. Exit code 2 blocks the action.
+2. **Deterministic hooks** (`.claude/hooks/`) — shell scripts that execute at six lifecycle points: SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop, SessionEnd. These **cannot be bypassed** by the agent. Exit code 2 blocks the action (PreToolUse) or completion (Stop). Quality-gate writes verification state to `.hook-state/last_quality_gate.json`; stop-gate reads it. Audit log: `reports/session-audit.log`. Both directories are self-gitignored.
 
 3. **Knowledge accumulation** (`tasks/lessons/` + `.claude/skills/`) — the agent learns from corrections (one lesson per file, with YAML frontmatter) and discoveries (skills) across sessions.
 
@@ -116,21 +116,30 @@ Key design principle: CLAUDE.md acts as a **logical directory** — it contains 
 │   │   ├── qa-reviewer.md         # Evidence-based QA verification agent
 │   │   └── dead-code-remover.md   # Dead code removal agent
 │   ├── hooks/                     # Deterministic shell script hooks
-│   │   ├── protect-files.sh       # Block edits to sensitive files
-│   │   ├── branch-protect.sh      # Block push to main/force push
-│   │   ├── block-dangerous-commands.sh  # Block destructive commands
-│   │   ├── lib/                    # Shared hook library (json-parse.sh)
-│   │   ├── loop-detect.sh         # Edit loop detection and prevention
-│   │   ├── conventional-commit.sh # Enforce commit message format
-│   │   ├── secret-scan.sh         # Detect secrets in code
-│   │   ├── unicode-scan.sh        # Detect invisible Unicode (Glassworm defense)
-│   │   ├── auto-lint.sh           # Auto-lint after edits (opt-in)
-│   │   ├── auto-format.sh         # Auto-format after edits (opt-in)
-│   │   ├── task-complete-notify.sh # Desktop notification on completion
-│   │   ├── skill-compliance.sh     # Skill checklist compliance (opt-in)
-│   │   ├── skill-extract-reminder.sh  # Skill extraction reminder (opt-in)
+│   │   ├── session-start.sh       # SessionStart: inject Tier 1 context pointers
+│   │   ├── prompt-router.sh       # UserPromptSubmit: domain-keyword context injection
+│   │   ├── protect-files.sh       # PreToolUse: block edits to secret files
+│   │   ├── protect-changes.sh     # PreToolUse: block architectural changes w/o CLAUDE_APPROVED=1
+│   │   ├── branch-protect.sh      # PreToolUse: block push to main/force push
+│   │   ├── block-dangerous-commands.sh  # PreToolUse: block destructive commands
+│   │   ├── conventional-commit.sh # PreToolUse: enforce commit message format
+│   │   ├── secret-scan.sh         # PostToolUse: detect secrets in code
+│   │   ├── unicode-scan.sh        # PostToolUse: detect invisible Unicode (Glassworm)
+│   │   ├── loop-detect.sh         # PostToolUse: edit loop detection
+│   │   ├── quality-gate.sh        # PostToolUse: run typecheck/lint, write .hook-state/
+│   │   ├── bash-budget.sh         # PostToolUse (Bash): estimate cumulative output token cost, one-shot warn at threshold
+│   │   ├── stop-gate.sh           # Stop: block completion when last quality gate failed
+│   │   ├── task-complete-notify.sh # Stop: desktop notification on success
+│   │   ├── session-end.sh         # SessionEnd: append audit line to reports/session-audit.log
+│   │   ├── auto-lint.sh           # PostToolUse: auto-lint after edits (opt-in)
+│   │   ├── auto-format.sh         # PostToolUse: auto-format after edits (opt-in)
+│   │   ├── skill-compliance.sh    # PostToolUse: skill checklist compliance (opt-in)
+│   │   ├── skill-extract-reminder.sh  # UserPromptSubmit: skill extraction reminder (opt-in)
+│   │   ├── lib/                    # Shared hook library (json-parse.sh, state-counter.sh)
 │   │   └── project/               # Project-specific hooks (never touched by kit)
-│   └── skills/                    # Reusable knowledge
+│   ├── extensions/                # Community / third-party skills (Layer 2 — see agent_docs/skills.md)
+│   │   └── README.md              #   Kit creates the dir + README; never touches contents
+│   └── skills/                    # Reusable knowledge (Layer 4 — kit-core skills)
 │       ├── _shared/               # Shared template blocks
 │       │   └── blocks/            # Reusable content blocks (preamble, scope, etc.)
 │       ├── _templates/            # .tmpl skill templates (source of truth)
@@ -147,15 +156,24 @@ Key design principle: CLAUDE.md acts as a **logical directory** — it contains 
 │       ├── accessibility-audit/   # WCAG 2.1 AA compliance
 │       ├── dependency-audit/      # Vulnerability & license checks
 │       ├── documentation-audit/   # Doc quality & sync audit
+│       ├── doc-gardening/         # Drift detection between docs/ and current code
+│       ├── quality-audit/         # golden-principles.yaml drift audit → docs/QUALITY_SCORE.md
+│       ├── references-sync/       # Sync llms.txt-style dependency refs into docs/references/
+│       ├── tasks-to-linear/       # Sync agent TaskList → Linear issues (one issue per task, idempotent by title)
+
+│       ├── constitution/          # Author/extend golden-principles.yaml interactively (pairs with /quality-audit)
 │       ├── project-health-report/ # Comprehensive health report (breadth-first, scoring)
 │       ├── review-pipeline/       # Parallel multi-audit review with dedupe (PR-scope)
 │       ├── lesson-refresh/        # Periodic refresh of tasks/lessons/ (keep/update/encode/archive)
 │       ├── pulse/                 # Time-windowed outcome report saved to tasks/pulses/
 │       ├── ship/                  # Deployment pipeline
+│       ├── scorecard/             # Windowed scorecard from reports/session-audit.log (schema_version 2 metrics)
+│       ├── harness-init/          # Scaffold OpenAI-style docs/ harness structure (idempotent)
 │       ├── retro/                 # Sprint retrospective & analytics
 │       ├── office-hours/          # Pre-coding product validation
 │       ├── debug/                 # Root-cause debugging
 │       ├── design-review/         # UI design consistency review
+│       ├── ui-component-builder/  # Production-ready UI component generator (a11y, states, responsive)
 │       └── shape-spec/            # Feature spec folder creation
 │
 ├── bin/                           # npm distribution entry point
@@ -171,7 +189,13 @@ Key design principle: CLAUDE.md acts as a **logical directory** — it contains 
 │   ├── validate-skills.sh         # Validates skill directory structure
 │   ├── gen-skill-docs.sh          # Generates web MDX docs from SKILL.md files
 │   ├── gen-agents-md.sh           # Generates cross-tool AGENTS.md from kit sources
-│   └── build-skills.sh            # Builds SKILL.md from .tmpl templates + shared blocks
+│   ├── build-skills.sh            # Builds SKILL.md from .tmpl templates + shared blocks
+│   ├── lesson-graph.sh            # Parses typed lesson frontmatter (supersedes/applies_to/contradicts/related_decisions); validates the graph and rewrites the auto sections in tasks/lessons/_index.md
+│   └── run-bench.sh               # KitBench runner — executes every scenario in bench/scenarios/ in an isolated temp dir
+│
+├── bench/                         # KitBench — reproducible eval harness for the kit's deterministic-enforcement claims
+│   ├── README.md                  # Corpus overview, how to add scenarios
+│   └── scenarios/                 # JSON scenarios (one per file: name, hook, setup_files, env, payload, expect)
 │
 └── examples/                      # Stack-specific templates
     ├── nextjs/                    # Next.js 16 + App Router

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -130,6 +130,7 @@ Developers using Claude Code and similar agents often get inconsistent results �
 │       ├── office-hours/          # Pre-coding product validation
 │       ├── debug/                 # Root-cause debugging
 │       ├── design-review/         # UI design consistency review
+│       ├── ui-component-builder/  # Production-ready UI component generator (a11y, states, responsive)
 │       └── shape-spec/            # Feature spec folder creation
 │
 ├── bin/                           # npm distribution entry point

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ User-invocable audit and guide skills — run with `/skill-name`:
 | `/office-hours` | Pre-coding product validation — clarify what and why before coding |
 | `/debug` | Systematic root-cause debugging with evidence-before-fix enforcement |
 | `/design-review` | UI design consistency, AI slop detection, and responsive behavior |
+| `/ui-component-builder` | Builds production-ready UI components with accessibility, states, and responsive behavior — not retrofitted polish |
 | `/skill-extractor` | Extracts non-obvious knowledge into reusable skills *(supports `mode:headless`)* |
 | `/skill-generator` | Generates project-specific coding skills from tech stack analysis |
 | `/shape-spec` | Creates timestamped feature spec folders for multi-session planning |
@@ -404,6 +405,7 @@ claude-code-kit/
       office-hours/                # Pre-coding product validation
       debug/                       # Root-cause debugging
       design-review/               # UI design consistency review
+      ui-component-builder/        # Production-ready UI component generator
       shape-spec/                  # Feature spec folder creation
       wiki-ingest/                 # Wiki source ingestion (--wiki)
       wiki-lint/                   # Wiki health checks (--wiki)


### PR DESCRIPTION
## Summary

- New skill at `.claude/skills/ui-component-builder/SKILL.md` that builds production-ready UI components with accessibility, states (loading/empty/error/disabled), responsive behavior, and prop-API design considered upfront — not retrofitted.
- Complements existing `/design-review` and `/accessibility-audit` which **review** components after they exist; this skill **produces** them.
- 5-phase process: Context Gathering → Component Architecture → Edge Cases & Responsive → Implementation → Documentation.

## Why

Inspired by a thread on senior-engineer-style prompting for Claude. The kit already had `/debug` (which covers the "senior debugging engineer" pattern comprehensively), but had no production-grade UI component generator — only reviewers (`/design-review`, `/accessibility-audit`). This fills that gap.

## Changes

- `.claude/skills/ui-component-builder/SKILL.md` (new) — passes validator with 0 warnings
- `CODEBASE_MAP.md` — skill listed in tree
- `README.md` — skill in slash-command table + tree
- `AGENTS.md` — regenerated via `./scripts/gen-agents-md.sh` (also caught up on stale content from prior releases)

## Test plan

- [x] `./scripts/validate-skills.sh` passes (309 ✓ / 0 ✗ / 0 !)
- [x] `./scripts/gen-agents-md.sh` regenerates cleanly
- [x] `./scripts/gen-skill-docs.sh` produces `ui-component-builder.mdx` for web
- [ ] Manual smoke: invoke `/ui-component-builder Button` in a Next.js project and verify the output matches the documented format
- [ ] release-please bumps to 1.13.0 on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)