### PR TITLE
feat: agent orchestration layer — handoff, telemetry, /feature-cycle

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -7,6 +7,10 @@ description: Thorough code reviewer focused on correctness, maintainability, and
 
 You are a thorough code reviewer focused on correctness, maintainability, and performance.
 
+## Handoff
+
+Before starting, Read `.hook-state/agent-handoff.md` if it exists — the previous sub-agent's short summary of what it did and what you should know. Before returning, **overwrite** that file (replace, don't append) with your own ≤5-line summary: what you changed or found, and what the next agent needs. It is a live scratchpad (~30 lines max), not a log — `journal-fold.sh` folds it into the session handoff at session end.
+
 ## Review Checklist
 
 ### Correctness

--- a/.claude/agents/dead-code-remover.md
+++ b/.claude/agents/dead-code-remover.md
@@ -7,6 +7,10 @@ description: Removes verified unused code through static reference analysis acro
 
 You are a dead code removal agent. Your job is to safely remove verified unused code from the codebase through systematic reference analysis.
 
+## Handoff
+
+Before starting, Read `.hook-state/agent-handoff.md` if it exists — the previous sub-agent's short summary of what it did and what you should know. Before returning, **overwrite** that file (replace, don't append) with your own ≤5-line summary: what you changed or found, and what the next agent needs. It is a live scratchpad (~30 lines max), not a log — `journal-fold.sh` folds it into the session handoff at session end.
+
 ## Process
 
 ### Step 1: Identify Candidates

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -7,6 +7,10 @@ description: Implementation planner that analyzes tasks, explores the codebase, 
 
 You are an implementation planner. Your job is to analyze a task, explore the codebase, and produce a clear, actionable plan.
 
+## Handoff
+
+Before starting, Read `.hook-state/agent-handoff.md` if it exists — the previous sub-agent's short summary of what it did and what you should know. Before returning, **overwrite** that file (replace, don't append) with your own ≤5-line summary: what you changed or found, and what the next agent needs. It is a live scratchpad (~30 lines max), not a log — `journal-fold.sh` folds it into the session handoff at session end.
+
 ## Process
 
 1. **Understand the goal** — restate it in 1-2 sentences

--- a/.claude/agents/qa-reviewer.md
+++ b/.claude/agents/qa-reviewer.md
@@ -7,6 +7,10 @@ description: Evidence-based QA reviewer that verifies task completion against co
 
 You are a QA reviewer. Your job is to verify that a task is genuinely complete — not just "looks done" but actually works. You default to skepticism: every claim needs evidence.
 
+## Handoff
+
+Before starting, Read `.hook-state/agent-handoff.md` if it exists — the previous sub-agent's short summary of what it did and what you should know. Before returning, **overwrite** that file (replace, don't append) with your own ≤5-line summary: what you changed or found, and what the next agent needs. It is a live scratchpad (~30 lines max), not a log — `journal-fold.sh` folds it into the session handoff at session end.
+
 ## Review Process
 
 1. **Read the task definition** — understand what "done" means (check `tasks/todo.md` or the task contract if one exists)

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -7,6 +7,10 @@ description: Security-focused code reviewer that finds vulnerabilities, not styl
 
 You are a security-focused code reviewer. Your job is to find vulnerabilities, not style issues.
 
+## Handoff
+
+Before starting, Read `.hook-state/agent-handoff.md` if it exists — the previous sub-agent's short summary of what it did and what you should know. Before returning, **overwrite** that file (replace, don't append) with your own ≤5-line summary: what you changed or found, and what the next agent needs. It is a live scratchpad (~30 lines max), not a log — `journal-fold.sh` folds it into the session handoff at session end.
+
 ## What to Check
 
 ### Input Validation

--- a/.claude/hooks/journal-fold.sh
+++ b/.claude/hooks/journal-fold.sh
@@ -2,19 +2,21 @@
 #
 # journal-fold.sh — SessionEnd hook
 #
-# After a session ends, decide what to do with .hook-state/session-journal.md
-# (populated by the `/note` skill mid-session):
+# After a session ends, fold two transient .hook-state artifacts into the
+# durable session handoff (tasks/handoff-<session-id>.md), then clear them so
+# the next session starts clean:
 #
-#   - If it contains [finding] or [decision] entries → fold into
-#     tasks/handoff-<session-id>.md so the next session can pick up
-#   - If it contains only [summary] entries → discard (transient breadcrumbs)
-#   - Always: remove the journal file so the next session starts clean
+#   - .hook-state/agent-handoff.md   — the live inter-agent scratchpad (CLA-37);
+#     the last sub-agent's <=5-line summary. Folded verbatim when non-empty.
+#   - .hook-state/session-journal.md — populated by the `/note` skill:
+#       * [finding] / [decision] entries → fold into the handoff
+#       * [summary]-only                 → discard (transient breadcrumbs)
 #
 # Runs alongside session-end.sh (the scorecard hook); both are wired under
 # SessionEnd in .claude/settings.json. Reads stdin for session_id but does
 # not require any payload.
 #
-# Always exits 0 (never blocks). Silent when there is no journal.
+# Always exits 0 (never blocks). Silent when there is nothing to fold.
 #
 
 set -euo pipefail
@@ -22,8 +24,41 @@ set -euo pipefail
 INPUT=$(cat)
 ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
 JOURNAL="$ROOT/.hook-state/session-journal.md"
+AGENT_HANDOFF="$ROOT/.hook-state/agent-handoff.md"
 
-# No journal? Silent exit.
+# Extract session_id once (shared by both folds); fall back to a timestamp slug.
+SESSION_ID=""
+if command -v python3 >/dev/null 2>&1; then
+  SESSION_ID=$(printf '%s' "$INPUT" | python3 -c "import sys,json
+try:
+    d = json.load(sys.stdin)
+    sys.stdout.write(d.get('session_id', '') or '')
+except Exception:
+    pass" 2>/dev/null || true)
+fi
+[ -n "$SESSION_ID" ] || SESSION_ID=$(date -u +%Y%m%d-%H%M%S)
+
+HANDOFF="$ROOT/tasks/handoff-${SESSION_ID}.md"
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# --- Fold the inter-agent handoff scratchpad (CLA-37) ---
+# The last sub-agent leaves a <=5-line summary here; preserve it in the session
+# handoff so the next session sees where the agent chain left off. Always clear
+# it afterward so the next session starts with an empty scratchpad.
+if [ -f "$AGENT_HANDOFF" ] && [ -s "$AGENT_HANDOFF" ]; then
+  mkdir -p "$ROOT/tasks"
+  {
+    echo ""
+    echo "## Agent handoff — folded from agent-handoff.md on $NOW"
+    echo ""
+    cat "$AGENT_HANDOFF"
+    echo ""
+  } >> "$HANDOFF"
+fi
+rm -f "$AGENT_HANDOFF"
+
+# --- Fold the /note journal ---
+# No journal? Nothing more to do.
 [ -f "$JOURNAL" ] || exit 0
 
 # Empty journal? Clean up and exit.
@@ -46,24 +81,8 @@ if [ "$FINDINGS" -eq 0 ] && [ "$DECISIONS" -eq 0 ]; then
   exit 0
 fi
 
-# Extract session_id from stdin (best effort, falls back to a timestamp slug).
-SESSION_ID=""
-if command -v python3 >/dev/null 2>&1; then
-  SESSION_ID=$(printf '%s' "$INPUT" | python3 -c "import sys,json
-try:
-    d = json.load(sys.stdin)
-    sys.stdout.write(d.get('session_id', '') or '')
-except Exception:
-    pass" 2>/dev/null || true)
-fi
-if [ -z "$SESSION_ID" ]; then
-  SESSION_ID=$(date -u +%Y%m%d-%H%M%S)
-fi
-
 # Fold journal contents into tasks/handoff-<session-id>.md (append if exists).
-HANDOFF="$ROOT/tasks/handoff-${SESSION_ID}.md"
 mkdir -p "$ROOT/tasks"
-NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 {
   echo ""

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -32,6 +32,11 @@ reset_state "$STATE_DIR/hook-firings.json"
 reset_state "$STATE_DIR/quality-gate-history.json"
 reset_state "$STATE_DIR/bash-budget.json"
 
+# Clear the inter-agent handoff scratchpad (CLA-37). It is per-session: each
+# sub-agent overwrites it with a <=5-line summary on exit, and journal-fold.sh
+# folds it into the session handoff at SessionEnd. Start every session empty.
+: > "$STATE_DIR/agent-handoff.md" 2>/dev/null || true
+
 # Write session metadata. session-end.sh reads it to compute
 # session_duration_seconds and propagate session_id into the scorecard.
 SESSION_ID=$(parse_json_field "session_id" 2>/dev/null || true)

--- a/.claude/hooks/subagent-post.sh
+++ b/.claude/hooks/subagent-post.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# subagent-post.sh — PostToolUse hook (matcher: Task)
+#
+# Closes the most recent OPEN telemetry row for the finishing sub-agent in
+# .hook-state/agent-invocations.jsonl: sets finished_at, duration_seconds,
+# and status=closed (outcome defaults to "completed"). Pairs with
+# subagent-pre.sh; /scorecard rolls these up per-agent (CLA-38).
+#
+# Never blocks. Always exits 0. No-op when there is no open row to close.
+#
+
+set -uo pipefail
+
+INPUT=$(cat)
+HOOK_LIB="$(cd "$(dirname "$0")/lib" 2>/dev/null && pwd)"
+# shellcheck source=/dev/null
+source "$HOOK_LIB/json-parse.sh"
+
+ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
+LOG="$ROOT/.hook-state/agent-invocations.jsonl"
+[ -f "$LOG" ] || exit 0
+
+AGENT=$(parse_json_field "subagent_type" 2>/dev/null || true)
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+NOW_EPOCH=$(date +%s)
+
+command -v python3 &>/dev/null || exit 0
+
+python3 - "$LOG" "$AGENT" "$NOW" "$NOW_EPOCH" <<'PY' 2>/dev/null || true
+import json, os, sys
+log, agent, now, epoch = sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4])
+try:
+    with open(log) as f:
+        lines = [ln.rstrip("\n") for ln in f]
+except FileNotFoundError:
+    sys.exit(0)
+
+# Parse each line; keep unparseable lines verbatim so nothing is lost.
+parsed = []
+for ln in lines:
+    s = ln.strip()
+    if not s:
+        parsed.append(("raw", ln))
+        continue
+    try:
+        parsed.append(("json", json.loads(s)))
+    except Exception:
+        parsed.append(("raw", ln))
+
+# Find the last OPEN row, preferring one whose agent matches (if known).
+idx = None
+for i in range(len(parsed) - 1, -1, -1):
+    kind, val = parsed[i]
+    if kind == "json" and val.get("status") == "open" and (not agent or val.get("agent") == agent):
+        idx = i
+        break
+if idx is None:
+    sys.exit(0)
+
+val = parsed[idx][1]
+val["finished_at"] = now
+start = val.get("started_epoch")
+if isinstance(start, int):
+    val["duration_seconds"] = max(0, epoch - start)
+val["status"] = "closed"
+val.setdefault("outcome", "completed")
+
+tmp = log + ".tmp"
+with open(tmp, "w") as f:
+    for kind, v in parsed:
+        f.write((json.dumps(v) if kind == "json" else v) + "\n")
+os.replace(tmp, log)
+PY
+
+exit 0

--- a/.claude/hooks/subagent-pre.sh
+++ b/.claude/hooks/subagent-pre.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# subagent-pre.sh — PreToolUse hook (matcher: Task)
+#
+# Opens an agent-invocation telemetry row when a sub-agent is dispatched:
+# appends one JSON line to .hook-state/agent-invocations.jsonl recording
+# {agent, task, started_at}. The paired PostToolUse hook (subagent-post.sh)
+# closes the row with finished_at + duration. /scorecard rolls these up
+# per-agent so you can see which sub-agent runs most and how long it takes
+# (CLA-38).
+#
+# Telemetry must never interfere with the call: this hook never blocks and
+# always exits 0, even on malformed input or a missing python3.
+#
+
+set -uo pipefail
+
+INPUT=$(cat)
+HOOK_LIB="$(cd "$(dirname "$0")/lib" 2>/dev/null && pwd)"
+# shellcheck source=/dev/null
+source "$HOOK_LIB/json-parse.sh"
+
+ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
+STATE_DIR="$ROOT/.hook-state"
+mkdir -p "$STATE_DIR" 2>/dev/null || true
+[ -f "$STATE_DIR/.gitignore" ] || printf '*\n!.gitignore\n' >"$STATE_DIR/.gitignore" 2>/dev/null || true
+
+AGENT=$(parse_json_field "subagent_type" 2>/dev/null || true)
+DESC=$(parse_json_field "description" 2>/dev/null || true)
+[ -n "$AGENT" ] || AGENT="unknown"
+
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+NOW_EPOCH=$(date +%s)
+LOG="$STATE_DIR/agent-invocations.jsonl"
+
+if command -v python3 &>/dev/null; then
+  python3 - "$LOG" "$AGENT" "$DESC" "$NOW" "$NOW_EPOCH" <<'PY' 2>/dev/null || true
+import json, sys
+log, agent, desc, now, epoch = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], int(sys.argv[5])
+row = {
+    "agent": agent,
+    "task": (desc or "")[:120],
+    "started_at": now,
+    "started_epoch": epoch,
+    "status": "open",
+}
+with open(log, "a") as f:
+    f.write(json.dumps(row) + "\n")
+PY
+else
+  # No python3: append a minimal, still-valid row (description omitted to avoid
+  # escaping bugs). The scorecard tolerates rows without a task field.
+  printf '{"agent":"%s","started_at":"%s","started_epoch":%s,"status":"open"}\n' \
+    "$AGENT" "$NOW" "$NOW_EPOCH" >> "$LOG" 2>/dev/null || true
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -92,6 +92,15 @@
             "command": ".claude/hooks/conventional-commit.sh"
           }
         ]
+      },
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/subagent-pre.sh"
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -122,6 +131,15 @@
           {
             "type": "command",
             "command": ".claude/hooks/bash-budget.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/subagent-post.sh"
           }
         ]
       }

--- a/.claude/skills/feature-cycle/SKILL.md
+++ b/.claude/skills/feature-cycle/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: feature-cycle
+description: End-to-end orchestrator that chains spec, plan, implement, verify, review, and ship from a local spec source. Runs the whole CLAUDE.md lifecycle as one command.
+user-invocable: true
+---
+
+# Feature Cycle
+
+## Core Rule
+
+Chain the kit's existing phases — never reimplement them. `/feature-cycle` is an orchestrator: it invokes `shape-spec`, the `planner` agent, the quality gate, `review-pipeline`, and `ship` in order, carrying context between them through `.hook-state/agent-handoff.md`. If a phase fails its gate, **halt** and surface the failure — never silently skip a phase.
+
+## Kit Context
+
+Before starting this skill, ensure you have completed session boot:
+
+1. Read `CODEBASE_MAP.md` for project understanding
+2. Read `CLAUDE.project.md` if it exists for project-specific rules
+3. Read `tasks/lessons/_index.md` for accumulated corrections (Top Rules + index)
+
+If any of these haven't been read in this session, read them now before proceeding.
+
+## When to Use
+
+Invoke with `/feature-cycle <spec-ref>` when:
+
+- You have a shaped spec (a `tasks/specs/<slug>/` folder, a `tasks/todo.md` entry, or a one-line description) and want the full Plan → Implement → Verify → Review → Ship lifecycle run as one command
+- You want the orchestration to live in the command, not in your head — each phase hands off to the next with shared context
+
+Not for:
+
+- Exploratory or ambiguous work that needs clarification first — run `/office-hours` to shape it, then feed the result here
+- A one-line fix you can do directly — the chain's overhead isn't worth it
+- Multi-issue / epic-level orchestration — run the cycle once per feature
+
+## Inputs
+
+`/feature-cycle <arg>`, where `<arg>` resolves in order:
+
+1. A path to a `tasks/specs/<slug>/` folder (from `shape-spec`) → use it as the spec
+2. A `tasks/todo.md` task title or anchor → use that task's plan
+3. Free text → treat as the feature description; the cycle scaffolds a spec via `shape-spec`
+
+No tracker is required or assumed. Pulling the spec from an external issue tracker (Linear / GitHub Issues / Jira) is an optional `.claude/extensions/` adapter, deliberately out of core.
+
+## Process
+
+Each phase reads `.hook-state/agent-handoff.md` on entry and overwrites it with a ≤5-line summary on exit, so the next phase starts with the previous phase's context (see `agent_docs/subagents.md → Runtime Handoff`). Sub-agent invocations are logged to telemetry automatically (`agent-invocations.jsonl`).
+
+### Phase 1: Resolve input
+
+Resolve `<arg>` to a spec (see Inputs). If it is free text and no spec exists, scaffold one with `shape-spec`. Restate the goal in 1–2 sentences and confirm it is concrete enough to plan; if not, stop and point the user at `/office-hours`.
+
+### Phase 2: Plan
+
+Spawn the `planner` sub-agent with the spec. The plan lands in `tasks/todo.md` (per the planner's contract). Do not implement yet.
+
+### Phase 3: Implement
+
+Execute the plan. Touch only the files the plan names; match existing style. If the plan turns out wrong mid-flight, halt and re-plan (per CLAUDE.md "if something goes sideways").
+
+### Phase 4: Verify
+
+Run the verification gate — typecheck, lint, tests. `quality-gate.sh` fires after every edit; run the full suite here too. **Halt on failure; no silent skip.** Quantify silent failures (processed / failed / skipped with reasons).
+
+### Phase 5: Review
+
+Run `/review-pipeline` over the diff. Address Cross-Audit and Critical findings before shipping.
+
+### Phase 6: Ship
+
+Run `/ship` (tests, CHANGELOG, branch, PR). Stop at the PR — a human approves the merge.
+
+### Halting
+
+If any phase fails its gate, stop the cycle, write the failure + resume point to `.hook-state/agent-handoff.md`, and surface it. The handoff file is enough to continue from the last completed phase in a later session.
+
+## Output Format
+
+Emit one progress line per phase and a final summary:
+
+```text
+/feature-cycle <spec>
+  ✓ Phase 1 Resolve   — spec: tasks/specs/2026-…/
+  ✓ Phase 2 Plan      — 4 steps in tasks/todo.md (planner)
+  ✓ Phase 3 Implement — 3 files touched
+  ✓ Phase 4 Verify    — typecheck / lint / tests green
+  ✓ Phase 5 Review    — review-pipeline: 0 critical, 1 major (addressed)
+  ✓ Phase 6 Ship      — PR #NN opened
+```
+
+On halt, mark the failed phase `✗`, print the reason, and note that `.hook-state/agent-handoff.md` holds the resume point.
+
+## Run Mode
+
+This skill supports interactive (default) and headless modes — see the canonical contract in `.claude/skills/_shared/blocks/mode-detection.md`.
+
+Headless detection: presence of `mode:headless` in arguments.
+
+| Decision point | Interactive | Headless |
+|---|---|---|
+| **Ambiguous spec** | Ask, or route to `/office-hours` | Fail fast: "spec not concrete enough to plan" |
+| **Phase gate failure** | Surface + ask how to proceed | Halt, write handoff, exit non-zero |
+| **Ship** | Open PR; human merges | Open PR; never auto-merge |
+
+## Notes
+
+- **Orchestrates; does not reimplement.** Quality depends on the underlying skills/agents (`shape-spec`, `planner`, `review-pipeline`, `ship`). Fix them there, not here.
+- **Resumable.** The handoff file carries context between phases; if interrupted, a later session continues from the last completed phase.
+- **Tracker-agnostic.** Core takes a local spec. Pulling from / updating an external tracker is an optional `.claude/extensions/` adapter, deliberately out of core — the kit ships no tracker dependency.
+- Built on the agent-handoff (CLA-37) and agent-telemetry (CLA-38) layers.

--- a/.claude/skills/scorecard/SKILL.md
+++ b/.claude/skills/scorecard/SKILL.md
@@ -35,7 +35,7 @@ Not for:
 
 ## Scope Rules
 
-- Reads `reports/session-audit.log` only — no other source of truth
+- Reads `reports/session-audit.log` and, when present, `.hook-state/agent-invocations.jsonl` (CLA-38 agent telemetry) — no other sources of truth
 - Parses both v1 (`schema_version` missing or `1`) and v2 records
 - Filters by window if provided; default to the last 7 days
 - Never modifies files; output is a single markdown report
@@ -67,6 +67,8 @@ Compute these aggregates over the windowed set of v2 records (v1 records contrib
 | **Bash output (estimated tokens)** | Sum of `metrics.bash_token_estimate`; if all are zero, surface that the bash-budget hook may not be installed |
 | **Compactions** | Sum of `metrics.compactions_observed` |
 | **Median session duration** | Median of `metrics.session_duration_seconds` (skip null/zero) |
+
+**Agent performance** (CLA-38) — only when `.hook-state/agent-invocations.jsonl` exists. Parse each JSONL row (`{agent, task, started_at, duration_seconds, status, outcome}`); skip unparseable lines and surface the count. Per agent compute: total invocations, completed (`status == "closed"`), still-open (`status == "open"` — a sub-agent that never returned, usually a crash or interrupted session), and median `duration_seconds` over closed rows. The file is append-only across sessions and gitignored; read the most recent rows and, if it exceeds ~1000 lines, note that the oldest should be trimmed — it is transient telemetry, not an audit log.
 
 ### Phase 3: Render
 
@@ -103,6 +105,15 @@ Output exactly one report. Keep it scannable. The shape is:
 - Compactions observed: <total>
 - Median session duration: <minutes>
 
+## Agent performance
+
+> Only shown when `.hook-state/agent-invocations.jsonl` exists (CLA-38 telemetry).
+
+| Agent | Invocations | Completed | Open | Median duration |
+|---|---:|---:|---:|---:|
+| code-reviewer | 18 | 18 | 0 | 47s |
+| planner | 12 | 11 | 1 | 2m11s |
+
 ## Per-session detail (most recent first)
 
 | Date | Pass? | Edits | Blocks | Duration |
@@ -123,6 +134,7 @@ After the table, add a single-paragraph "What this says" callout only when one o
 - **Quality-gate pass rate < 70%** → suggest reviewing the failing tool's last failures (point at `.hook-state/last_quality_gate.json` and `stderr_tail`)
 - **Skip-gate used in >1 session** → suggest documenting the bypass reasons in `tasks/decisions.md`
 - **One hook accounts for >70% of blocks** → suggest tightening prompt guidance around that domain or relaxing the hook if it's noisy
+- **A sub-agent has >2 still-open rows, or a markedly higher median duration than its peers** → flag it for investigation; if the same agent keeps stalling on a recurring task keyword (≥3 times), suggest capturing a lesson in `tasks/lessons/`
 
 Do not add follow-ups when nothing is notable. Silence is fine.
 
@@ -134,6 +146,7 @@ The full render schema lives inside **Phase 3: Render** above (markdown code fen
 - **`## Quality-gate`** — pass rate, skip-gate usage, most-recent gate status
 - **`## Blocks fired (cumulative)`** — per-hook block counts table
 - **`## Activity`** — edits, lessons / decisions added, bash output (estimated tokens), compactions, median session duration
+- **`## Agent performance`** — per-agent invocation counts + median duration from `.hook-state/agent-invocations.jsonl` (CLA-38), shown only when that file exists
 - **`## Per-session detail (most recent first)`** — table of `Date / Pass? / Edits / Blocks / Duration` for the window
 - **Optional follow-up paragraph** — single-paragraph "What this says" callout, emitted only when one of the Phase 4 thresholds trips (e.g. quality-gate pass rate < 70%)
 

--- a/.kit-manifest
+++ b/.kit-manifest
@@ -22,6 +22,8 @@
 .claude/hooks/skill-compliance.sh
 .claude/hooks/skill-extract-reminder.sh
 .claude/hooks/stop-gate.sh
+.claude/hooks/subagent-post.sh
+.claude/hooks/subagent-pre.sh
 .claude/hooks/task-complete-notify.sh
 .claude/hooks/unicode-scan.sh
 .claude/settings.json
@@ -36,6 +38,7 @@
 .claude/skills/design-review
 .claude/skills/doc-gardening
 .claude/skills/documentation-audit
+.claude/skills/feature-cycle
 .claude/skills/harness-init
 .claude/skills/interface-design
 .claude/skills/lesson-refresh

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ User-invocable audit and guide skills — run with `/skill-name`:
 | `/skill-generator` | Generates project-specific coding skills from tech stack analysis |
 | `/shape-spec` | Creates timestamped feature spec folders for multi-session planning |
 | `/review-pipeline` | Runs multiple audits in parallel over a PR-scope diff, dedupes findings, and saves a confidence-gated report *(supports `mode:headless`)* |
+| `/feature-cycle` | End-to-end orchestrator — chains `shape-spec` → `planner` → implement → verify → `/review-pipeline` → `/ship` from a local spec, halting on any gate failure *(supports `mode:headless`)* |
 | `/lesson-refresh` | Periodic refresh of `tasks/lessons/` — keep / update / promote / encode / archive verdicts *(supports `mode:headless`)* |
 | `/pulse` | Time-windowed outcome report saved to `tasks/pulses/` — what shipped, broke, was learned, is open *(supports `mode:headless`)* |
 | `/wiki-ingest` | Ingest source into knowledge wiki — summarize, cross-reference, update index *(requires `--wiki`)* |

--- a/agent_docs/subagents.md
+++ b/agent_docs/subagents.md
@@ -95,6 +95,23 @@ Then: Plan the full-stack feature using all three results
 
 ---
 
+## Runtime Handoff (`.hook-state/agent-handoff.md`)
+
+Subagents can't see each other's context — each gets a fresh window and returns only a summary. For a chain where one agent's output feeds the next (plan → implement → review), the kit gives them one shared scratchpad: `.hook-state/agent-handoff.md`.
+
+The contract (baked into all five `.claude/agents/*` definitions):
+
+- **On entry:** Read `.hook-state/agent-handoff.md` if present — the previous agent's ≤5-line summary.
+- **On exit:** **overwrite** it (replace, never append) with your own ≤5-line summary of what you did and what the next agent needs.
+
+It is a *live* scratchpad, not a journal — short by design (~30 lines max). `session-start.sh` clears it at the start of every session; `journal-fold.sh` folds whatever is left into `tasks/handoff-<session-id>.md` at session end, then clears it. For durable cross-session context use `tasks/handoff-*.md`; for mid-session breadcrumbs use `/note` (`.hook-state/session-journal.md`).
+
+### Telemetry (`.hook-state/agent-invocations.jsonl`)
+
+Every `Task` dispatch is logged for free: `subagent-pre.sh` (PreToolUse on `Task`) opens a row with `{agent, task, started_at}`; `subagent-post.sh` (PostToolUse on `Task`) closes it with `finished_at` + `duration_seconds`. `/scorecard` rolls these up per-agent — invocations, completed, still-open (crash/interrupt signal), and median duration — so you can see which sub-agent runs most and where time goes. The hooks never block the call; the log is append-only and gitignored.
+
+---
+
 ## Research-Then-Implement Pattern
 
 The most important subagent pattern. Keeps implementation context clean.

--- a/agent_docs/workflow.md
+++ b/agent_docs/workflow.md
@@ -8,6 +8,8 @@ Receive Task → Understand → Research → Plan → Confirm → Implement → 
 
 Every task follows this flow. Never skip steps.
 
+**Canonical happy-path:** `/feature-cycle <spec>` runs this lifecycle end-to-end as one command — it chains `shape-spec` → `planner` → implement → quality gate → `/review-pipeline` → `/ship`, carrying context between phases through `.hook-state/agent-handoff.md` and halting on any gate failure. Use it when you have a shaped spec and want the orchestration in the command rather than in your head; drive the phases by hand when you need finer control.
+
 ---
 
 ## Goal-Driven Task Reframing

--- a/bench/README.md
+++ b/bench/README.md
@@ -40,6 +40,9 @@ Each scenario runs in a **fresh temp directory** — no shared state between sce
 | s16 | `session-start-working-tree-silent-on-clean` | Working Tree block stays out of `additionalContext` on a fresh-checkout (no `.git`) session — CLA-28 silent-on-clean guarantee |
 | s17 | `lesson-resurface-smoke` | `scripts/lesson-resurface.sh` emits the pointer for an archived lesson matching the query vocabulary AND does NOT leak the lesson body's sentinel phrases — CLA-25 / CLA-32 pointer-only contract |
 | s18 | `journal-fold-creates-handoff` | `.claude/hooks/journal-fold.sh` folds a `/note`-populated `.hook-state/session-journal.md` (with findings + decisions) into `tasks/handoff-<session-id>.md` at session end — CLA-33 |
+| s19 | `journal-fold-folds-agent-handoff` | `journal-fold.sh` folds a non-empty `.hook-state/agent-handoff.md` (the inter-agent scratchpad) into `tasks/handoff-<session-id>.md` even with no journal present — CLA-37 |
+| s20 | `subagent-pre-logs-invocation` | `subagent-pre.sh` (PreToolUse on Task) appends an open telemetry row to `.hook-state/agent-invocations.jsonl` — CLA-38 |
+| s21 | `subagent-post-closes-invocation` | `subagent-post.sh` (PostToolUse on Task) closes the latest open telemetry row with `finished_at` + `duration_seconds` — CLA-38 |
 
 ## Add a scenario
 

--- a/bench/scenarios/s19-journal-fold-folds-agent-handoff.json
+++ b/bench/scenarios/s19-journal-fold-folds-agent-handoff.json
@@ -1,0 +1,15 @@
+{
+  "name": "s19-journal-fold-folds-agent-handoff",
+  "hook": ".claude/hooks/journal-fold.sh",
+  "setup_files": {
+    ".hook-state/agent-handoff.md": "planner -> implementer: plan written to tasks/todo.md, 3 files to touch in src/auth. watch the token refresh edge case.\n"
+  },
+  "payload": {
+    "session_id": "kitbench-s19"
+  },
+  "expect": {
+    "exit_code": 0,
+    "file_grew": ["tasks/handoff-kitbench-s19.md"]
+  },
+  "notes": "CLA-37: a non-empty .hook-state/agent-handoff.md (the inter-agent scratchpad) folds into tasks/handoff-<session-id>.md at session end, even with no /note journal present. Asserts the session handoff captures where the agent chain left off."
+}

--- a/bench/scenarios/s20-subagent-pre-logs-invocation.json
+++ b/bench/scenarios/s20-subagent-pre-logs-invocation.json
@@ -1,0 +1,16 @@
+{
+  "name": "s20-subagent-pre-logs-invocation",
+  "hook": ".claude/hooks/subagent-pre.sh",
+  "payload": {
+    "tool_name": "Task",
+    "tool_input": {
+      "subagent_type": "planner",
+      "description": "plan the auth refactor"
+    }
+  },
+  "expect": {
+    "exit_code": 0,
+    "file_grew": [".hook-state/agent-invocations.jsonl"]
+  },
+  "notes": "CLA-38: dispatching a sub-agent (PreToolUse on Task) appends one open telemetry row to .hook-state/agent-invocations.jsonl. subagent-post.sh closes it on PostToolUse; /scorecard rolls these up per-agent."
+}

--- a/bench/scenarios/s21-subagent-post-closes-invocation.json
+++ b/bench/scenarios/s21-subagent-post-closes-invocation.json
@@ -1,0 +1,18 @@
+{
+  "name": "s21-subagent-post-closes-invocation",
+  "hook": ".claude/hooks/subagent-post.sh",
+  "setup_files": {
+    ".hook-state/agent-invocations.jsonl": "{\"agent\": \"planner\", \"task\": \"plan\", \"started_at\": \"2026-05-25T03:00:00Z\", \"started_epoch\": 1779678000, \"status\": \"open\"}\n"
+  },
+  "payload": {
+    "tool_name": "Task",
+    "tool_input": {
+      "subagent_type": "planner"
+    }
+  },
+  "expect": {
+    "exit_code": 0,
+    "file_grew": [".hook-state/agent-invocations.jsonl"]
+  },
+  "notes": "CLA-38: PostToolUse on Task closes the latest open telemetry row (status open -> closed, adds finished_at + duration_seconds). Asserts the hook runs cleanly and the log persists."
+}


### PR DESCRIPTION
## Summary
The agent orchestration layer — CLA-37 → CLA-38 → CLA-39 — for the 1.16.0 release.

### CLA-37 — runtime handoff
`.hook-state/agent-handoff.md`: a per-session, replace-not-append scratchpad. `session-start.sh` clears it; all 5 sub-agents Read it on entry and **overwrite** it with a ≤5-line summary on exit; `journal-fold.sh` folds it into `tasks/handoff-<id>.md` at SessionEnd. Documented in `agent_docs/subagents.md`. KitBench **s19**.

### CLA-38 — invocation telemetry
`subagent-pre.sh` (PreToolUse/Task) opens a row `{agent, task, started_at}`; `subagent-post.sh` (PostToolUse/Task) closes it with `finished_at` + `duration_seconds` in `.hook-state/agent-invocations.jsonl`. `/scorecard` gains an **Agent performance** section (per-agent invocations, completed, still-open, median duration) + a lesson-candidate follow-up. Wired in `settings.json`. KitBench **s20/s21**.

### CLA-39 — `/feature-cycle`
Tracker-agnostic orchestrator: `shape-spec → planner → implement → quality-gate → review-pipeline → ship`, carrying context through the handoff file and **halting on any gate failure**. Driven by a local spec (spec folder / `tasks/todo.md` / free text) — no tracker dependency. Canonical happy-path in `workflow.md` + README.

## Verification (local)
- **KitBench 21/21** (added s19/s20/s21; existing s14/s16/s18 still green)
- **validate-skills**: `feature-cycle` valid (2 pre-existing failures in `note`/`lesson-resurface` are unrelated to this PR)
- **Manifest Sync `--check`** passes (regenerated)
- **markdownlint** 0 errors on all 11 touched markdown files
- telemetry hooks smoke-tested (open → close with duration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
