### PR TITLE
feat: lesson-resurface helper + bench coverage (s16, s17) + vocabulary clarity

### DIFF
--- a/.claude/skills/lesson-resurface/SKILL.md
+++ b/.claude/skills/lesson-resurface/SKILL.md
@@ -10,6 +10,22 @@ user-invocable: true
 
 Given a short task summary, return a ranked list of _pointers_ to lessons under `tasks/lessons/` (including `_archive/`) whose `applies_to` topic tags overlap with the task. Return paths only — never load, read, or paraphrase lesson bodies into context. The agent decides whether to `Read` each pointer.
 
+## How
+
+The deterministic loop (vocabulary discovery, scoring, supersession resolution, output formatting) lives in `scripts/lesson-resurface.sh`. The skill is a thin pass-through:
+
+```bash
+scripts/lesson-resurface.sh "<task summary>"
+```
+
+Or, if invoking without a CLI argument, set the env var:
+
+```bash
+LESSON_QUERY="<task summary>" scripts/lesson-resurface.sh
+```
+
+Read the helper's stdout. It already emits the exact output format described under `## Output Format` below. **Do not** invent a different format — the helper is the source of truth.
+
 ## Kit Context
 
 Before running this skill, ensure session boot is done:
@@ -40,50 +56,28 @@ Not for:
 - Replacing `/lesson-refresh` — that skill handles lifecycle (keep/update/archive); this skill handles recall
 - Cross-project search — operates within one repo's `tasks/lessons/` tree
 
-## Process
+## What the helper does (for reference)
 
-### Phase 1: Extract topics from the task summary
-
-1. Read the user argument. If no argument, read the active task header in `tasks/todo.md` → `## In Progress` → first `###`.
-2. Reduce the summary to 1–4 canonical topic tags. The vocabulary is whatever `applies_to` values appear across `tasks/lessons/*.md`. Run this once to discover the current vocabulary:
-
-   ```bash
-   grep -h '^applies_to:' tasks/lessons/*.md tasks/lessons/_archive/*.md 2>/dev/null \
-     | sed 's/applies_to: *\[//; s/\].*//; s/,/\n/g' \
-     | tr -d ' '"'"'' | sort -u | grep -v '^$'
-   ```
-
-3. Match the task summary against that vocabulary using substring + word-stem matches. Common topics: `scope-discipline`, `plan-first`, `verification`, `tooling`, `protected-changes`, `dependencies`, `auth`, `migrations`, `testing`, `hooks`, `subagents`, `deploy`, `context-hygiene`, `model-vs-code`.
-4. If the task summary maps to zero canonical topics, return "No matching topics found in `applies_to` vocabulary; no lessons to resurface." and stop.
-
-### Phase 2: Score lessons
-
-1. List `tasks/lessons/*.md` and `tasks/lessons/_archive/*.md` (if the archive exists). Skip `_TEMPLATE.md` and `_index.md`.
-2. For each file, read **only the frontmatter** — do not load the body.
-3. Score:
+1. **Discovers** the canonical `applies_to` vocabulary by scanning frontmatter across `tasks/lessons/*.md` + `tasks/lessons/_archive/*.md`.
+2. **Substring-matches** the task summary (lowercased) against the vocabulary. If zero topics match, exits with "No matching topics" and stops.
+3. **Scores** each lesson:
    - `+3` per topic in `applies_to` that matches an extracted task topic
-   - `+1` per free-form `tags` entry that matches a task topic
+   - `+1` per free-form `tags` entry that matches
    - `−2` if `status: archived`
    - `−1` if `status: superseded`
    - `+1` if `confidence: high`
-4. Drop lessons with score ≤ 0.
+   - Drops lessons with score ≤ 0
+4. **Resolves supersession** — if a matched lesson is `status: superseded` and an active lesson supersedes it AND that active lesson is already in the match list, drops the older one. The agent never reads deprecated rules unintentionally.
+5. **Emits** the top-5 pointers in the format below.
 
-### Phase 3: Resolve supersession chains
+Frontmatter parsing reads only the YAML block between the first pair of `---` markers — body content is never loaded.
 
-For each matched lesson with `status: superseded`:
+## Output Format
 
-1. Find the active lesson whose `supersedes:` list contains this slug.
-2. If the successor is already in the match list, drop the older one.
-3. If the successor is not in the match list, replace the older one with the successor (so the user sees the _current_ rule, not the deprecated one).
-
-This step ensures the agent never wastes time reading a deprecated lesson when a newer one already exists.
-
-### Phase 4: Emit pointers
-
-Return a compact, pointer-only listing. Max 5 entries; if more match, mention the count and stop at 5.
+The helper emits this exact shape (do not reformat downstream):
 
 ```text
-Matched lessons for topics [<extracted topics>]:
+Matched lessons for topics [<comma-separated topics>]:
 
 1. tasks/lessons/_archive/2025-12-01-deps-version-mismatch.md
    applies_to: [dependencies, plan-first]
@@ -106,17 +100,24 @@ If nothing matches above threshold:
 No archived/superseded lessons match topics [<topics>]. Proceed with the Top Rules already in context.
 ```
 
-## Output Format
+If the query itself doesn't intersect the vocabulary:
+
+```text
+No matching topics found in applies_to vocabulary; no lessons to resurface.
+```
+
+## Rules
 
 Always:
 
-- Show paths (max 5)
+- Run `scripts/lesson-resurface.sh` for the deterministic loop — never re-implement scoring in the agent's reasoning
+- Pass the helper's output through verbatim (the format is the contract)
 - Show `applies_to`, `status`, `confidence`, and `title` from frontmatter — these are tiny and useful for the agent's decision to Read
 - Never include `## Issue`, `## Root Cause`, `## Rule`, or `## References` text — those are the body; surfacing them is the agent's decision
 
 Never:
 
-- Print the full lesson body
+- Print full lesson bodies (the helper deliberately doesn't load them)
 - Load lesson bodies into the conversation context
 - Summarize what a lesson says (the title is the summary; for more, the agent reads the file)
 - Modify any file (this skill is read-only)
@@ -125,11 +126,21 @@ Never:
 
 Self-check before relying on results:
 
-1. Pick a known-archived lesson (`status: archived` in its frontmatter)
-2. Construct a task summary that includes one of its `applies_to` topics
-3. Run `/lesson-resurface "<that summary>"`
-4. Confirm the archived lesson appears in the pointer list
-5. Confirm the body of the lesson is NOT in your context (search the conversation for distinctive phrases from the lesson body — should find none)
+```bash
+# 1. Confirm the helper returns the kit's example lesson on a known topic
+./scripts/lesson-resurface.sh "scope-discipline"
+# Expect: 1 result pointing at tasks/lessons/2026-04-15-example-tsconfig.md
+
+# 2. Confirm a vocabulary miss is silent
+./scripts/lesson-resurface.sh "unrelated nonsense words"
+# Expect: "No matching topics found in applies_to vocabulary..."
+
+# 3. Confirm env-var invocation works
+LESSON_QUERY="tooling" ./scripts/lesson-resurface.sh
+# Expect: same result as (1) — both topics in the lesson's applies_to
+```
+
+Regression coverage lives in `bench/scenarios/s17-lesson-resurface-smoke.json`.
 
 ## Pairs With
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ Ask yourself: _"Would a staff engineer approve this?"_
 ## Self-Improvement Loop
 - After ANY correction from the user: add a lesson under `tasks/lessons/` using `tasks/lessons/_TEMPLATE.md` (file name: `<YYYY-MM-DD>-<slug>.md`)
 - Format: frontmatter + Issue → Root Cause → Rule (see `tasks/lessons/_TEMPLATE.md`)
-- Tag the lesson's domain via `applies_to: [topic1, topic2]` (canonical: `scope-discipline`, `plan-first`, `verification`, `tooling`, `dependencies`, `auth`, `migrations`, `testing`, `hooks`, `subagents`, `deploy`, `context-hygiene`, `model-vs-code`). These tags power both `_index.md → Active Rules By Topic` and the resurface flow below.
+- Tag the lesson's domain via `applies_to: [topic1, topic2]`. **Suggested canonical tags** (extend per project as needed): `scope-discipline`, `plan-first`, `verification`, `tooling`, `dependencies`, `auth`, `migrations`, `testing`, `hooks`, `subagents`, `deploy`, `context-hygiene`, `model-vs-code`. These tags power both `_index.md → Active Rules By Topic` and the resurface flow below.
 - Promote critical, recurring rules to `tasks/lessons/_index.md` → `## Top Rules` (set `top_rule: true` in the lesson's frontmatter)
 - Review `tasks/lessons/_index.md` at every session start
 - **Recall dormant lessons on demand.** Archived or superseded lessons are not auto-loaded. When a task touches an area a prior session may have covered, run `/lesson-resurface "<task summary>"` — the skill returns matching lesson _paths_ (with `applies_to` and `title`), never the bodies. The agent decides whether to `Read` each. Pairs with the Goal-Driven Reframing step in `agent_docs/workflow.md`.

--- a/bench/README.md
+++ b/bench/README.md
@@ -37,6 +37,8 @@ Each scenario runs in a **fresh temp directory** — no shared state between sce
 | s13 | `prompt-router-quiet-on-neutral` | Neutral prompt → empty stdout |
 | s14 | `session-start-injects-tier1` | Outputs valid JSON with `additionalContext` referencing `CODEBASE_MAP.md` |
 | s15 | `session-end-writes-audit-line` | Appends one line to `reports/session-audit.log` |
+| s16 | `session-start-working-tree-silent-on-clean` | Working Tree block stays out of `additionalContext` on a fresh-checkout (no `.git`) session — CLA-28 silent-on-clean guarantee |
+| s17 | `lesson-resurface-smoke` | `scripts/lesson-resurface.sh` emits the pointer for an archived lesson matching the query vocabulary AND does NOT leak the lesson body's sentinel phrases — CLA-25 / CLA-32 pointer-only contract |
 
 ## Add a scenario
 
@@ -55,6 +57,7 @@ Drop a JSON file in `bench/scenarios/sNN-<name>.json`:
     "exit_code": 2,
     "stderr_contains": ["BLOCKED"],
     "stdout_contains": [],
+    "stdout_not_contains": [],
     "stdout_empty": false,
     "stderr_not_contains": [],
     "state": [

--- a/bench/scenarios/s16-session-start-working-tree.json
+++ b/bench/scenarios/s16-session-start-working-tree.json
@@ -1,0 +1,17 @@
+{
+  "name": "s16-session-start-working-tree-silent-on-clean",
+  "hook": ".claude/hooks/session-start.sh",
+  "setup_files": {
+    "CODEBASE_MAP.md": "# CODEBASE_MAP\nPresent so session-start has something to point at.\n",
+    "tasks/lessons/_index.md": "# Lesson Index\n\n## Top Rules\n- Example top rule from lessons index.\n"
+  },
+  "payload": {
+    "session_id": "kitbench-s16"
+  },
+  "expect": {
+    "exit_code": 0,
+    "stdout_contains": ["additionalContext", "CODEBASE_MAP.md"],
+    "stdout_not_contains": ["Working tree (uncommitted)"]
+  },
+  "notes": "CLA-28 regression: the Working Tree block must be silent when there is no git context (the temp workdir has no .git dir). Complements s14 — confirms the new block doesn't leak in fresh-checkout sessions. A dirty-tree variant requires `setup_command` runner support and is deferred."
+}

--- a/bench/scenarios/s17-lesson-resurface-smoke.json
+++ b/bench/scenarios/s17-lesson-resurface-smoke.json
@@ -1,0 +1,27 @@
+{
+  "name": "s17-lesson-resurface-smoke",
+  "hook": "scripts/lesson-resurface.sh",
+  "setup_files": {
+    "tasks/lessons/_archive/2026-01-01-fake-deps.md": "---\ntitle: Conflicting peer-dep versions blocked the build\ncreated: 2026-01-01\nupdated: 2026-01-01\ntags: [npm, peer-deps]\nproblem_type: tool\nsource: correction\nconfidence: high\ntop_rule: false\nstatus: archived\nrelated: []\nsupersedes: []\napplies_to: [dependencies]\ncontradicts: []\nrelated_decisions: []\n---\n\n## Issue\n\nXANADU_SENTINEL_BODY_PHRASE — installing react@19 produced peer-dep warnings the resolver couldn't reconcile.\n\n## Root Cause\n\nXANADU_SENTINEL_ROOT — multiple packages locked to react@18 transitively.\n\n## Rule\n\nXANADU_SENTINEL_RULE — always check `npm ls react` for transitive locks before bumping major versions.\n"
+  },
+  "env": {
+    "LESSON_QUERY": "investigating dependencies mismatch"
+  },
+  "expect": {
+    "exit_code": 0,
+    "stdout_contains": [
+      "Matched lessons for topics [dependencies]",
+      "tasks/lessons/_archive/2026-01-01-fake-deps.md",
+      "applies_to: [dependencies]",
+      "status: archived",
+      "title: Conflicting peer-dep versions blocked the build",
+      "These are pointers, not content"
+    ],
+    "stdout_not_contains": [
+      "XANADU_SENTINEL_BODY_PHRASE",
+      "XANADU_SENTINEL_ROOT",
+      "XANADU_SENTINEL_RULE"
+    ]
+  },
+  "notes": "Smoke test for /lesson-resurface (CLA-25 + CLA-32). Pre-populates an archived lesson with three distinctive body sentinels, then asserts the helper emits the pointer + frontmatter fields AND does NOT leak any body sentinel into stdout — the pointer-only contract."
+}

--- a/scripts/lesson-resurface.sh
+++ b/scripts/lesson-resurface.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+#
+# lesson-resurface.sh — deterministic frontmatter scan + scoring for /lesson-resurface
+#
+# Backs the `/lesson-resurface` skill: scans tasks/lessons/ + _archive/, scores
+# lessons by `applies_to` topic overlap with the task summary, resolves
+# supersession chains, prints top-5 pointers (paths + frontmatter only — never
+# bodies). The skill's SKILL.md delegates the deterministic loop here.
+#
+# Usage:
+#   ./scripts/lesson-resurface.sh "<task summary>"
+#   LESSON_QUERY="<task summary>" ./scripts/lesson-resurface.sh
+#
+# Exit codes:
+#   0  matches found OR clean no-match (vocabulary miss)
+#   1  tasks/lessons/ directory does not exist
+#   2  usage error (no query supplied)
+#
+# Output goes to stdout. Format matches the SKILL.md "Phase 4: Emit pointers"
+# example block verbatim.
+#
+
+set -uo pipefail
+
+QUERY="${1:-${LESSON_QUERY:-}}"
+ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+LESSONS_DIR="$ROOT/tasks/lessons"
+ARCHIVE_DIR="$LESSONS_DIR/_archive"
+
+if [ ! -d "$LESSONS_DIR" ]; then
+  echo "lesson-resurface: $LESSONS_DIR does not exist" >&2
+  exit 1
+fi
+
+if [ -z "$QUERY" ]; then
+  echo "lesson-resurface: usage: $0 \"<task summary>\" (or set LESSON_QUERY env)" >&2
+  exit 2
+fi
+
+# Helper: extract a frontmatter field from a lesson file. Reads only the YAML
+# block between the first pair of `---` markers — body content is ignored.
+get_field() {
+  local file="$1" field="$2"
+  awk -v field="$field" '
+    BEGIN { in_fm = 0; count = 0 }
+    /^---$/ {
+      count++
+      if (count == 1) { in_fm = 1; next }
+      if (count == 2) { exit }
+    }
+    in_fm && $0 ~ "^" field ":" {
+      sub("^" field ": *", "")
+      print
+      exit
+    }
+  ' "$file"
+}
+
+# Helper: list all lesson files (active + archive), skipping templates/index.
+list_lessons() {
+  for f in "$LESSONS_DIR"/*.md; do
+    [ -f "$f" ] || continue
+    local base
+    base=$(basename "$f")
+    [ "$base" = "_TEMPLATE.md" ] && continue
+    [ "$base" = "_index.md" ] && continue
+    printf '%s\n' "$f"
+  done
+  if [ -d "$ARCHIVE_DIR" ]; then
+    for f in "$ARCHIVE_DIR"/*.md; do
+      [ -f "$f" ] || continue
+      printf '%s\n' "$f"
+    done
+  fi
+}
+
+# Phase 1: discover canonical applies_to vocabulary from all lessons.
+VOCAB=""
+while IFS= read -r f; do
+  raw=$(get_field "$f" "applies_to")
+  [ -z "$raw" ] && continue
+  cleaned=$(printf '%s' "$raw" | tr -d "[]\"'" | tr ',' '\n' | tr -d ' ')
+  VOCAB="${VOCAB}${cleaned}"$'\n'
+done < <(list_lessons)
+VOCAB=$(printf '%s' "$VOCAB" | grep -v '^$' | sort -u)
+
+# Phase 1: match the query against vocabulary (substring + lower-case).
+QUERY_LOWER=$(printf '%s' "$QUERY" | tr '[:upper:]' '[:lower:]')
+MATCHED_TOPICS=""
+while IFS= read -r topic; do
+  [ -z "$topic" ] && continue
+  if printf '%s' "$QUERY_LOWER" | grep -q -- "$topic"; then
+    MATCHED_TOPICS="${MATCHED_TOPICS}${topic}"$'\n'
+  fi
+done <<<"$VOCAB"
+MATCHED_TOPICS=$(printf '%s' "$MATCHED_TOPICS" | grep -v '^$' || true)
+
+if [ -z "$MATCHED_TOPICS" ]; then
+  echo "No matching topics found in applies_to vocabulary; no lessons to resurface."
+  exit 0
+fi
+
+# Build a single space-separated topic list for grep ops.
+TOPICS_LIST=$(printf '%s' "$MATCHED_TOPICS" | tr '\n' ' ')
+
+# Phase 2: score every lesson. Output rows: score<TAB>path<TAB>applies_to<TAB>status<TAB>confidence<TAB>title
+SCORED=""
+while IFS= read -r f; do
+  applies_to=$(get_field "$f" "applies_to")
+  tags=$(get_field "$f" "tags")
+  status=$(get_field "$f" "status")
+  confidence=$(get_field "$f" "confidence")
+  title=$(get_field "$f" "title")
+  score=0
+
+  applies_clean=" $(printf '%s' "$applies_to" | tr -d "[]\"'" | tr ',' ' ') "
+  tags_clean=" $(printf '%s' "$tags" | tr -d "[]\"'" | tr ',' ' ') "
+
+  for topic in $TOPICS_LIST; do
+    if printf '%s' "$applies_clean" | grep -wq -- "$topic"; then
+      score=$((score + 3))
+    fi
+    if printf '%s' "$tags_clean" | grep -wq -- "$topic"; then
+      score=$((score + 1))
+    fi
+  done
+
+  case "$status" in
+    archived) score=$((score - 2)) ;;
+    superseded) score=$((score - 1)) ;;
+  esac
+
+  [ "$confidence" = "high" ] && score=$((score + 1))
+
+  if [ "$score" -gt 0 ]; then
+    SCORED="${SCORED}${score}"$'\t'"${f}"$'\t'"${applies_to}"$'\t'"${status}"$'\t'"${confidence}"$'\t'"${title}"$'\n'
+  fi
+done < <(list_lessons)
+
+# Sort by score descending (tab-separated, numeric on field 1).
+SCORED=$(printf '%s' "$SCORED" | grep -v '^$' | sort -t$'\t' -k1,1 -rn)
+
+if [ -z "$SCORED" ]; then
+  TOPICS_CSV=$(printf '%s' "$MATCHED_TOPICS" | tr '\n' ',' | sed 's/,$//; s/,/, /g')
+  printf 'No archived/superseded lessons match topics [%s]. Proceed with the Top Rules already in context.\n' "$TOPICS_CSV"
+  exit 0
+fi
+
+# Phase 3: resolve supersession chains. Drop a superseded lesson if some active
+# lesson supersedes it AND that active lesson is already in our match list.
+FILTERED=""
+while IFS=$'\t' read -r score path applies_to status confidence title; do
+  [ -z "$path" ] && continue
+  drop=0
+  if [ "$status" = "superseded" ]; then
+    base=$(basename "$path" .md)
+    while IFS= read -r active; do
+      active_status=$(get_field "$active" "status")
+      [ "$active_status" = "active" ] || continue
+      supersedes=$(get_field "$active" "supersedes" | tr -d "[]\"'" | tr ',' ' ')
+      if printf ' %s ' "$supersedes" | grep -wq -- "$base"; then
+        active_base=$(basename "$active" .md)
+        # Is the successor already in match list?
+        if printf '%s' "$SCORED" | grep -q -- "${active_base}\.md"$'\t'; then
+          drop=1
+          break
+        fi
+      fi
+    done < <(list_lessons)
+  fi
+  if [ "$drop" -eq 0 ]; then
+    FILTERED="${FILTERED}${score}"$'\t'"${path}"$'\t'"${applies_to}"$'\t'"${status}"$'\t'"${confidence}"$'\t'"${title}"$'\n'
+  fi
+done <<<"$SCORED"
+
+# Phase 4: emit pointers (top 5).
+TOPICS_CSV=$(printf '%s' "$MATCHED_TOPICS" | tr '\n' ',' | sed 's/,$//; s/,/, /g')
+echo "Matched lessons for topics [$TOPICS_CSV]:"
+echo ""
+
+COUNT=0
+TOTAL=0
+TMP_FILTERED=$(printf '%s' "$FILTERED" | grep -v '^$' || true)
+TOTAL=$(printf '%s\n' "$TMP_FILTERED" | grep -c '^' 2>/dev/null || echo 0)
+# grep -c with empty input on macOS yields blank; coerce.
+[ -z "$TOTAL" ] && TOTAL=0
+
+while IFS=$'\t' read -r score path applies_to status confidence title; do
+  [ -z "$path" ] && continue
+  COUNT=$((COUNT + 1))
+  [ "$COUNT" -gt 5 ] && break
+
+  rel_path="${path#$ROOT/}"
+  echo "$COUNT. $rel_path"
+  echo "   applies_to: $applies_to"
+  echo "   status: $status | confidence: $confidence"
+  echo "   title: $title"
+  echo ""
+done <<<"$TMP_FILTERED"
+
+if [ "$TOTAL" -gt 5 ]; then
+  echo "… $((TOTAL - 5)) more matched (not shown)."
+  echo ""
+fi
+
+echo "These are pointers, not content. Read any that look relevant before proceeding; the bodies were intentionally NOT loaded."
+exit 0

--- a/scripts/run-bench.sh
+++ b/scripts/run-bench.sh
@@ -183,6 +183,11 @@ def run_scenario(scenario):
             if needle not in (proc.stdout or ""):
                 failures.append(f"stdout missing substring {needle!r}")
 
+        # stdout_not_contains
+        for needle in scenario.get("expect", {}).get("stdout_not_contains", []):
+            if needle in (proc.stdout or ""):
+                failures.append(f"stdout unexpectedly contains {needle!r}")
+
         # stdout_empty
         if scenario.get("expect", {}).get("stdout_empty", False):
             if (proc.stdout or "").strip() != "":


### PR DESCRIPTION
## Closes

- CLA-30 — CLAUDE.md vocabulary: frame canonical tag list as suggestion, not state
- CLA-31 — bench: scenarios for working-tree signal and lesson-resurface
- CLA-32 — scripts/lesson-resurface.sh — deterministic helper behind the skill

## Summary

Three follow-ups from the post-PR-139 self-review, bundled into one PR because they all touch the lesson-resurface surface and are coherent as a single review unit.

### CLA-30 — Vocabulary clarity (1-line CLAUDE.md edit)

\`applies_to\` tag list reframed from "canonical:" to "**Suggested canonical tags** (extend per project as needed):". The kit ships exactly one example lesson today using 2 tags; the 13-item list is aspirational. New users no longer read it as the active taxonomy.

### CLA-32 — \`scripts/lesson-resurface.sh\` helper

Backs \`/lesson-resurface\`. Pure bash 3.2 (no associative arrays, no python3). \`awk\`-based frontmatter parser reads only the YAML block between the first pair of \`---\` markers — bodies are never touched. Implements the full pipeline documented in SKILL.md:

- vocabulary discovery from \`applies_to\` across all lessons
- substring matching (lowercased query vs vocabulary)
- scoring: +3 \`applies_to\`, +1 \`tags\`, −2 archived, −1 superseded, +1 high-confidence
- supersession-chain resolution
- top-5 pointer emission

Two invocation paths:
\`\`\`bash
./scripts/lesson-resurface.sh "scope-discipline"
LESSON_QUERY="scope-discipline" ./scripts/lesson-resurface.sh
\`\`\`

SKILL.md thinned to delegate the deterministic loop to the helper (output is the contract).

### CLA-31 — bench scenarios s16 + s17

- **s16** \`session-start-working-tree-silent-on-clean\`: asserts the Working Tree block doesn't leak into \`additionalContext\` on a fresh-checkout session (no \`.git\`). Covers CLA-28's silent-on-clean guarantee.
- **s17** \`lesson-resurface-smoke\`: pre-populates an archived lesson with three distinctive body sentinel phrases (\`XANADU_SENTINEL_*\`), runs the helper, asserts the pointer + frontmatter fields appear in stdout AND none of the body sentinels do. End-to-end check of the pointer-only contract.

\`scripts/run-bench.sh\` gains a \`stdout_not_contains\` assertion (5 lines, symmetric with the existing \`stderr_not_contains\`). Required for s17.

\`bench/README.md\` updated with both new scenarios and the new assertion key.

## Test plan

- [x] \`bash -n scripts/lesson-resurface.sh\` — syntax OK
- [x] \`scripts/lesson-resurface.sh "scope-discipline"\` returns the example tsconfig lesson
- [x] \`scripts/lesson-resurface.sh "nonsense xyz"\` returns "No matching topics" + exit 0
- [x] \`LESSON_QUERY="tooling" scripts/lesson-resurface.sh\` works
- [x] \`scripts/run-bench.sh\` — 17/17 pass (15 existing + 2 new), no flakiness in repeated runs
- [ ] CI green

## Deferred (filed as new work, not this PR)

- **Dirty-tree bench variant** for working-tree (modified+untracked, branch-ahead). Requires \`setup_command\` runner support — out of scope here. CLA-31 acceptance criteria 1 covered with the silent-on-clean variant; the harder variants would be a separate spike.

## Out of scope

- Auto-promotion of suggested tags to \`tasks/lessons/_TEMPLATE.md\` defaults
- Vector / embedding match in the helper (intentional design)
- Cross-repo lesson search

🤖 Generated with [Claude Code](https://claude.com/claude-code)