### PR TITLE
feat: 4 Karpathy 12-rule gaps + role-bound model rule + dirty-tree session signal

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -93,6 +93,28 @@ if command -v git &>/dev/null && [ -d "$ROOT/.git" ]; then
     append_line ""
     append_line "Branch: $BRANCH"
   fi
+
+  # 5. Working tree status — flag dirty state so the agent reconciles against
+  # the active task before picking up uncommitted files as "in scope".
+  # Silent when the tree is clean (no noise on fresh sessions).
+  PORCELAIN=$(git -C "$ROOT" status --porcelain 2>/dev/null || true)
+  if [ -n "$PORCELAIN" ]; then
+    MOD_COUNT=$(printf '%s\n' "$PORCELAIN" | grep -cE '^( M|M |MM|AM| A| D| R)' 2>/dev/null || true)
+    UNT_COUNT=$(printf '%s\n' "$PORCELAIN" | grep -cE '^\?\?' 2>/dev/null || true)
+    DEFAULT_BRANCH=$(git -C "$ROOT" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || echo main)
+    AHEAD=0
+    if [ -n "${BRANCH:-}" ] && [ "$BRANCH" != "$DEFAULT_BRANCH" ]; then
+      AHEAD=$(git -C "$ROOT" rev-list --count "${DEFAULT_BRANCH}..HEAD" 2>/dev/null || echo 0)
+    fi
+    append_line ""
+    append_line "Working tree (uncommitted):"
+    [ "${MOD_COUNT:-0}" -gt 0 ] && append_line "- ${MOD_COUNT} modified file(s) (run \`git status\` to inspect)"
+    [ "${UNT_COUNT:-0}" -gt 0 ] && append_line "- ${UNT_COUNT} untracked file(s)"
+    if [ "${AHEAD:-0}" -gt 0 ]; then
+      append_line "- Branch is ${AHEAD} commit(s) ahead of ${DEFAULT_BRANCH}"
+    fi
+    append_line "- Plan check: are these changes part of the active task in tasks/todo.md? If not, flag before proceeding."
+  fi
 fi
 
 # Nothing substantive? Skip the hook output entirely (don't pollute context).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,12 +45,25 @@ If something goes sideways mid-task: STOP, re-read the original goal, re-plan.
 ---
 
 ## Model Selection
-Match the model to the phase, not the project:
+Match the model to the phase, not the project. Two roles:
 
-- **Opus** — Plan / Architecture / Debug. Use for `tasks/todo.md` authoring, ADR drafting in `tasks/decisions.md`, `/deepening-review`, `/interface-design`, and any task where reasoning quality matters more than throughput.
-- **Sonnet** — Implement / Edit / Verify. Use for the Implement phase, routine edits, test writing, and running the verification gate.
+- **Planner** — heavy reasoning, architecture decisions, debug. Use the most capable model available. Reach for it when authoring `tasks/todo.md`, drafting ADRs in `tasks/decisions.md`, running `/deepening-review` / `/interface-design`, and any task where reasoning quality matters more than throughput. *(Currently: Opus.)*
+- **Implementer** — file edits, test writing, routine verification. Use the fastest workhorse model — the Implement phase of the lifecycle, running the verification gate, and most edits. *(Currently: Sonnet.)*
 
-Default to Sonnet. Switch to Opus for the Plan phase of any non-trivial task, then back to Sonnet for Implement. Long Opus sessions waste budget; long Sonnet sessions miss architectural mistakes.
+Default to Implementer. Switch to Planner for the Plan phase of any non-trivial task, then back. Long Planner sessions waste budget; long Implementer sessions miss architectural mistakes. Names of specific models age fast; the role mapping does not.
+
+---
+
+## Model vs Code
+The model is for **judgment** tasks: classify, draft, summarize, extract, explain, decide between options that lack a deterministic answer. Everything **deterministic** belongs in code, not in a prompt:
+
+- Routing on status codes / branching on flags
+- Retries on transient errors
+- Format conversions with known input/output shapes (dates, slugs, JSON ↔ YAML)
+- Hash, encode, parse, validate against a schema
+- Lookups in a fixed table
+
+Asking the model to do deterministic work burns tokens *and* introduces non-determinism into a path that has a correct answer. If a `switch`, a regex, or a config file can answer it, let it. The model orchestrates; deterministic code executes.
 
 ---
 
@@ -58,6 +71,7 @@ Default to Sonnet. Switch to Opus for the Plan phase of any non-trivial task, th
 - Touch ONLY files directly required by the task
 - Never refactor opportunistically
 - **Match existing style** in any file you edit — quote style, indentation, naming convention, async/promise patterns — even if you'd write it differently from scratch. Style drift inside a touched file is an unrelated change. See `agent_docs/conventions.md → Match Existing Style`.
+- **Surface style conflicts, don't blend.** If a file or its neighbours contain two valid styles for the same thing (two error-handling patterns, two date libraries, two casing conventions), pick one and *ask* — do not interpolate. Blending doubles the bug surface and hides intent from reviewers.
 - Log unrelated issues under `tasks/todo.md → ## Not Now`
 - State every assumption explicitly before acting on it
 - If 2+ valid approaches exist with real tradeoffs: present them, don't decide silently
@@ -85,6 +99,7 @@ Every task must pass before marking complete:
 2. Lint
 3. Tests
 4. Smoke test (verify real behavior — call endpoint, open page, run CLI)
+5. **Quantify silent failures.** If the task processes N items, report `(processed / failed / skipped) with reasons` — never report "complete" while a subset was silently skipped. A green-looking task with 14% silently-dropped records is the worst failure mode, because the surface looks correct.
 
 Ask yourself: _"Would a staff engineer approve this?"_
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,8 +47,8 @@ If something goes sideways mid-task: STOP, re-read the original goal, re-plan.
 ## Model Selection
 Match the model to the phase, not the project. Two roles:
 
-- **Planner** — heavy reasoning, architecture decisions, debug. Use the most capable model available. Reach for it when authoring `tasks/todo.md`, drafting ADRs in `tasks/decisions.md`, running `/deepening-review` / `/interface-design`, and any task where reasoning quality matters more than throughput. *(Currently: Opus.)*
-- **Implementer** — file edits, test writing, routine verification. Use the fastest workhorse model — the Implement phase of the lifecycle, running the verification gate, and most edits. *(Currently: Sonnet.)*
+- **Planner** — heavy reasoning, architecture decisions, debug. Use the most capable model available. Reach for it when authoring `tasks/todo.md`, drafting ADRs in `tasks/decisions.md`, running `/deepening-review` / `/interface-design`, and any task where reasoning quality matters more than throughput. _(Currently: Opus.)_
+- **Implementer** — file edits, test writing, routine verification. Use the fastest workhorse model — the Implement phase of the lifecycle, running the verification gate, and most edits. _(Currently: Sonnet.)_
 
 Default to Implementer. Switch to Planner for the Plan phase of any non-trivial task, then back. Long Planner sessions waste budget; long Implementer sessions miss architectural mistakes. Names of specific models age fast; the role mapping does not.
 
@@ -63,7 +63,7 @@ The model is for **judgment** tasks: classify, draft, summarize, extract, explai
 - Hash, encode, parse, validate against a schema
 - Lookups in a fixed table
 
-Asking the model to do deterministic work burns tokens *and* introduces non-determinism into a path that has a correct answer. If a `switch`, a regex, or a config file can answer it, let it. The model orchestrates; deterministic code executes.
+Asking the model to do deterministic work burns tokens _and_ introduces non-determinism into a path that has a correct answer. If a `switch`, a regex, or a config file can answer it, let it. The model orchestrates; deterministic code executes.
 
 ---
 
@@ -71,7 +71,7 @@ Asking the model to do deterministic work burns tokens *and* introduces non-dete
 - Touch ONLY files directly required by the task
 - Never refactor opportunistically
 - **Match existing style** in any file you edit — quote style, indentation, naming convention, async/promise patterns — even if you'd write it differently from scratch. Style drift inside a touched file is an unrelated change. See `agent_docs/conventions.md → Match Existing Style`.
-- **Surface style conflicts, don't blend.** If a file or its neighbours contain two valid styles for the same thing (two error-handling patterns, two date libraries, two casing conventions), pick one and *ask* — do not interpolate. Blending doubles the bug surface and hides intent from reviewers.
+- **Surface style conflicts, don't blend.** If a file or its neighbours contain two valid styles for the same thing (two error-handling patterns, two date libraries, two casing conventions), pick one and _ask_ — do not interpolate. Blending doubles the bug surface and hides intent from reviewers.
 - Log unrelated issues under `tasks/todo.md → ## Not Now`
 - State every assumption explicitly before acting on it
 - If 2+ valid approaches exist with real tradeoffs: present them, don't decide silently

--- a/agent_docs/hooks.md
+++ b/agent_docs/hooks.md
@@ -12,7 +12,7 @@ Philosophy: **Use prompts for guidance. Use hooks for behavior that should run e
 
 | Hook | File | What it does |
 |------|------|-------------|
-| **session-start** | `.claude/hooks/session-start.sh` | Auto-injects Tier 1 context: confirms CODEBASE_MAP/CLAUDE.project presence, top rules from `tasks/lessons/_index.md`, active task from `tasks/todo.md`, current git branch. Replaces the prompt rule "read Tier 1 files at session start". |
+| **session-start** | `.claude/hooks/session-start.sh` | Auto-injects Tier 1 context: confirms CODEBASE_MAP/CLAUDE.project presence, top rules from `tasks/lessons/_index.md`, active task from `tasks/todo.md`, current git branch, and **working-tree status** (modified/untracked file counts + branch-ahead distance when the tree is dirty, with a "plan check" nudge to reconcile against the active task). Replaces the prompt rule "read Tier 1 files at session start". Silent on clean trees. |
 
 ### UserPromptSubmit (runs before the model sees each user prompt)
 

--- a/agent_docs/workflow.md
+++ b/agent_docs/workflow.md
@@ -254,6 +254,17 @@ Claude Code exposes two commands:
 | Context window indicator past ~70-80% | `/compact` *now*, don't wait for the auto-trigger |
 | Switching from Plan phase to Implement phase on a non-trivial task | `/clear`, then start Implement with the plan file as the only input |
 
+### Suggested budgets
+
+Rough orientation numbers, **not** caps the agent must enforce:
+
+| Scope | Target |
+|---|---|
+| Single task | ~4k tokens of conversation |
+| Single session | ~30k tokens before `/compact` |
+
+Past ~30k tokens you start seeing the classic symptom: the agent re-suggests a fix you rejected 20 turns earlier. That's the actual cue, not the number. The numbers exist so "should I `/compact` now?" has a deterministic answer instead of vibes.
+
 ### Rules
 
 1. Before `/clear`, make sure the things you need next session are written down — `tasks/todo.md`, `tasks/handoff-*.md`, an open `tasks/specs/<slug>/` folder, or a fresh ADR in `tasks/decisions.md`. The clear is destructive for in-memory state, not for files.


### PR DESCRIPTION
Three issues in one PR — coherent because all four files form a small consistent edit of the session-discipline layer (CLAUDE.md, workflow.md, hooks).

## Closes

- CLA-27 — Adopt 4 missing rules from the "12 rules" CLAUDE.md list
- CLA-28 — Session-start hook: surface uncommitted changes as planning signal
- CLA-29 — Model Selection: reframe rule as role-bound, not name-bound

## Changes

### CLAUDE.md
- **Model Selection** reframed: Planner / Implementer roles instead of Opus / Sonnet names. Names appear only as parenthetical "*(Currently: …)*" examples. (CLA-29)
- New **Model vs Code** section: model for judgment, code for deterministic work. Lists the categories that should never be a prompt (routing, retries, format conversion, schema validation). (CLA-27 gap 1)
- **Scope Discipline** new bullet: "Surface style conflicts, don't blend" — if a file's neighbours contain two valid styles, pick one and ask, never interpolate. (CLA-27 gap 3)
- **Verification** new step 5: "Quantify silent failures" — if the task processes N items, report (processed/failed/skipped) with reasons. The 14%-silently-skipped failure mode. (CLA-27 gap 4)

### agent_docs/workflow.md
- **Context Hygiene** new subsection: "Suggested budgets" — ~4k per task, ~30k per session as orientation numbers. Not caps; gives `/compact` a deterministic trigger alongside the existing symptom-based table. (CLA-27 gap 2)

### .claude/hooks/session-start.sh
- New **Working Tree** block emitted when `git status --porcelain` is non-empty: modified/untracked counts, branch-ahead distance from default branch, and a "plan check" nudge. Silent on clean trees. (CLA-28)

### agent_docs/hooks.md
- session-start row updated to describe the working-tree behavior.

## Test plan

- [x] `bash -n .claude/hooks/session-start.sh` — syntax OK
- [x] Hook dry-run on the dirty branch — emits the Working Tree block with the right counts
- [ ] CI green (markdown lint, link check, template validation, KitBench)
- [ ] Manual smoke: clean tree → block silent; branches with diverged commits → ahead count shows
- [ ] CLAUDE.md renders with all four changes in correct sections

## Out of scope (filed separately)

- Lesson resurfacing — CLA-25 in flight as PR 2
- DFMT pattern spike — CLA-26 in flight as PR 3 (spec doc only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)