### PR TITLE
fix: kit audit — stop-gate staleness, fail-closed hooks, protect-changes scoping, docs accuracy

### DIFF
--- a/.claude/hooks/block-dangerous-commands.sh
+++ b/.claude/hooks/block-dangerous-commands.sh
@@ -9,7 +9,13 @@
 set -euo pipefail
 
 INPUT=$(cat)
-HOOK_LIB="$(cd "$(dirname "$0")/lib" 2>/dev/null && pwd)"
+HOOK_LIB="$(cd "$(dirname "$0")/lib" 2>/dev/null && pwd || true)"
+# Fail closed: a safety hook that can't load its library must block, not
+# silently no-op. Empty HOOK_LIB → lib/ missing → exit 2 (CLA-47).
+if [ -z "$HOOK_LIB" ] || [ ! -f "$HOOK_LIB/json-parse.sh" ]; then
+  echo "BLOCKED: $(basename "$0") cannot load .claude/hooks/lib/ — refusing to run fail-open. Reinstall kit hooks (cck init --upgrade)." >&2
+  exit 2
+fi
 source "$HOOK_LIB/json-parse.sh"
 source "$HOOK_LIB/state-counter.sh"
 

--- a/.claude/hooks/branch-protect.sh
+++ b/.claude/hooks/branch-protect.sh
@@ -9,7 +9,13 @@
 set -euo pipefail
 
 INPUT=$(cat)
-HOOK_LIB="$(cd "$(dirname "$0")/lib" 2>/dev/null && pwd)"
+HOOK_LIB="$(cd "$(dirname "$0")/lib" 2>/dev/null && pwd || true)"
+# Fail closed: a safety hook that can't load its library must block, not
+# silently no-op. Empty HOOK_LIB → lib/ missing → exit 2 (CLA-47).
+if [ -z "$HOOK_LIB" ] || [ ! -f "$HOOK_LIB/json-parse.sh" ]; then
+  echo "BLOCKED: $(basename "$0") cannot load .claude/hooks/lib/ — refusing to run fail-open. Reinstall kit hooks (cck init --upgrade)." >&2
+  exit 2
+fi
 source "$HOOK_LIB/json-parse.sh"
 source "$HOOK_LIB/state-counter.sh"
 

--- a/.claude/hooks/protect-changes.sh
+++ b/.claude/hooks/protect-changes.sh
@@ -18,7 +18,13 @@
 set -euo pipefail
 
 INPUT=$(cat)
-HOOK_LIB="$(cd "$(dirname "$0")/lib" 2>/dev/null && pwd)"
+HOOK_LIB="$(cd "$(dirname "$0")/lib" 2>/dev/null && pwd || true)"
+# Fail closed: a safety hook that can't load its library must block, not
+# silently no-op. Empty HOOK_LIB → lib/ missing → exit 2 (CLA-47).
+if [ -z "$HOOK_LIB" ] || [ ! -f "$HOOK_LIB/json-parse.sh" ]; then
+  echo "BLOCKED: $(basename "$0") cannot load .claude/hooks/lib/ — refusing to run fail-open. Reinstall kit hooks (cck init --upgrade)." >&2
+  exit 2
+fi
 source "$HOOK_LIB/json-parse.sh"
 source "$HOOK_LIB/state-counter.sh"
 

--- a/.claude/hooks/protect-changes.sh
+++ b/.claude/hooks/protect-changes.sh
@@ -14,6 +14,12 @@
 # session, or pass it explicitly to the hook subshell. Reasoning behind the
 # approval must be recorded in tasks/decisions.md (ADR template).
 #
+# Build configs (tsconfig, next.config, tailwind.config, Dockerfile, …) only
+# hard-block when CCK_PROTECT_BUILD_CONFIGS=1 (set by the strict profile). In
+# the standard profile they emit a non-blocking heads-up instead, since they are
+# edited routinely. Dependency manifests, migrations, auth logic, and CI
+# workflows always block regardless of profile.
+#
 
 set -euo pipefail
 
@@ -70,9 +76,13 @@ if [ "$BLOCKED" = false ]; then
   esac
 fi
 
-# Auth / security paths
+# Auth / security paths. Presentational components under */components/* are UI,
+# not auth logic — skip them so login forms / auth widgets don't trip the gate
+# on every edit (CLA-48). Backend auth logic (src/auth/, lib/auth/, middleware)
+# still blocks.
 if [ "$BLOCKED" = false ]; then
   case "$NORM" in
+    */components/*) ;; # presentational — not an auth-logic change
     */auth/*|auth/*|*/security/*|security/*|*/permissions/*|permissions/*|*/middleware/auth*|*/lib/auth/*)
       BLOCKED=true
       REASON="auth/security path — verify threat model and add tests before editing"
@@ -80,12 +90,18 @@ if [ "$BLOCKED" = false ]; then
   esac
 fi
 
-# Build system / core architecture configs (basename match)
+# Build system / core architecture configs (basename match). Blocking these is
+# opt-in: the strict profile sets CCK_PROTECT_BUILD_CONFIGS=1, but in the standard
+# profile they are edited routinely, so we advise without blocking (CLA-48).
 if [ "$BLOCKED" = false ]; then
   case "$BASENAME" in
     Dockerfile|docker-compose.yml|docker-compose.yaml|Makefile|tsconfig.json|tsconfig.*.json|vite.config.ts|vite.config.js|next.config.js|next.config.mjs|next.config.ts|webpack.config.js|rollup.config.js|tailwind.config.js|tailwind.config.ts)
-      BLOCKED=true
-      REASON="build config — core architecture change, requires plan and approval"
+      if [ "${CCK_PROTECT_BUILD_CONFIGS:-0}" = "1" ]; then
+        BLOCKED=true
+        REASON="build config — core architecture change, requires plan and approval"
+      else
+        echo "protect-changes: heads-up — '$FILE_PATH' is a build config. Treat structural changes (toolchain, build target, module system) as a Protected Change per CLAUDE.md. Set CCK_PROTECT_BUILD_CONFIGS=1 (strict profile) to enforce a hard stop." >&2
+      fi
       ;;
   esac
 fi

--- a/.claude/hooks/protect-files.sh
+++ b/.claude/hooks/protect-files.sh
@@ -9,7 +9,13 @@
 set -euo pipefail
 
 INPUT=$(cat)
-HOOK_LIB="$(cd "$(dirname "$0")/lib" 2>/dev/null && pwd)"
+HOOK_LIB="$(cd "$(dirname "$0")/lib" 2>/dev/null && pwd || true)"
+# Fail closed: a safety hook that can't load its library must block, not
+# silently no-op. Empty HOOK_LIB → lib/ missing → exit 2 (CLA-47).
+if [ -z "$HOOK_LIB" ] || [ ! -f "$HOOK_LIB/json-parse.sh" ]; then
+  echo "BLOCKED: $(basename "$0") cannot load .claude/hooks/lib/ — refusing to run fail-open. Reinstall kit hooks (cck init --upgrade)." >&2
+  exit 2
+fi
 source "$HOOK_LIB/json-parse.sh"
 source "$HOOK_LIB/state-counter.sh"
 

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -31,6 +31,11 @@ mkdir -p "$STATE_DIR" 2>/dev/null || true
 reset_state "$STATE_DIR/hook-firings.json"
 reset_state "$STATE_DIR/quality-gate-history.json"
 reset_state "$STATE_DIR/bash-budget.json"
+# Also clear the verdict stop-gate.sh reads. quality-gate.sh only overwrites it
+# on a qualifying edit, so a "failed" verdict from a prior session would
+# otherwise persist and block completion of a new session that makes no code
+# edit (e.g. a Markdown-only or Q&A session). New session starts with no verdict.
+reset_state "$STATE_DIR/last_quality_gate.json"
 
 # Clear the inter-agent handoff scratchpad (CLA-37). It is per-session: each
 # sub-agent overwrites it with a <=5-line summary on exit, and journal-fold.sh

--- a/.claude/skills/lesson-resurface/SKILL.md
+++ b/.claude/skills/lesson-resurface/SKILL.md
@@ -10,7 +10,7 @@ user-invocable: true
 
 Given a short task summary, return a ranked list of _pointers_ to lessons under `tasks/lessons/` (including `_archive/`) whose `applies_to` topic tags overlap with the task. Return paths only — never load, read, or paraphrase lesson bodies into context. The agent decides whether to `Read` each pointer.
 
-## How
+## Process
 
 The deterministic loop (vocabulary discovery, scoring, supersession resolution, output formatting) lives in `scripts/lesson-resurface.sh`. The skill is a thin pass-through:
 

--- a/.claude/skills/note/SKILL.md
+++ b/.claude/skills/note/SKILL.md
@@ -10,7 +10,7 @@ user-invocable: true
 
 Append `<ISO8601> [<tag>] <text>` to `.hook-state/session-journal.md`. Tag MUST be one of `finding`, `decision`, `summary`. The journal is transient (gitignored, same lifetime as other `.hook-state/*`) but durable across `/compact` within the same session.
 
-## How
+## Process
 
 ```bash
 scripts/note.sh <tag> <text>

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -111,3 +111,14 @@ jobs:
         run: |
           chmod +x scripts/sync-manifest.sh
           ./scripts/sync-manifest.sh --check
+
+  skill-validation:
+    name: Skill Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate skill structure (frontmatter + required sections)
+        run: |
+          chmod +x scripts/validate-skills.sh
+          ./scripts/validate-skills.sh

--- a/README.md
+++ b/README.md
@@ -184,28 +184,49 @@ Claude: *implements, then runs:*
 
 ## Hooks
 
-Hooks are shell scripts that run automatically — unlike CLAUDE.md rules (advisory), hooks are **deterministic**.
+Hooks are shell scripts that run automatically — unlike CLAUDE.md rules (advisory), hooks are **deterministic**. The kit ships **22** hooks; the standard profile wires up 18, and 4 are opt-in (they can be slow or conflict with project configs).
 
-| Hook | Type | What it does |
+**Guardrails — block on violation (PreToolUse / Stop):**
+
+| Hook | Event | What it does |
 |------|------|-------------|
 | `protect-files` | PreToolUse | Blocks edits to `.env`, credentials, private keys, lock files |
+| `protect-changes` | PreToolUse | Blocks edits to dependency manifests, migrations, and auth logic. Build configs block only under the **strict** profile (`CCK_PROTECT_BUILD_CONFIGS=1`); UI under `components/` is exempt |
 | `branch-protect` | PreToolUse | Blocks push to `main`/`master` and force pushes |
 | `block-dangerous-commands` | PreToolUse | Blocks `rm -rf /`, `git reset --hard`, `DROP TABLE`, etc. |
 | `conventional-commit` | PreToolUse | Enforces `feat:`, `fix:`, `refactor:` commit message format |
-| `secret-scan` | PostToolUse | Warns if API keys, tokens, or passwords are found |
-| `unicode-scan` | PostToolUse | Detects invisible Unicode (Glassworm supply chain attack defense) |
-| `loop-detect` | PostToolUse | Detects edit loops — warns at 4, blocks at 6 edits to the same file |
-| `task-complete-notify` | Stop | Desktop notification + sound when Claude finishes |
-| `auto-lint` | PostToolUse | Runs linter after edits *(opt-in)* |
-| `auto-format` | PostToolUse | Runs formatter after edits *(opt-in)* |
-| `skill-compliance` | PostToolUse | Checks edited files against active skill checklists *(opt-in)* |
-| `skill-extract-reminder` | UserPromptSubmit | Reminds to extract discoveries as skills *(opt-in)* |
+| `quality-gate` | PostToolUse | Runs typecheck / lint / syntax-check after an edit; records the verdict |
+| `stop-gate` | Stop | Blocks completion when the last quality gate failed (bypass: `SKIP_QUALITY_GATE=1`) |
 
-Opt-in hooks are not enabled by default — they can be slow or conflict with project configs. See `agent_docs/hooks.md` for how to enable them and write your own.
+**Context & observability — inject or warn, never block:**
+
+| Hook | Event | What it does |
+|------|------|-------------|
+| `session-start` | SessionStart | Injects Tier-1 pointers, top rules, active task, branch + dirty-tree status; resets session state |
+| `prompt-router` | UserPromptSubmit | Injects a reminder when a prompt touches a sensitive inflection (auth, deps, schema) |
+| `secret-scan` | PostToolUse | Warns if API keys, tokens, or passwords are found |
+| `unicode-scan` | PostToolUse | Detects invisible Unicode (Glassworm supply-chain attack defense) |
+| `loop-detect` | PostToolUse | Detects edit loops — warns at 4, signals at 6 edits to the same file |
+| `bash-budget` | PostToolUse | Warns once when cumulative Bash output crosses a token threshold |
+| `subagent-pre` / `subagent-post` | PreToolUse / PostToolUse | Log sub-agent (`Task`) invocations and fold their handoff summaries |
+| `session-end` | SessionEnd | Writes a session audit line + scorecard inputs |
+| `journal-fold` | SessionEnd | Folds `/note` journal findings into the session handoff |
+| `task-complete-notify` | Stop | Desktop notification + sound when Claude finishes |
+
+**Opt-in — not enabled by default:**
+
+| Hook | Event | What it does |
+|------|------|-------------|
+| `auto-lint` | PostToolUse | Runs linter after edits |
+| `auto-format` | PostToolUse | Runs formatter after edits |
+| `skill-compliance` | PostToolUse | Checks edited files against active skill checklists |
+| `skill-extract-reminder` | UserPromptSubmit | Reminds to extract discoveries as skills |
+
+See `agent_docs/hooks.md` for how to enable the opt-in hooks and write your own.
 
 ### KitBench — hooks are tested
 
-The hooks above aren't documentation, they're a contract. The kit ships [`bench/`](bench/README.md): a reproducible eval harness with 15 scenarios covering every blocking hook plus regression tests for past bugs (composer.lock slip-through, `EXIT_CODE=$?` after `|| true`, `.github/workflows/ci.yml` basename-with-slash miss, word-boundary regex rejecting "authentication"). Run it any time with `./scripts/run-bench.sh`; CI runs it on every PR.
+The hooks above aren't documentation, they're a contract. The kit ships [`bench/`](bench/README.md): a reproducible eval harness with 25 scenarios covering every blocking hook plus regression tests for past bugs (composer.lock slip-through, `EXIT_CODE=$?` after `|| true`, `.github/workflows/ci.yml` basename-with-slash miss, word-boundary regex rejecting "authentication", stale quality-gate verdict blocking a fresh session). Run it any time with `./scripts/run-bench.sh`; CI runs it on every PR.
 
 ```text
 KitBench
@@ -215,7 +236,7 @@ KitBench
   s03-protect-changes-blocks-package-json           PASS
   ...                                               PASS
 ========================================
-  15/15 PASS  0 FAIL
+  25/25 PASS  0 FAIL
 ```
 
 ## Agents
@@ -262,6 +283,13 @@ User-invocable audit and guide skills — run with `/skill-name`:
 | `/feature-cycle` | End-to-end orchestrator — chains `shape-spec` → `planner` → implement → verify → `/review-pipeline` → `/ship` from a local spec, halting on any gate failure *(supports `mode:headless`)* |
 | `/lesson-refresh` | Periodic refresh of `tasks/lessons/` — keep / update / promote / encode / archive verdicts *(supports `mode:headless`)* |
 | `/pulse` | Time-windowed outcome report saved to `tasks/pulses/` — what shipped, broke, was learned, is open *(supports `mode:headless`)* |
+| `/note` | Appends a timestamped `finding`/`decision`/`summary` to the session journal — across-compaction memory, folded into handoff at session end |
+| `/constitution` | Authors `golden-principles.yaml` from a 5-question intake or codebase inference — the rules `/quality-audit` checks against *(supports `mode:headless`)* |
+| `/quality-audit` | Audits code against the project's `golden-principles.yaml` and updates `docs/QUALITY_SCORE.md` *(supports `mode:headless`)* |
+| `/scorecard` | Per-session scorecard from hook telemetry — quality-gate pass rate, blocks fired, bash budget *(supports `mode:headless`)* |
+| `/harness-init` | Scaffolds the harness docs pattern (`docs/ARCHITECTURE.md`, design docs, references) without overwriting existing files *(supports `mode:headless`)* |
+| `/references-sync` | Populates `docs/references/<package>-llms.txt` so the agent reads curated library docs on demand *(supports `mode:headless`)* |
+| `/doc-gardening` | Prunes stale docs, fixes drift, and refreshes cross-references *(supports `mode:headless`)* |
 | `/wiki-ingest` | Ingest source into knowledge wiki — summarize, cross-reference, update index *(requires `--wiki`)* |
 | `/wiki-lint` | Health-check the knowledge wiki — contradictions, orphans, stale content *(requires `--wiki`)* |
 | `/wiki-briefing` | Morning briefing from the wiki — recent activity, new sources, open items *(requires `--wiki`)* |
@@ -289,6 +317,11 @@ Each template includes a customized `CLAUDE.md` with stack-specific rules and a 
 | `./scripts/gen-skill-docs.sh` | Generates web MDX docs from SKILL.md files |
 | `./scripts/build-skills.sh` | Builds SKILL.md from `.tmpl` templates + shared blocks |
 | `./scripts/migrate-lessons.sh` | One-time migration from legacy `tasks/lessons.md` to per-file `tasks/lessons/` structure |
+| `./scripts/run-bench.sh` | Runs KitBench — every hook scenario in `bench/scenarios/` (CI runs this on each PR) |
+| `./scripts/sync-manifest.sh` | Regenerates `.kit-manifest`; `--check` fails CI when it's stale |
+| `./scripts/lesson-resurface.sh` | Backs `/lesson-resurface` — returns dormant-lesson pointers matched by topic |
+| `./scripts/lesson-graph.sh` | Generates the `tasks/lessons/_index.md` auto-sections from `applies_to` tags |
+| `./scripts/note.sh` | Backs `/note` — appends a validated, timestamped line to the session journal |
 
 ### Status line setup
 
@@ -384,7 +417,7 @@ claude-code-kit/
   .claude/
     settings.json                  # Hook configs & permissions
     agents/                        # code-reviewer, security-reviewer, planner, qa-reviewer, dead-code-remover, wiki-maintainer
-    hooks/                         # 12 deterministic hook scripts
+    hooks/                         # 22 deterministic hook scripts (lib/ shared helpers)
       project/                     # Project-specific hooks (yours)
     skills/                        # Reusable knowledge & audit skills
       _shared/blocks/              # Shared template blocks (preamble, scope, etc.)

--- a/bench/scenarios/s22-session-start-clears-stale-quality-gate.json
+++ b/bench/scenarios/s22-session-start-clears-stale-quality-gate.json
@@ -1,0 +1,16 @@
+{
+  "name": "s22-session-start-clears-stale-quality-gate",
+  "hook": ".claude/hooks/session-start.sh",
+  "setup_files": {
+    ".hook-state/last_quality_gate.json": "{\"status\":\"failed\",\"exit_code\":1,\"tool\":\"ruff\",\"edited_file\":\"x.py\",\"duration_seconds\":0,\"stderr_tail\":\"E\"}\n",
+    "CODEBASE_MAP.md": "# CODEBASE_MAP\nPresent so session-start has something to point at.\n"
+  },
+  "payload": {
+    "session_id": "kitbench-s22"
+  },
+  "expect": {
+    "exit_code": 0,
+    "file_absent": [".hook-state/last_quality_gate.json"]
+  },
+  "notes": "CLA-44 regression: session-start.sh must clear .hook-state/last_quality_gate.json. quality-gate.sh only overwrites that verdict on a qualifying edit, so a 'failed' verdict from a prior session would otherwise persist and make stop-gate.sh (s09) block completion of a new session that performs no code edit. Pairs with s09/s10/s11."
+}

--- a/bench/scenarios/s23-protect-changes-build-config-blocks-in-strict.json
+++ b/bench/scenarios/s23-protect-changes-build-config-blocks-in-strict.json
@@ -1,0 +1,14 @@
+{
+  "name": "s23-protect-changes-build-config-blocks-in-strict",
+  "hook": ".claude/hooks/protect-changes.sh",
+  "env": { "CCK_PROTECT_BUILD_CONFIGS": "1" },
+  "payload": {
+    "tool_name": "Edit",
+    "tool_input": { "file_path": "{TMPROOT}/tsconfig.json" }
+  },
+  "expect": {
+    "exit_code": 2,
+    "stderr_contains": ["BLOCKED", "build config"]
+  },
+  "notes": "CLA-48: build-config blocking is opt-in. With CCK_PROTECT_BUILD_CONFIGS=1 (strict profile) editing tsconfig.json hard-blocks."
+}

--- a/bench/scenarios/s24-protect-changes-build-config-warns-in-standard.json
+++ b/bench/scenarios/s24-protect-changes-build-config-warns-in-standard.json
@@ -1,0 +1,13 @@
+{
+  "name": "s24-protect-changes-build-config-warns-in-standard",
+  "hook": ".claude/hooks/protect-changes.sh",
+  "payload": {
+    "tool_name": "Edit",
+    "tool_input": { "file_path": "{TMPROOT}/tsconfig.json" }
+  },
+  "expect": {
+    "exit_code": 0,
+    "stderr_contains": ["heads-up", "build config"]
+  },
+  "notes": "CLA-48: in the standard profile (no CCK_PROTECT_BUILD_CONFIGS) a build-config edit advises but does NOT block — reduces out-of-box friction."
+}

--- a/bench/scenarios/s25-protect-changes-allows-ui-component.json
+++ b/bench/scenarios/s25-protect-changes-allows-ui-component.json
@@ -1,0 +1,13 @@
+{
+  "name": "s25-protect-changes-allows-ui-component",
+  "hook": ".claude/hooks/protect-changes.sh",
+  "payload": {
+    "tool_name": "Edit",
+    "tool_input": { "file_path": "{TMPROOT}/src/components/auth/LoginForm.tsx" }
+  },
+  "expect": {
+    "exit_code": 0,
+    "stderr_not_contains": ["BLOCKED"]
+  },
+  "notes": "CLA-48: presentational components under */components/* are UI, not auth logic — must not trip the auth gate. Backend auth logic (s06: src/auth/login.ts) still blocks."
+}

--- a/install.sh
+++ b/install.sh
@@ -881,10 +881,11 @@ if [ ! -d "$DEST/.claude/hooks" ]; then
     cp "$f" "$DEST/.claude/hooks/"
     manifest_add ".claude/hooks/$(basename "$f")"
   done
-  # Copy shared hook library
+  # Copy shared hook library. Safety hooks fail closed without it (CLA-47),
+  # so a silent miss would block every Edit/Bash. Hard-error instead of || true.
   if [ -d "$CLONE_DIR/.claude/hooks/lib" ]; then
     mkdir -p "$DEST/.claude/hooks/lib"
-    cp "$CLONE_DIR/.claude/hooks/lib/"*.sh "$DEST/.claude/hooks/lib/" 2>/dev/null || true
+    cp "$CLONE_DIR/.claude/hooks/lib/"*.sh "$DEST/.claude/hooks/lib/" || error "Failed to copy hook library (.claude/hooks/lib/) — safety hooks would not run"
     manifest_add ".claude/hooks/lib"
   fi
   chmod +x "$DEST/.claude/hooks/"*.sh 2>/dev/null || true

--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,9 @@ upgrade_dir() {
 generate_strict_settings() {
   cat <<'SETTINGS_EOF'
 {
+  "env": {
+    "CCK_PROTECT_BUILD_CONFIGS": "1"
+  },
   "permissions": {
     "allow": [
       "Bash(npm test*)",

--- a/scripts/run-bench.sh
+++ b/scripts/run-bench.sh
@@ -219,6 +219,12 @@ def run_scenario(scenario):
             if os.path.getsize(full) == 0:
                 failures.append(f"file expected non-empty: {fg}")
 
+        # file_absent (state cleared / never created)
+        for fa in scenario.get("expect", {}).get("file_absent", []):
+            full = os.path.join(workdir, fa)
+            if os.path.exists(full):
+                failures.append(f"file expected absent: {fa}")
+
         return (not failures), failures, proc.stdout, proc.stderr
     finally:
         shutil.rmtree(workdir, ignore_errors=True)

--- a/tasks/decisions.md
+++ b/tasks/decisions.md
@@ -221,6 +221,24 @@ Track important technical decisions here so they don't get lost between sessions
   - Pairs naturally with `/harness-init` (ADR-010 in PR #124) — that skill scaffolds `docs/QUALITY_SCORE.md`; this skill maintains it
   - **NOTE on numbering**: ADR-005..010 are reserved by PRs #117..#124 (assumed merge order). If merge order changes, renumber to next free slot at merge time.
 
+### ADR-016: protect-changes scopes auth + build-config blocking by intent and profile
+- **Date**: 2026-05-25
+- **Status**: accepted
+- **Context**: `protect-changes.sh` runs in the standard (default) profile and blocked every edit under any `*/auth/*` directory plus all build configs (tsconfig, next.config, tailwind.config, vite, webpack, Dockerfile, …). On a typical frontend that meant frequent `BLOCKED` prompts on presentational components (e.g. `components/auth/LoginForm.tsx`) and on routinely-edited config files — training users to set `CLAUDE_APPROVED=1` globally (which defeats the gate) or uninstall. (CLA-48)
+- **Options**:
+  - A) **Status quo** — keep blanket blocking. Pros: maximal caution. Cons: false-positive fatigue erodes the gate's credibility; users bypass it wholesale.
+  - B) **Drop auth + build-config protection entirely.** Pros: zero friction. Cons: loses genuine protection on two areas where a staff engineer most wants a pause.
+  - C) **Scope by intent + profile** — keep auth-logic, dependency, migration, and CI blocking always; exclude presentational UI from the auth match; make build-config blocking opt-in per profile.
+- **Decision**: C.
+  - **Auth:** skip paths under `*/components/*` (UI, not auth logic). Backend auth logic (`src/auth/`, `lib/auth/`, `middleware/auth*`, `*/security/*`, `*/permissions/*`) still blocks.
+  - **Build configs:** hard-block only when `CCK_PROTECT_BUILD_CONFIGS=1`. The strict profile sets it via `settings.json → env`; the standard profile emits a non-blocking heads-up instead.
+  - Dependency manifests, migrations/schema, and CI workflows block unconditionally in every profile — unchanged.
+- **Consequences**:
+  - `protect-changes.sh` gains a `*/components/*` skip and the env gate; the header documents `CCK_PROTECT_BUILD_CONFIGS`.
+  - `generate_strict_settings()` in `install.sh` adds `"env": { "CCK_PROTECT_BUILD_CONFIGS": "1" }`.
+  - KitBench gains s23 (strict blocks build config), s24 (standard warns), s25 (UI component allowed); s06 (backend auth still blocks) unchanged.
+  - README hooks table marks build-config blocking as strict-only.
+
 ### ADR-015: Skill catalog formalised as a four-layer resolution order using existing primitives
 - **Date**: 2026-05-18
 - **Status**: accepted


### PR DESCRIPTION
Audit-driven fixes for the next patch release (1.16.1). Each commit closes one Linear issue.

## Fixes

- **CLA-44 — `fix`: clear `last_quality_gate.json` at session start.** `session-start.sh` reset three state files but not the verdict `stop-gate.sh` reads, so a `failed` gate from a prior session could block completion of a new session that made no qualifying edit. Adds the reset + KitBench `s22` + a `file_absent` assertion primitive in `run-bench.sh`.
- **CLA-45 — `fix`: kit passed its own `validate-skills.sh`.** `note` and `lesson-resurface` declared `user-invocable` but lacked the required `## Process` section (2 failed). Renamed their `## How` heading to `## Process`, and added a `skill-validation` CI job so it can't regress.
- **CLA-47 — `fix`: safety hooks fail closed when `.claude/hooks/lib/` is missing.** Empty `HOOK_LIB` previously let `set -e` exit 1 (non-blocking) at the assignment, so `protect-files` / `protect-changes` / `block-dangerous-commands` / `branch-protect` silently stopped enforcing. Now they exit 2 with a clear message; `install.sh` hard-errors if the lib copy fails.
- **CLA-48 — `fix`: scope `protect-changes` by intent + profile (ADR-016).** Skips presentational UI under `*/components/*`; build-config blocking is now opt-in via `CCK_PROTECT_BUILD_CONFIGS=1` (set by the strict profile's `settings.json → env`), warn-only in standard. Dependency manifests, migrations, auth logic, and CI workflows still block in every profile. New scenarios `s23`/`s24`/`s25`; `s06` unchanged.
- **CLA-46 — `docs`: README accuracy.** `12 → 22` hooks (table now lists the default-on operational hooks, grouped guardrails / observability / opt-in), KitBench `15 → 25`, and added 7 shipped-but-undocumented skills + 5 scripts.

Deferred: **CLA-49** (web docs site drift) lives in the separate `web/` repo.

## Verification

- KitBench: **25/25 PASS** (was 21; +s22, s23, s24, s25)
- `validate-skills.sh`: **0 failed** (was 2)
- Fail-closed verified manually: all four blockers exit 2 with no `lib/`
- `.kit-manifest` unchanged; strict `settings.json` validated as JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)