### PR TITLE
chore: sync plugin marketplace to 1.15.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,14 +8,14 @@
   },
   "metadata": {
     "description": "Discipline kit that turns Claude Code from eager intern to staff engineer. Hooks, skills, and CLAUDE.md rules for Plan → Confirm → Implement → Verify.",
-    "version": "1.13.0"
+    "version": "1.15.0"
   },
   "plugins": [
     {
       "name": "claude-code-kit",
       "source": "./",
       "description": "Plan → Confirm → Implement → Verify discipline for Claude Code. Tier'd session boot, hooks (quality gate, protect-changes, branch-protect, secret-scan, conventional-commit, loop-detect), skills (architecture-review, code-quality-audit, design-review, performance-audit, security-review, refactoring-guide, dead-code-audit, accessibility-audit, deepening-review, interface-design, office-hours, shape-spec, retro, ship, skill-extractor, skill-generator, ui-component-builder, testing-audit, project-health-report, documentation-audit, dependency-audit), CLAUDE.md ruleset, lessons-as-memory, ADR decisions, and a wiki module for synthesised knowledge.",
-      "version": "1.13.0",
+      "version": "1.15.0",
       "author": {
         "name": "tansuasici",
         "url": "https://github.com/tansuasici"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "claude-code-kit",
   "description": "Discipline kit that turns Claude Code from eager intern to staff engineer. Hooks, skills, and CLAUDE.md rules for Plan → Confirm → Implement → Verify.",
-  "version": "1.13.0",
+  "version": "1.15.0",
   "author": {
     "name": "tansuasici",
     "url": "https://github.com/tansuasici"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,6 +14,21 @@
           "type": "json",
           "path": "package.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".claude-plugin/marketplace.json",
+          "jsonpath": "$.metadata.version"
+        },
+        {
+          "type": "json",
+          "path": ".claude-plugin/marketplace.json",
+          "jsonpath": "$.plugins[0].version"
         }
       ]
     }


### PR DESCRIPTION
## Summary
The plugin marketplace files were stuck at **1.13.0** — release-please only bumped `VERSION` + `package.json`, so `.claude-plugin/{plugin,marketplace}.json` silently missed 1.14.0 **and** 1.15.0. Plugin-marketplace users saw 1.13.0 while npm was at 1.15.0.

- Bump all three version fields (`plugin.json $.version`, `marketplace.json $.metadata.version` + `$.plugins[0].version`) to **1.15.0**.
- Add those paths to release-please `extra-files` so they auto-bump on every future release (no more drift).

`chore:` — no version bump, no new npm release; just brings the git-based marketplace current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
