### PR TITLE
feat(skills): /note — mid-session across-compaction memory (DFMT spike build)

### DIFF
--- a/.claude/hooks/journal-fold.sh
+++ b/.claude/hooks/journal-fold.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# journal-fold.sh — SessionEnd hook
+#
+# After a session ends, decide what to do with .hook-state/session-journal.md
+# (populated by the `/note` skill mid-session):
+#
+#   - If it contains [finding] or [decision] entries → fold into
+#     tasks/handoff-<session-id>.md so the next session can pick up
+#   - If it contains only [summary] entries → discard (transient breadcrumbs)
+#   - Always: remove the journal file so the next session starts clean
+#
+# Runs alongside session-end.sh (the scorecard hook); both are wired under
+# SessionEnd in .claude/settings.json. Reads stdin for session_id but does
+# not require any payload.
+#
+# Always exits 0 (never blocks). Silent when there is no journal.
+#
+
+set -euo pipefail
+
+INPUT=$(cat)
+ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
+JOURNAL="$ROOT/.hook-state/session-journal.md"
+
+# No journal? Silent exit.
+[ -f "$JOURNAL" ] || exit 0
+
+# Empty journal? Clean up and exit.
+if [ ! -s "$JOURNAL" ]; then
+  rm -f "$JOURNAL"
+  exit 0
+fi
+
+# Count entries by tag. `grep -c` returns "" on no match in some envs; coerce.
+FINDINGS=$(grep -c '\[finding\]' "$JOURNAL" 2>/dev/null || true)
+DECISIONS=$(grep -c '\[decision\]' "$JOURNAL" 2>/dev/null || true)
+SUMMARIES=$(grep -c '\[summary\]' "$JOURNAL" 2>/dev/null || true)
+FINDINGS=${FINDINGS:-0}
+DECISIONS=${DECISIONS:-0}
+SUMMARIES=${SUMMARIES:-0}
+
+# If only summaries (no findings/decisions), discard.
+if [ "$FINDINGS" -eq 0 ] && [ "$DECISIONS" -eq 0 ]; then
+  rm -f "$JOURNAL"
+  exit 0
+fi
+
+# Extract session_id from stdin (best effort, falls back to a timestamp slug).
+SESSION_ID=""
+if command -v python3 >/dev/null 2>&1; then
+  SESSION_ID=$(printf '%s' "$INPUT" | python3 -c "import sys,json
+try:
+    d = json.load(sys.stdin)
+    sys.stdout.write(d.get('session_id', '') or '')
+except Exception:
+    pass" 2>/dev/null || true)
+fi
+if [ -z "$SESSION_ID" ]; then
+  SESSION_ID=$(date -u +%Y%m%d-%H%M%S)
+fi
+
+# Fold journal contents into tasks/handoff-<session-id>.md (append if exists).
+HANDOFF="$ROOT/tasks/handoff-${SESSION_ID}.md"
+mkdir -p "$ROOT/tasks"
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+{
+  echo ""
+  echo "## Journal — folded from session-journal.md on $NOW"
+  echo ""
+  cat "$JOURNAL"
+  echo ""
+  echo "**Counts:** findings: $FINDINGS · decisions: $DECISIONS · summaries: $SUMMARIES"
+  echo ""
+} >> "$HANDOFF"
+
+rm -f "$JOURNAL"
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -146,6 +146,10 @@
           {
             "type": "command",
             "command": ".claude/hooks/session-end.sh"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/journal-fold.sh"
           }
         ]
       }

--- a/.claude/skills/note/SKILL.md
+++ b/.claude/skills/note/SKILL.md
@@ -83,7 +83,7 @@ Noted: 2026-05-22T19:30:11Z [finding] qdrant client treats null filter as ANY
 → .hook-state/session-journal.md (3 entries)
 ```
 
-The appended line in the journal file is exactly the first stdout line minus the `Noted: ` prefix.
+The appended line in the journal file is exactly the first stdout line minus the `Noted:` prefix.
 
 ## Rules
 

--- a/.claude/skills/note/SKILL.md
+++ b/.claude/skills/note/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: note
+description: Append a timestamped mid-session note to the session journal — finding/decision/summary tags for across-compaction memory. The journal is folded to handoff at session end by .claude/hooks/journal-fold.sh.
+user-invocable: true
+---
+
+# Note
+
+## Core Rule
+
+Append `<ISO8601> [<tag>] <text>` to `.hook-state/session-journal.md`. Tag MUST be one of `finding`, `decision`, `summary`. The journal is transient (gitignored, same lifetime as other `.hook-state/*`) but durable across `/compact` within the same session.
+
+## How
+
+```bash
+scripts/note.sh <tag> <text>
+```
+
+The helper validates the tag, ensures the `.hook-state/` dir + `.gitignore` exist, appends a timestamped line, and prints a confirmation with the new entry count.
+
+## Tags
+
+Three only — pick exactly one per note. Don't invent new tags; extend the vocabulary only after a recurring pattern shows up across multiple sessions.
+
+| Tag | Use for |
+|---|---|
+| `finding` | A non-obvious technical observation worth carrying past `/compact` (e.g. "qdrant treats null filter as ANY") |
+| `decision` | A choice made mid-session that may later become an ADR in `tasks/decisions.md` (e.g. "going with Drizzle over Prisma") |
+| `summary` | A "what state are we in right now" checkpoint, useful before a tool-heavy block (e.g. "auth wired, billing endpoints next") |
+
+The lifecycle differs by tag:
+
+- `finding` / `decision` → folded into `tasks/handoff-<session-id>.md` at session end (durable)
+- `summary` → discarded at session end if no findings/decisions are present (transient breadcrumb)
+
+## When to Use
+
+When you discover something that:
+
+- The session needs to remember after `/compact` (compaction wipes mid-session findings from the conversation)
+- Doesn't yet warrant a lesson (correction-driven) or ADR (architectural decision)
+- Is too small to commit as a code change
+
+Examples:
+
+```bash
+scripts/note.sh finding "qdrant client treats null filter as ANY, not none"
+scripts/note.sh decision "going with Drizzle over Prisma — see ADR-014 draft"
+scripts/note.sh summary "auth wired, billing endpoints next"
+```
+
+Not for:
+
+- Code — use `Edit` / `Write`
+- Across-session memory — use `tasks/lessons/` (correction-driven) or `tasks/decisions.md` (ADRs)
+- Long-form content — the journal is one line per entry; for paragraphs use a real file
+- Replacing the lesson flow — lessons come from user corrections, not agent self-discovery
+
+## Lifecycle
+
+```text
+mid-session (you call /note)
+  └─► .hook-state/session-journal.md (append)
+
+/compact happens
+  └─► CLAUDE.md → After Compaction tells you to re-read the journal
+
+session ends
+  └─► .claude/hooks/journal-fold.sh:
+        ├─ findings or decisions present? → fold to tasks/handoff-<session-id>.md
+        ├─ only summaries? → discard
+        └─ always: rm .hook-state/session-journal.md
+```
+
+The journal never persists across sessions; durable content lands in handoff.
+
+## Output Format
+
+`scripts/note.sh` prints to stdout:
+
+```text
+Noted: 2026-05-22T19:30:11Z [finding] qdrant client treats null filter as ANY
+→ .hook-state/session-journal.md (3 entries)
+```
+
+The appended line in the journal file is exactly the first stdout line minus the `Noted: ` prefix.
+
+## Rules
+
+Always:
+
+- Use `scripts/note.sh` — never write to the journal file directly (the helper guarantees timestamp format and tag validation)
+- Pick a tag explicitly — let the agent's classifier earn its place; never `/note auto`
+- Keep notes one-line — multiple notes if you need to record multiple things
+
+Never:
+
+- Use this skill for content that should be committed (code, ADRs, lessons)
+- Read other agents' notes (this is a per-session, local journal — sharing happens via handoff)
+- Bypass the helper script — direct `echo >>` skips timestamp + gitignore guards
+
+## Smoke Test
+
+```bash
+# 1. Write a finding
+./scripts/note.sh finding "test observation"
+cat .hook-state/session-journal.md
+# Expect: one ISO8601 line with [finding] test observation
+
+# 2. Add a decision
+./scripts/note.sh decision "test choice"
+wc -l .hook-state/session-journal.md
+# Expect: 2
+
+# 3. Invalid tag is rejected
+./scripts/note.sh nonsense "ignored"
+# Expect: exit 2, stderr: "invalid tag 'nonsense'"
+
+# 4. Missing args rejected
+./scripts/note.sh finding
+# Expect: exit 2, usage message
+```
+
+End-to-end roundtrip (skill write → fold at session end) is covered in `bench/scenarios/s18-note-journal-fold.json`.
+
+## Pairs With
+
+- **CLAUDE.md → After Compaction** — instructs re-read of the journal post-compaction
+- **`.claude/hooks/journal-fold.sh`** — SessionEnd companion that consumes the journal
+- **`tasks/handoff-*.md`** — auto-populated by `journal-fold.sh` from this skill's output
+- **`tasks/lessons/`** — across-session memory (different time-scale; a `finding` may later turn into a lesson if it recurs)
+
+## Out of Scope
+
+- Tag vocabulary beyond `finding`/`decision`/`summary` — extend later if patterns emerge
+- LLM-classified or auto-tagged notes — agent picks the tag explicitly
+- Auto-promotion of `finding` entries to `tasks/lessons/` — that's a separate, deliberate lifecycle (`/lesson-refresh` plus user judgment)
+- Cross-session journal merging — every session starts with an empty journal
+- Reading journal contents during write (this skill writes only; reading happens in `## After Compaction`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,8 @@ Context compaction can happen mid-session. When you detect a compaction (convers
 2. Re-read the specific files you were actively editing
 3. Re-read any contract file (`tasks/*_CONTRACT.md`) if one was active
 4. Re-read `tasks/lessons/_index.md` → `## Top Rules` section only
-5. Do NOT continue coding until you've re-established context
+5. Re-read `.hook-state/session-journal.md` if it exists — pre-compaction findings the agent intentionally journaled with the `/note` skill (`finding` / `decision` / `summary` lines). Lives only inside the current session; folded to handoff at session end.
+6. Do NOT continue coding until you've re-established context
 
 This is the single most important rule for long sessions.
 

--- a/agent_docs/hooks.md
+++ b/agent_docs/hooks.md
@@ -53,6 +53,7 @@ Philosophy: **Use prompts for guidance. Use hooks for behavior that should run e
 | Hook | File | What it does |
 |------|------|-------------|
 | **session-end** | `.claude/hooks/session-end.sh` | Appends a JSON audit line to `reports/session-audit.log` with session id, exit reason, and last quality-gate status. |
+| **journal-fold** | `.claude/hooks/journal-fold.sh` | Consumes `.hook-state/session-journal.md` (populated mid-session by the `/note` skill). If `[finding]` or `[decision]` entries are present, folds them into `tasks/handoff-<session-id>.md`. If only `[summary]` entries, discards. Always removes the journal so the next session starts clean. Silent when no journal exists. |
 
 ### Optional (installed but not enabled by default)
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -39,6 +39,7 @@ Each scenario runs in a **fresh temp directory** — no shared state between sce
 | s15 | `session-end-writes-audit-line` | Appends one line to `reports/session-audit.log` |
 | s16 | `session-start-working-tree-silent-on-clean` | Working Tree block stays out of `additionalContext` on a fresh-checkout (no `.git`) session — CLA-28 silent-on-clean guarantee |
 | s17 | `lesson-resurface-smoke` | `scripts/lesson-resurface.sh` emits the pointer for an archived lesson matching the query vocabulary AND does NOT leak the lesson body's sentinel phrases — CLA-25 / CLA-32 pointer-only contract |
+| s18 | `journal-fold-creates-handoff` | `.claude/hooks/journal-fold.sh` folds a `/note`-populated `.hook-state/session-journal.md` (with findings + decisions) into `tasks/handoff-<session-id>.md` at session end — CLA-33 |
 
 ## Add a scenario
 

--- a/bench/scenarios/s18-journal-fold-creates-handoff.json
+++ b/bench/scenarios/s18-journal-fold-creates-handoff.json
@@ -1,0 +1,15 @@
+{
+  "name": "s18-journal-fold-creates-handoff",
+  "hook": ".claude/hooks/journal-fold.sh",
+  "setup_files": {
+    ".hook-state/session-journal.md": "2026-05-22T10:00:00Z [finding] qdrant client treats null filter as ANY, not none\n2026-05-22T10:05:00Z [decision] going with Drizzle over Prisma — see ADR-014 draft\n2026-05-22T10:10:00Z [summary] auth wired, billing endpoints next\n"
+  },
+  "payload": {
+    "session_id": "kitbench-s18"
+  },
+  "expect": {
+    "exit_code": 0,
+    "file_grew": ["tasks/handoff-kitbench-s18.md"]
+  },
+  "notes": "CLA-33 regression: a journal with findings/decisions/summaries folds to tasks/handoff-<session-id>.md at session end. Asserts the handoff file is created with content. Summary-only discard path is exercised in the manual smoke test in scripts/note.sh's SKILL.md (would require `file_gone` assertion to test here)."
+}

--- a/scripts/note.sh
+++ b/scripts/note.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# note.sh — append a tagged journal entry for mid-session across-compaction memory.
+#
+# Backs the `/note` skill. Writes one timestamped line to
+# `.hook-state/session-journal.md` and reports the new entry count.
+# The journal is transient (gitignored, same lifetime as other .hook-state/*)
+# and is consumed by `.claude/hooks/journal-fold.sh` at session end.
+#
+# Usage:
+#   ./scripts/note.sh <tag> <text>
+#
+# Tag must be one of: finding, decision, summary.
+#
+# Exit codes:
+#   0  appended successfully
+#   2  usage error (missing args or invalid tag)
+#
+
+set -euo pipefail
+
+TAG="${1:-}"
+shift || true
+TEXT="${*:-}"
+
+if [ -z "$TAG" ] || [ -z "$TEXT" ]; then
+  echo "note: usage: $0 <tag> <text>" >&2
+  echo "      tag must be one of: finding, decision, summary" >&2
+  exit 2
+fi
+
+case "$TAG" in
+  finding|decision|summary) ;;
+  *)
+    echo "note: invalid tag '$TAG'; must be one of: finding, decision, summary" >&2
+    exit 2
+    ;;
+esac
+
+ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+STATE_DIR="$ROOT/.hook-state"
+mkdir -p "$STATE_DIR"
+[ -f "$STATE_DIR/.gitignore" ] || printf '*\n!.gitignore\n' >"$STATE_DIR/.gitignore"
+
+JOURNAL="$STATE_DIR/session-journal.md"
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+LINE="$NOW [$TAG] $TEXT"
+printf '%s\n' "$LINE" >> "$JOURNAL"
+
+COUNT=$(wc -l < "$JOURNAL" | tr -d ' ')
+echo "Noted: $LINE"
+echo "→ .hook-state/session-journal.md ($COUNT entries)"
+exit 0


### PR DESCRIPTION
## Closes

- CLA-33 — `/note` skill: mid-session across-compaction memory (DFMT spike build)

## Summary

Implements the **BUILD DIFFERENTLY** path the DFMT spike (CLA-26 / PR #140) recommended. Closes the across-compaction memory gap kit had between its across-session primitives (`tasks/lessons/`, `tasks/decisions.md`, `tasks/handoff-*.md`) and the mid-session conversation context that `/compact` wipes.

## The lifecycle

```text
mid-session: agent calls /note
  └─► scripts/note.sh <tag> <text>
       └─► appends "<ISO8601> [<tag>] <text>" to .hook-state/session-journal.md

/compact happens
  └─► CLAUDE.md → After Compaction step 5 tells agent to re-read the journal

session ends
  └─► .claude/hooks/journal-fold.sh:
        ├─ findings or decisions present? → fold to tasks/handoff-<session-id>.md
        ├─ only summaries? → discard (transient breadcrumbs)
        └─ always: rm .hook-state/session-journal.md
```

## Tags (closed vocabulary)

| Tag | Purpose | Lifecycle |
|---|---|---|
| `finding` | Non-obvious technical observation worth carrying past `/compact` | Folded to handoff |
| `decision` | Choice made mid-session that may later become an ADR | Folded to handoff |
| `summary` | "What state are we in right now" checkpoint | Discarded at session end if alone |

Differential lifecycle is deliberate — summaries are breadcrumbs, not durable findings.

## What's in the diff

- `scripts/note.sh` — helper script (47 lines bash, validates tag, atomic append)
- `.claude/skills/note/SKILL.md` — skill prose that points at the helper
- `.claude/hooks/journal-fold.sh` — new SessionEnd hook (87 lines bash, fold-or-discard logic)
- `.claude/settings.json` — wires `journal-fold.sh` into the SessionEnd hook array after `session-end.sh`
- `CLAUDE.md → After Compaction` — adds step 5 (re-read journal) and renumbers
- `agent_docs/hooks.md` — documents the new hook in the SessionEnd table
- `bench/scenarios/s18-journal-fold-creates-handoff.json` — regression for findings/decisions → handoff
- `bench/README.md` — registers s18

## Test plan

- [x] `bash -n scripts/note.sh && bash -n .claude/hooks/journal-fold.sh` — both pass
- [x] `.claude/settings.json` is valid JSON (python3 `json.load`)
- [x] Manual roundtrip in a temp dir: write finding+decision+summary, run journal-fold with session_id "test-session-xyz", confirm `tasks/handoff-test-session-xyz.md` exists with all three entries and the journal file is removed
- [x] Manual discard path: write summary only, run journal-fold, confirm journal removed and no handoff file created
- [x] Invalid tag (`nonsense`) is rejected with exit 2
- [x] `scripts/run-bench.sh` → 18/18 pass (15 pre-existing + s16/s17 from PR #141 + new s18)
- [ ] CI green

## Deferred (not blocking)

- **`file_gone` bench assertion** — would let s18-companion test the summary-only discard path inside the bench harness. Out of scope for this PR; the manual smoke test in the SKILL.md covers it for now.
- **Auto-promotion of `[finding]` entries to `tasks/lessons/`** — separate lifecycle (the lesson flow is user-correction-driven; agent self-discovery via `/note` doesn't auto-promote).

## Out of scope

- Tag vocabulary beyond `finding`/`decision`/`summary` — extend later if recurring patterns demand
- LLM-classified or auto-tagged notes — agent picks the tag explicitly per call
- Cross-session journal merging — every session starts with an empty journal by design

🤖 Generated with [Claude Code](https://claude.com/claude-code)