### PR TITLE
docs(claude-md): note subdirectory CLAUDE.md auto-loading [CLA-35]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,4 +181,5 @@ Read only what's relevant to the current task:
 ## Project Overlay
 If `CLAUDE.project.md` exists, read it after this file. Project-specific rules override kit defaults.
 If `agent_docs/project/` contains docs, load them when relevant to the current task.
+Subdirectory `CLAUDE.md` files (e.g. `src/api/CLAUDE.md`, `tests/CLAUDE.md`) are auto-loaded by Claude Code when the agent enters that directory. Use them for **module-local** rules that the root CLAUDE.md shouldn't carry (e.g. API-specific naming, test-specific patterns). Root CLAUDE.md still loads first; subdirectory files extend, not replace.
 Project hooks in `.claude/hooks/project/` are configured separately in settings and are never modified by kit upgrades.


### PR DESCRIPTION
## Summary
- Adds one bullet under `CLAUDE.md → ## Project Overlay` documenting that Claude Code auto-loads subdirectory `CLAUDE.md` files (e.g. `src/api/CLAUDE.md`) when the agent enters that directory.
- Pure documentation — no code, hook, or skill changes.

## Why
This is native Claude Code behaviour (see [Anthropic memory docs](https://docs.claude.com/en/docs/claude-code/memory)) but kit's own `CLAUDE.md` never said so. Multi-module repo users would otherwise bloat the root file.

## Test plan
- [x] `CLAUDE.md → Project Overlay` has the new bullet
- [x] No other files touched
- [ ] Reviewer skim: tone matches surrounding bullets

Closes CLA-35

🤖 Generated with [Claude Code](https://claude.com/claude-code)