### PR TITLE
feat(plugin): publish kit as Claude Code plugin marketplace listing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "claude-code-kit",
+  "id": "claude-code-kit",
+  "owner": {
+    "name": "tansuasici",
+    "url": "https://github.com/tansuasici"
+  },
+  "metadata": {
+    "description": "Discipline kit that turns Claude Code from eager intern to staff engineer. Hooks, skills, and CLAUDE.md rules for Plan → Confirm → Implement → Verify.",
+    "version": "1.13.0"
+  },
+  "plugins": [
+    {
+      "name": "claude-code-kit",
+      "source": "./",
+      "description": "Plan → Confirm → Implement → Verify discipline for Claude Code. Tier'd session boot, hooks (quality gate, protect-changes, branch-protect, secret-scan, conventional-commit, loop-detect), skills (architecture-review, code-quality-audit, design-review, performance-audit, security-review, refactoring-guide, dead-code-audit, accessibility-audit, deepening-review, interface-design, office-hours, shape-spec, retro, ship, skill-extractor, skill-generator, ui-component-builder, testing-audit, project-health-report, documentation-audit, dependency-audit), CLAUDE.md ruleset, lessons-as-memory, ADR decisions, and a wiki module for synthesised knowledge.",
+      "version": "1.13.0",
+      "author": {
+        "name": "tansuasici",
+        "url": "https://github.com/tansuasici"
+      },
+      "keywords": [
+        "workflow",
+        "discipline",
+        "hooks",
+        "skills",
+        "claude-md",
+        "plan-first",
+        "quality-gate",
+        "scope-discipline"
+      ],
+      "category": "workflow",
+      "homepage": "https://claudecodekit-dd431.web.app",
+      "license": "MIT"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "claude-code-kit",
   "description": "Discipline kit that turns Claude Code from eager intern to staff engineer. Hooks, skills, and CLAUDE.md rules for Plan → Confirm → Implement → Verify.",
-  "version": "1.10.0",
+  "version": "1.13.0",
   "author": {
     "name": "tansuasici",
     "url": "https://github.com/tansuasici"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,9 +37,20 @@ This is the single most important rule for long sessions.
 For any task touching 3+ files, architectural decisions, new dependencies, or workflow changes:
 - Before researching or planning, restate the request as a **verifiable goal** (see `agent_docs/workflow.md → Goal-Driven Task Reframing`). "Fix the bug" → "Write a test that reproduces it, then make it pass."
 - Write a plan to `tasks/todo.md` using the template in `agent_docs/workflow.md`
+- For in-session ideation, use Claude Code's built-in **Plan Mode** (`Shift+Tab` to toggle) — it stages reasoning and proposed edits without applying them until you exit the mode. Use this alongside `tasks/todo.md` for the plan-of-record.
 - Do not implement until the plan is confirmed
 
 If something goes sideways mid-task: STOP, re-read the original goal, re-plan.
+
+---
+
+## Model Selection
+Match the model to the phase, not the project:
+
+- **Opus** — Plan / Architecture / Debug. Use for `tasks/todo.md` authoring, ADR drafting in `tasks/decisions.md`, `/deepening-review`, `/interface-design`, and any task where reasoning quality matters more than throughput.
+- **Sonnet** — Implement / Edit / Verify. Use for the Implement phase, routine edits, test writing, and running the verification gate.
+
+Default to Sonnet. Switch to Opus for the Plan phase of any non-trivial task, then back to Sonnet for Implement. Long Opus sessions waste budget; long Sonnet sessions miss architectural mistakes.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ Or with curl:
 curl -fsSL https://raw.githubusercontent.com/tansuasici/claude-code-kit/main/install.sh | bash
 ```
 
-Or as a [Claude Code plugin](https://code.claude.com/docs/en/plugins) (once the marketplace listing is live):
+Or as a [Claude Code plugin](https://code.claude.com/docs/en/plugins):
 
 ```text
 /plugin marketplace add tansuasici/claude-code-kit
-/plugin install claude-code-kit
+/plugin install claude-code-kit@claude-code-kit
 ```
 
 | Path | What you get | When to use |

--- a/agent_docs/workflow.md
+++ b/agent_docs/workflow.md
@@ -234,6 +234,72 @@ This can be as simple as a shell script that:
 
 ---
 
+## Context Hygiene
+
+The `## After Compaction` rule in `CLAUDE.md` is **reactive** — what to do once compaction has happened. This section is **proactive** — when to evict context yourself before quality degrades.
+
+Claude Code exposes two commands:
+
+- **`/compact`** — summarises the conversation so far and replaces it with the summary. Keeps the thread alive; trades fidelity for headroom.
+- **`/clear`** — wipes the conversation entirely. `CLAUDE.md` and project files are re-read on next turn; mid-task scratch state is gone.
+
+### When to use which
+
+| Trigger | Use |
+|---|---|
+| Just finished a contract / feature, starting a new one | `/clear` |
+| Switching branches mid-session | `/clear` |
+| Conversation is long but you're still on the same task and need the history | `/compact` |
+| Responses are getting slower, more drift, more "I forgot what we decided" | `/compact` (or `/clear` if the task has natural boundaries) |
+| Context window indicator past ~70-80% | `/compact` *now*, don't wait for the auto-trigger |
+| Switching from Plan phase to Implement phase on a non-trivial task | `/clear`, then start Implement with the plan file as the only input |
+
+### Rules
+
+1. Before `/clear`, make sure the things you need next session are written down — `tasks/todo.md`, `tasks/handoff-*.md`, an open `tasks/specs/<slug>/` folder, or a fresh ADR in `tasks/decisions.md`. The clear is destructive for in-memory state, not for files.
+2. After `/compact`, re-read the same Tier 1 files as `## After Compaction` in `CLAUDE.md` — a summary is not the same as the original context.
+3. Don't `/compact` to "save tokens" if the task is small. The summary itself costs context; only useful when the conversation has grown.
+4. If you find yourself wanting to compact every 20 turns, the real fix is `## Separate Research from Implementation` above — too much exploration is bleeding into the active task.
+
+This complements `## Session Strategy → One Session Per Contract` — that section says "start new sessions per task"; this section says "and inside a session, prune as you go."
+
+---
+
+## Visual Feedback
+
+For UI work, a screenshot is faster and less ambiguous than describing a problem in words. Claude Code accepts pasted images directly into the prompt.
+
+### The pattern
+
+1. Capture the offending region — `Cmd+Shift+4` on macOS, `Win+Shift+S` on Windows, `Shift+PrintScreen` on most Linux DEs. Capture *the smallest area* that contains the problem, not the whole window.
+2. Paste into the Claude Code prompt with `Ctrl+V` (or `Cmd+V`). The image attaches to the next message.
+3. Pair the image with a **specific** instruction. The image shows *what*; you still need to say *what to change*.
+
+### What to say with the image
+
+| Bad (ambiguous) | Good (specific) |
+|---|---|
+| "This looks wrong, fix it." | "The spacing between the avatar and the username is too tight — match the 12px gap used elsewhere in this list." |
+| "Make this better." | "The button's border-radius doesn't match the card it sits inside. Card is 8px, button is 4px. Align them." |
+| "Why is this broken?" | "This dropdown overflows the viewport on mobile. Reproduce the layout in CSS and propose a fix that keeps the menu inside the safe area." |
+
+### When to use it
+
+- Spacing, alignment, contrast, or visual hierarchy issues — words struggle, images don't
+- Cross-browser / cross-viewport differences — capture both, paste both, compare
+- "AI slop" detection — paste the rendered output alongside `DESIGN.md` and ask "where does this diverge from the design system?"
+- Error states in browser devtools — paste the console / network panel screenshot instead of typing the stack trace
+
+### When *not* to use it
+
+- Code problems — text is canonical, screenshots of code lose structure
+- Logic bugs — the visual output is downstream; show the data or the failing test instead
+- Anything reproducible by `npm test` — let verification do the work
+
+Pairs with the `/design-review` skill: that skill produces a structured report against `DESIGN.md`; screenshot feedback is the lightweight, in-loop counterpart for *during* implementation.
+
+---
+
 ## PR / Commit Workflow
 
 ### Commit Messages


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/marketplace.json` so the kit can be installed via Claude Code's plugin system: `/plugin marketplace add tansuasici/claude-code-kit` → `/plugin install claude-code-kit@claude-code-kit`. The repo now functions both as the npm-published kit *and* as a one-plugin marketplace.
- Bumps `.claude-plugin/plugin.json` to 1.13.0 (it was stuck at 1.10.0 — release-please isn't rewriting it; see follow-up below).
- Adds four small but real gaps spotted while reviewing competing CLAUDE.md packages and the "40 features" thread:
  - **Model Selection** (CLAUDE.md): Opus for Plan/Architecture/Debug, Sonnet for Implement/Edit/Verify. Default Sonnet, switch to Opus for Plan phase of non-trivial tasks.
  - **Plan Mode reference** (CLAUDE.md → Plan First): one-line pointer to Claude Code's built-in `Shift+Tab` Plan Mode alongside `tasks/todo.md`.
  - **Context Hygiene** (workflow.md): proactive `/compact` and `/clear` — the existing `## After Compaction` rule was reactive only. Triggers table + four rules covering when to evict vs preserve state.
  - **Visual Feedback** (workflow.md): screenshot paste pattern for UI work, paired with a bad-vs-good instruction table. Connects to the `/design-review` skill.

## Test plan

- [ ] `/plugin marketplace add tansuasici/claude-code-kit` resolves once the PR is merged to `main`
- [ ] `/plugin install claude-code-kit@claude-code-kit` installs the kit's skills + hooks under the plugin namespace
- [ ] CLAUDE.md renders cleanly (no broken anchors)
- [ ] `agent_docs/workflow.md` validate-skills.sh / validate.sh pass (no markdown lint regressions)
- [ ] README install snippet matches the marketplace.json name/plugins[0].name

## Follow-up

- `.claude-plugin/plugin.json` version field should be appended to `release-please-config.json` extra-files so the bot keeps it in sync going forward. Filing as a separate issue.

Generated with [Claude Code](https://claude.com/claude-code)