### PR TITLE
docs: RELEASING.md runbook — npm 2FA + Granular token + EOTP recovery [CLA-36]

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Or as a [Claude Code plugin](https://code.claude.com/docs/en/plugins):
 
 Then fill in `CODEBASE_MAP.md` with your project's details and start a Claude Code session.
 
+> **Maintainers:** see [`RELEASING.md`](./RELEASING.md) for the release flow (npm token setup, 2FA mode requirement, EOTP recovery).
+
 ### Installer options
 
 | Flag | Description |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,57 @@
+# RELEASING
+
+How `@tansuasici/claude-code-kit` ships, plus the failure modes the npm side will surface if it isn't set up right. Read this before cutting a release.
+
+## 1. Normal release
+
+release-please opens a PR titled `chore(main): release X.Y.Z` whenever there are unreleased `feat:` / `fix:` commits on `main`. Merge that PR. The release workflow then tags, publishes to npm, and updates the plugin marketplace automatically.
+
+## 2. NPM_TOKEN setup (one-time)
+
+Create a **Granular Access Token** at https://www.npmjs.com/settings/\<user\>/tokens:
+
+- Scope: `@tansuasici/claude-code-kit`
+- Permissions: Read + Write
+- Expiry: 1 year
+
+Paste it into the `NPM_TOKEN` repo secret via GitHub UI → Settings → Secrets and variables → Actions. Never pass it through CLI history, chat, or screenshots. Set a calendar reminder ~11 months out to rotate.
+
+## 3. 2FA mode requirement (the lesson)
+
+Set the npm account 2FA mode to **`Authorization only`**, not `Authorization and writes`. Check at https://www.npmjs.com/settings/\<user\>/profile. With `Authorization and writes`, every `npm publish` requires an interactive OTP — CI will fail with `EOTP` regardless of token type or validity. This is an account-level setting; the repo cannot configure it.
+
+## 4. EOTP recovery (manual publish fallback)
+
+When CI publish fails with `EOTP`:
+
+```bash
+git fetch --tags
+git checkout vX.Y.Z
+npm login                                       # browser auth
+npm publish --access public                     # OTP prompt at terminal
+git checkout main
+npm view @tansuasici/claude-code-kit version    # verify
+```
+
+Then fix the underlying cause (almost always §3 above) so the next release doesn't need this step.
+
+## 5. Token rotation hygiene
+
+If a token is ever exposed (chat, logs, screenshots, terminal scrollback), revoke it immediately at https://www.npmjs.com/settings/\<user\>/tokens. Generate a fresh one. Update the `NPM_TOKEN` GitHub Secret. Do not reuse a token that may have been compromised, even if it "looks fine."
+
+## 6. Plugin marketplace publication
+
+`.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` versions stay in sync with the npm package via release-please — there is no separate publish step. Users install the plugin with:
+
+```text
+/plugin marketplace add tansuasici/claude-code-kit
+/plugin install claude-code-kit@claude-code-kit
+```
+
+---
+
+## Sources
+
+- npm Granular Access Tokens — https://docs.npmjs.com/about-access-tokens
+- npm Two-Factor Authentication — https://docs.npmjs.com/about-two-factor-authentication
+- Claude Code plugins — https://code.claude.com/docs/en/plugins

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,7 +8,7 @@ release-please opens a PR titled `chore(main): release X.Y.Z` whenever there are
 
 ## 2. NPM_TOKEN setup (one-time)
 
-Create a **Granular Access Token** at https://www.npmjs.com/settings/\<user\>/tokens:
+Create a **Granular Access Token** at `https://www.npmjs.com/settings/<user>/tokens`:
 
 - Scope: `@tansuasici/claude-code-kit`
 - Permissions: Read + Write
@@ -18,7 +18,7 @@ Paste it into the `NPM_TOKEN` repo secret via GitHub UI → Settings → Secrets
 
 ## 3. 2FA mode requirement (the lesson)
 
-Set the npm account 2FA mode to **`Authorization only`**, not `Authorization and writes`. Check at https://www.npmjs.com/settings/\<user\>/profile. With `Authorization and writes`, every `npm publish` requires an interactive OTP — CI will fail with `EOTP` regardless of token type or validity. This is an account-level setting; the repo cannot configure it.
+Set the npm account 2FA mode to **`Authorization only`**, not `Authorization and writes`. Check at `https://www.npmjs.com/settings/<user>/profile`. With `Authorization and writes`, every `npm publish` requires an interactive OTP — CI will fail with `EOTP` regardless of token type or validity. This is an account-level setting; the repo cannot configure it.
 
 ## 4. EOTP recovery (manual publish fallback)
 
@@ -37,7 +37,7 @@ Then fix the underlying cause (almost always §3 above) so the next release does
 
 ## 5. Token rotation hygiene
 
-If a token is ever exposed (chat, logs, screenshots, terminal scrollback), revoke it immediately at https://www.npmjs.com/settings/\<user\>/tokens. Generate a fresh one. Update the `NPM_TOKEN` GitHub Secret. Do not reuse a token that may have been compromised, even if it "looks fine."
+If a token is ever exposed (chat, logs, screenshots, terminal scrollback), revoke it immediately at `https://www.npmjs.com/settings/<user>/tokens`. Generate a fresh one. Update the `NPM_TOKEN` GitHub Secret. Do not reuse a token that may have been compromised, even if it "looks fine."
 
 ## 6. Plugin marketplace publication
 
@@ -52,6 +52,6 @@ If a token is ever exposed (chat, logs, screenshots, terminal scrollback), revok
 
 ## Sources
 
-- npm Granular Access Tokens — https://docs.npmjs.com/about-access-tokens
-- npm Two-Factor Authentication — https://docs.npmjs.com/about-two-factor-authentication
-- Claude Code plugins — https://code.claude.com/docs/en/plugins
+- npm Granular Access Tokens — <https://docs.npmjs.com/about-access-tokens>
+- npm Two-Factor Authentication — <https://docs.npmjs.com/about-two-factor-authentication>
+- Claude Code plugins — <https://code.claude.com/docs/en/plugins>


### PR DESCRIPTION
## Summary
- New top-level `RELEASING.md` documenting the full release flow and the failure modes the v1.14.0 release uncovered.
- One-line link from README "Quick Start" so maintainers can find it.

## Why
v1.14.0 release-please CI publish failed with `EOTP` even with a valid `NPM_TOKEN`. Root cause: npm account 2FA mode was `Authorization and writes`, forcing interactive OTP on every publish regardless of token type. The fix is account-level (npm settings), but the **knowledge** had to live in the repo so the next maintainer doesn't hit the same wall.

## What's in the doc
1. Normal release-please flow
2. NPM_TOKEN setup (Granular Access Token, scope, expiry, rotation reminder)
3. The 2FA-mode lesson — `Authorization only`, not `Authorization and writes`
4. EOTP recovery (manual publish fallback steps)
5. Token rotation hygiene
6. Plugin marketplace (in sync via release-please)

## Test plan
- [x] `RELEASING.md` exists at repo root with the six sections
- [x] README "Quick Start" has a one-line link
- [x] No actual token values, OTP values, or secret content in the doc
- [x] Sources cite the relevant npm + Anthropic plugin docs

## Out of scope
- Automating the 2FA mode change (account-level setting, repo can't touch it)
- A `scripts/release.sh` mirroring the manual fallback — fallback only runs when CI fails, mirroring it in code doesn't fix the cause
- Migrating to OIDC provenance — orthogonal future work

Closes CLA-36

🤖 Generated with [Claude Code](https://claude.com/claude-code)