### PR TITLE
fix: resolve audit findings (CLA-53–69) + stack templates, cck skills, macOS/install CI (CLA-70–73)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
     {
       "name": "claude-code-kit",
       "source": "./",
-      "description": "Plan → Confirm → Implement → Verify discipline for Claude Code. Tier'd session boot, hooks (quality gate, protect-changes, branch-protect, secret-scan, conventional-commit, loop-detect), skills (architecture-review, code-quality-audit, design-review, performance-audit, security-review, refactoring-guide, dead-code-audit, accessibility-audit, deepening-review, interface-design, office-hours, shape-spec, retro, ship, skill-extractor, skill-generator, ui-component-builder, testing-audit, project-health-report, documentation-audit, dependency-audit), CLAUDE.md ruleset, lessons-as-memory, ADR decisions, and a wiki module for synthesised knowledge.",
+      "description": "Plan → Confirm → Implement → Verify discipline for Claude Code. Tiered session boot, deterministic hooks (quality gate, protect-changes, branch-protect, secret-scan, conventional-commit, loop-detect, and more), 36 user-invocable skills across audit / workflow / meta / wiki categories, 6 review agents (code-reviewer, security-reviewer, qa-reviewer, planner, dead-code-remover, wiki-maintainer), a CLAUDE.md ruleset, lessons-as-memory, ADR decisions, and optional wiki + HTML-artifacts modules.",
       "version": "1.16.1",
       "author": {
         "name": "tansuasici",

--- a/.claude/hooks/block-dangerous-commands.sh
+++ b/.claude/hooks/block-dangerous-commands.sh
@@ -36,12 +36,31 @@ REASON=""
 # The optional (--\s+)? handles the POSIX end-of-options separator (e.g. rm -rf -- /)
 RM_RECURSIVE='rm\s+(-[a-zA-Z]*r[a-zA-Z]*\s+(-[a-zA-Z]+\s+)*|-r\s+-f\s+|-f\s+-r\s+|--recursive\s+(-f\s+|--force\s+)?|-r\s+--force\s+)(--\s+)?'
 
-if echo "$COMMAND" | grep -qE "${RM_RECURSIVE}/[[:space:]]*($|[;&|])"; then
+# Absolute system directories that must never be recursively deleted. Deeper,
+# project-local paths (e.g. /home/u/app/node_modules, /tmp/build) stay allowed —
+# only the catastrophic roots and system trees are blocked.
+RM_SYS_DIRS='etc|usr|var|bin|sbin|lib|lib64|opt|boot|dev|proc|sys|root|srv|System|Library|Applications|private|Network|Volumes|cores'
+
+# rm -rf /   or   rm -rf /*   (whole filesystem)
+if echo "$COMMAND" | grep -qE "${RM_RECURSIVE}/(\\*|[[:space:]]*($|[;&|]))"; then
   BLOCKED=true
   REASON="Recursive delete on root directory"
 fi
 
-if echo "$COMMAND" | grep -qE "${RM_RECURSIVE}(~|\\\$HOME|\\\$\{HOME\})\b"; then
+# rm -rf /etc , /usr/local , sudo rm -rf /etc/nginx — any system path
+if echo "$COMMAND" | grep -qE "${RM_RECURSIVE}/(${RM_SYS_DIRS})(/|[[:space:]]|[;&|]|$)"; then
+  BLOCKED=true
+  REASON="Recursive delete on a system directory"
+fi
+
+# Whole home directory: ~ , ~/Documents , \$HOME , /home/<user> , /Users/<user>.
+# Deeper paths (~/proj/dist, /home/u/app/node_modules) remain allowed.
+if echo "$COMMAND" | grep -qE "${RM_RECURSIVE}(~|\\\$HOME|\\\$\{HOME\})(/[^/[:space:];&|]+)?([[:space:]]|[;&|]|$)"; then
+  BLOCKED=true
+  REASON="Recursive delete on home directory"
+fi
+
+if echo "$COMMAND" | grep -qE "${RM_RECURSIVE}/(home|Users)(/[^/[:space:];&|]+)?([[:space:]]|[;&|]|$)"; then
   BLOCKED=true
   REASON="Recursive delete on home directory"
 fi
@@ -54,6 +73,12 @@ fi
 if echo "$COMMAND" | grep -qE "${RM_RECURSIVE}\\*"; then
   BLOCKED=true
   REASON="Recursive delete with wildcard"
+fi
+
+# --no-preserve-root exists only to defeat rm's built-in root guard
+if echo "$COMMAND" | grep -qE -- '--no-preserve-root'; then
+  BLOCKED=true
+  REASON="rm --no-preserve-root bypasses root protection"
 fi
 
 # Git history destruction
@@ -84,10 +109,12 @@ if echo "$COMMAND" | grep -qE 'docker\s+system\s+prune\s+-a'; then
   REASON="Docker system prune -a removes all unused images and containers"
 fi
 
-# chmod/chown on broad paths
-if echo "$COMMAND" | grep -qE '(chmod|chown)\s+-R\s+.*\s+/'; then
+# chmod/chown -R on the filesystem root or a system directory. Recursive perms
+# on app/home paths (/srv/app, /var/www, /home/u/app) stay allowed — those are
+# routine for deploys and were false-positives under the old `.*\s+/` matcher.
+if echo "$COMMAND" | grep -qE '(chmod|chown)\s+-R\s+([^;&|]*\s)?/((etc|usr|bin|sbin|lib|lib64|boot|dev|proc|sys|root|System|Library)(/|[[:space:]]|[;&|]|$)|[[:space:]]*($|[;&|]))'; then
   BLOCKED=true
-  REASON="Recursive permission change on root path"
+  REASON="Recursive permission change on a system directory"
 fi
 
 if [ "$BLOCKED" = true ]; then

--- a/.claude/hooks/branch-protect.sh
+++ b/.claude/hooks/branch-protect.sh
@@ -33,11 +33,15 @@ TOOL_NAME=$(parse_json_field "tool_name")
 COMMAND=$(parse_json_field "command")
 [ -z "$COMMAND" ] && exit 0
 
+# `git push` possibly preceded by global options like `git -c key=val push`.
+# Matching the prefix means `git -c color.ui=always push origin main` can't slip by.
+GIT_PUSH='git\s+(-c\s+\S+\s+)*push'
+
 # Check for force push (check first — always block regardless of branch)
 # Allow --force-with-lease (safer alternative) but block --force and -f
-if echo "$COMMAND" | grep -qE 'git\s+push\s+.*--force-with-lease'; then
+if echo "$COMMAND" | grep -qE "${GIT_PUSH}\s+.*--force-with-lease"; then
   : # Allow --force-with-lease (only overwrites if remote matches expectations)
-elif echo "$COMMAND" | grep -qE 'git\s+push\s+.*--force|git\s+push\s+.*-f\b'; then
+elif echo "$COMMAND" | grep -qE "${GIT_PUSH}\s+.*--force|${GIT_PUSH}\s+.*-f\b"; then
   bump_branch_block
   echo "BLOCKED: Force push detected"
   echo ""
@@ -47,8 +51,15 @@ elif echo "$COMMAND" | grep -qE 'git\s+push\s+.*--force|git\s+push\s+.*-f\b'; th
   exit 2
 fi
 
-# Check for git push to protected branches (explicit branch name)
-if echo "$COMMAND" | grep -qE 'git\s+push\s+(\S+\s+)?(main|master)\s*($|[;&|])|git\s+push\s+.*\s+HEAD:(main|master)\b'; then
+# Check for git push to a protected branch, named explicitly. Two shapes:
+#   1. main/master as the final positional arg, regardless of how many options
+#      precede it:  git push origin main | git push -u origin main |
+#                   git push --set-upstream origin main
+#   2. a refspec whose DESTINATION is protected:  HEAD:main | local:master |
+#      main:main   (pushing TO main). `git push origin main:feature` is allowed —
+#      that pushes local main to a feature branch, not to remote main.
+if echo "$COMMAND" | grep -qE "${GIT_PUSH}\s+(\S+\s+)*(main|master)([[:space:]]|[;&|]|$)" \
+  || echo "$COMMAND" | grep -qE "${GIT_PUSH}\s+.*:(main|master)([[:space:]]|[;&|]|$)"; then
   bump_branch_block
   echo "BLOCKED: Direct push to main/master branch"
   echo ""
@@ -59,7 +70,7 @@ if echo "$COMMAND" | grep -qE 'git\s+push\s+(\S+\s+)?(main|master)\s*($|[;&|])|g
 fi
 
 # Check for `git push <remote> HEAD` when on main/master
-if echo "$COMMAND" | grep -qE 'git\s+push\s+\S+\s+HEAD\b'; then
+if echo "$COMMAND" | grep -qE "${GIT_PUSH}\s+\S+\s+HEAD\b"; then
   CURRENT_BRANCH=$(git branch --show-current 2>/dev/null) || CURRENT_BRANCH=""
   if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ]; then
     bump_branch_block
@@ -72,8 +83,9 @@ if echo "$COMMAND" | grep -qE 'git\s+push\s+\S+\s+HEAD\b'; then
   fi
 fi
 
-# Check for bare `git push` when on main/master (no branch specified)
-if echo "$COMMAND" | grep -qE '(^|[;&|]\s*)git\s+push(\s+-u)?(\s+origin)?\s*($|[;&|])'; then
+# Check for bare `git push` (no branch given) while on main/master. Tolerates
+# `-u`/`--set-upstream` and an explicit remote: `git push`, `git push -u origin`.
+if echo "$COMMAND" | grep -qE "(^|[;&|]\s*)${GIT_PUSH}(\s+(-u|--set-upstream))?(\s+origin)?\s*($|[;&|])"; then
   CURRENT_BRANCH=$(git branch --show-current 2>/dev/null) || CURRENT_BRANCH=""
   if [ -z "$CURRENT_BRANCH" ]; then
     exit 0  # Cannot determine branch, allow the push

--- a/.claude/hooks/conventional-commit.sh
+++ b/.claude/hooks/conventional-commit.sh
@@ -26,12 +26,14 @@ if ! echo "$COMMAND" | grep -qE 'git\s+commit'; then
   exit 0
 fi
 
-# Extract commit message from -m/--message flag
-MSG=$(echo "$COMMAND" | grep -oE '(-m|--message)[[:space:]]*"[^"]*"' | sed -E 's/(-m|--message)[[:space:]]*"//;s/"$//' || echo "")
+# Extract commit message. Matches -m, --message, AND combined short flags that
+# end in m (e.g. -am, -sm) — `git commit -am "..."` previously slipped through
+# because the literal substring "-m" never appears in "-am".
+MSG=$(echo "$COMMAND" | grep -oE '(-[a-zA-Z]*m|--message)[[:space:]]*"[^"]*"' | sed -E 's/^(-[a-zA-Z]*m|--message)[[:space:]]*"//;s/"$//' || echo "")
 
 # Also try single quotes
 if [ -z "$MSG" ]; then
-  MSG=$(echo "$COMMAND" | grep -oE "(-m|--message)[[:space:]]*'[^']*'" | sed -E "s/(-m|--message)[[:space:]]*'//;s/'$//" || echo "")
+  MSG=$(echo "$COMMAND" | grep -oE "(-[a-zA-Z]*m|--message)[[:space:]]*'[^']*'" | sed -E "s/^(-[a-zA-Z]*m|--message)[[:space:]]*'//;s/'\$//" || echo "")
 fi
 
 # If using heredoc or no -m flag, skip validation

--- a/.claude/hooks/loop-detect.sh
+++ b/.claude/hooks/loop-detect.sh
@@ -24,10 +24,15 @@ esac
 FILE_PATH=$(parse_json_field "file_path")
 [ -z "$FILE_PATH" ] && exit 0
 
-# Track file in a session-scoped temp file
-TRACK_FILE="/tmp/claude-loop-detect-$$"
-# Use parent PID for session scope (agent runs hooks as child processes)
-TRACK_FILE="/tmp/claude-loop-detect-${PPID:-$$}"
+# Track edits in a project-scoped state file keyed by session id. $PPID is NOT
+# stable across separately-spawned PostToolUse hooks — each invocation got its
+# own track file, so the counter never accumulated and the guard never fired.
+# CLAUDE_PROJECT_DIR + session_id are stable for the life of a session.
+ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
+SESSION_ID=$(parse_json_field "session_id")
+STATE_DIR="$ROOT/.hook-state"
+mkdir -p "$STATE_DIR" 2>/dev/null || true
+TRACK_FILE="$STATE_DIR/loop-detect-${SESSION_ID:-session}.log"
 
 # Append current edit
 echo "$FILE_PATH" >> "$TRACK_FILE"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -87,7 +87,13 @@ jobs:
 
   kitbench:
     name: KitBench (hook scenarios)
-    runs-on: ubuntu-latest
+    # Run on macOS too — the product ships bash + targets macOS, and the hooks
+    # use grep/sed/basename whose BSD vs GNU differences this leg catches.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -100,6 +106,21 @@ jobs:
         run: |
           chmod +x .claude/hooks/*.sh scripts/run-bench.sh
           ./scripts/run-bench.sh
+
+  install-test:
+    name: Install / Uninstall smoke test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Smoke-test install -> upgrade -> uninstall
+        run: |
+          chmod +x install.sh uninstall.sh scripts/*.sh .claude/hooks/*.sh
+          bash scripts/test-install.sh
 
   manifest-sync:
     name: Manifest Sync

--- a/.kit-manifest
+++ b/.kit-manifest
@@ -61,10 +61,6 @@
 .claude/skills/testing-audit
 .claude/skills/ui-component-builder
 .kit-manifest
-CLAUDE.md
-CODEBASE_MAP.md
-DESIGN.md
-VERSION
 agent_docs/architecture-language.md
 agent_docs/contracts.md
 agent_docs/conventions.md
@@ -75,6 +71,9 @@ agent_docs/skills.md
 agent_docs/subagents.md
 agent_docs/testing.md
 agent_docs/workflow.md
+CLAUDE.md
+CODEBASE_MAP.md
+DESIGN.md
 scripts/build-skills.sh
 scripts/convert.sh
 scripts/doctor.sh
@@ -87,10 +86,12 @@ scripts/note.sh
 scripts/run-bench.sh
 scripts/statusline.sh
 scripts/sync-manifest.sh
+scripts/test-install.sh
 scripts/validate-skills.sh
 scripts/validate.sh
 tasks/decisions.md
 tasks/handoff.md
-tasks/lessons/_TEMPLATE.md
 tasks/lessons/_index.md
+tasks/lessons/_TEMPLATE.md
 tasks/todo.md
+VERSION

--- a/.kit-manifest
+++ b/.kit-manifest
@@ -61,6 +61,10 @@
 .claude/skills/testing-audit
 .claude/skills/ui-component-builder
 .kit-manifest
+CLAUDE.md
+CODEBASE_MAP.md
+DESIGN.md
+VERSION
 agent_docs/architecture-language.md
 agent_docs/contracts.md
 agent_docs/conventions.md
@@ -71,9 +75,6 @@ agent_docs/skills.md
 agent_docs/subagents.md
 agent_docs/testing.md
 agent_docs/workflow.md
-CLAUDE.md
-CODEBASE_MAP.md
-DESIGN.md
 scripts/build-skills.sh
 scripts/convert.sh
 scripts/doctor.sh
@@ -91,7 +92,6 @@ scripts/validate-skills.sh
 scripts/validate.sh
 tasks/decisions.md
 tasks/handoff.md
-tasks/lessons/_index.md
 tasks/lessons/_TEMPLATE.md
+tasks/lessons/_index.md
 tasks/todo.md
-VERSION

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Then fill in `CODEBASE_MAP.md` with your project's details and start a Claude Co
 |------|-------------|
 | `--template nextjs` | Use a stack-specific template (`nextjs`, `node-api`, `python-fastapi`). Auto-detected if omitted. |
 | `--profile minimal` | Hooks only, no CLAUDE.md or docs |
-| `--profile strict` | All hooks enabled (auto-lint, auto-format, skill-extract-reminder) |
+| `--profile strict` | All hooks enabled — the 4 opt-in ones too (auto-lint, auto-format, skill-compliance, skill-extract-reminder) |
 | `--upgrade` | Add new files without overwriting your customizations |
 | `--diff` | Compare local installation against latest kit (read-only) |
 | `--gitignore` | Add kit files to `.gitignore` (keep kit local, don't push to repo) |
@@ -99,6 +99,7 @@ curl -fsSL .../install.sh | bash -s -- --version v1.0.0
 ```bash
 npx @tansuasici/claude-code-kit init              # Install kit
 npx @tansuasici/claude-code-kit doctor            # Check installation health
+npx @tansuasici/claude-code-kit skills            # List available /skill commands
 npx @tansuasici/claude-code-kit convert all       # Export to Cursor/Windsurf/Aider/AGENTS.md
 npx @tansuasici/claude-code-kit generate agents-md  # Generate AGENTS.md only
 npx @tansuasici/claude-code-kit --version         # Show version
@@ -303,6 +304,11 @@ Each template includes a customized `CLAUDE.md` with stack-specific rules and a 
 | `nextjs` | Next.js 16, App Router, Prisma, Tailwind | Server/Client Component rules, build verification |
 | `node-api` | Express, TypeScript, Knex.js | Layered architecture, API design conventions |
 | `python-fastapi` | FastAPI, SQLAlchemy 2.0, Pydantic v2 | Async patterns, dependency injection, Alembic |
+| `go` | Go modules, stdlib-first | Error wrapping, context propagation, `-race` tests, small interfaces |
+| `rust` | Cargo, edition-pinned | `Result`/`?` (no `unwrap`), clippy `-D warnings`, `unsafe` gating |
+| `django` | Django (+ DRF), ORM | Fat models, migration discipline, N+1 avoidance, settings-via-env |
+
+Auto-detected from your project files (`next.config.*`, `go.mod`, `Cargo.toml`, `manage.py`, `requirements.txt`, `package.json`) when `--template` is omitted.
 
 ## Scripts
 
@@ -318,6 +324,7 @@ Each template includes a customized `CLAUDE.md` with stack-specific rules and a 
 | `./scripts/build-skills.sh` | Builds SKILL.md from `.tmpl` templates + shared blocks |
 | `./scripts/migrate-lessons.sh` | One-time migration from legacy `tasks/lessons.md` to per-file `tasks/lessons/` structure |
 | `./scripts/run-bench.sh` | Runs KitBench — every hook scenario in `bench/scenarios/` (CI runs this on each PR) |
+| `./scripts/test-install.sh` | Smoke-tests install → upgrade → uninstall on a throwaway project (CI runs this on ubuntu + macOS) |
 | `./scripts/sync-manifest.sh` | Regenerates `.kit-manifest`; `--check` fails CI when it's stale |
 | `./scripts/lesson-resurface.sh` | Backs `/lesson-resurface` — returns dormant-lesson pointers matched by topic |
 | `./scripts/lesson-graph.sh` | Generates the `tasks/lessons/_index.md` auto-sections from `applies_to` tags |
@@ -435,7 +442,19 @@ claude-code-kit/
       accessibility-audit/         # WCAG 2.1 AA compliance
       dependency-audit/            # Vulnerability & license checks
       documentation-audit/         # Doc quality & sync audit
+      doc-gardening/               # Docs↔code drift detection
       project-health-report/       # Comprehensive health report
+      review-pipeline/             # Parallel multi-audit review (PR-scope)
+      quality-audit/               # golden-principles.yaml drift audit
+      constitution/                # Author/extend golden-principles.yaml
+      references-sync/             # Sync llms.txt-style dependency refs
+      harness-init/                # Scaffold docs/ harness structure
+      feature-cycle/               # End-to-end lifecycle orchestrator
+      lesson-refresh/              # Periodic tasks/lessons/ refresh
+      lesson-resurface/            # Surface dormant lessons by topic
+      pulse/                       # Time-windowed outcome report
+      scorecard/                   # Session-telemetry scorecard
+      note/                        # Session-journal note (across compaction)
       ship/                        # Deployment pipeline
       retro/                       # Sprint retrospective & analytics
       office-hours/                # Pre-coding product validation

--- a/bench/scenarios/s26-block-dangerous-rm-system-path.json
+++ b/bench/scenarios/s26-block-dangerous-rm-system-path.json
@@ -1,0 +1,6 @@
+{
+  "name": "s26-block-dangerous-rm-system-path",
+  "hook": ".claude/hooks/block-dangerous-commands.sh",
+  "payload": { "tool_name": "Bash", "tool_input": { "command": "sudo rm -rf /etc/nginx" } },
+  "expect": { "exit_code": 2, "stdout_contains": ["BLOCKED"] }
+}

--- a/bench/scenarios/s27-block-dangerous-rm-no-preserve-root.json
+++ b/bench/scenarios/s27-block-dangerous-rm-no-preserve-root.json
@@ -1,0 +1,6 @@
+{
+  "name": "s27-block-dangerous-rm-no-preserve-root",
+  "hook": ".claude/hooks/block-dangerous-commands.sh",
+  "payload": { "tool_name": "Bash", "tool_input": { "command": "rm -rf --no-preserve-root /" } },
+  "expect": { "exit_code": 2, "stdout_contains": ["BLOCKED"] }
+}

--- a/bench/scenarios/s28-block-dangerous-allows-project-rm.json
+++ b/bench/scenarios/s28-block-dangerous-allows-project-rm.json
@@ -1,0 +1,6 @@
+{
+  "name": "s28-block-dangerous-allows-project-rm",
+  "hook": ".claude/hooks/block-dangerous-commands.sh",
+  "payload": { "tool_name": "Bash", "tool_input": { "command": "rm -rf node_modules dist" } },
+  "expect": { "exit_code": 0, "stdout_empty": true }
+}

--- a/bench/scenarios/s29-block-dangerous-chmod-system.json
+++ b/bench/scenarios/s29-block-dangerous-chmod-system.json
@@ -1,0 +1,6 @@
+{
+  "name": "s29-block-dangerous-chmod-system",
+  "hook": ".claude/hooks/block-dangerous-commands.sh",
+  "payload": { "tool_name": "Bash", "tool_input": { "command": "chmod -R 777 /etc" } },
+  "expect": { "exit_code": 2, "stdout_contains": ["BLOCKED"] }
+}

--- a/bench/scenarios/s30-block-dangerous-allows-chown-app.json
+++ b/bench/scenarios/s30-block-dangerous-allows-chown-app.json
@@ -1,0 +1,6 @@
+{
+  "name": "s30-block-dangerous-allows-chown-app",
+  "hook": ".claude/hooks/block-dangerous-commands.sh",
+  "payload": { "tool_name": "Bash", "tool_input": { "command": "chown -R deploy:deploy /srv/app" } },
+  "expect": { "exit_code": 0, "stdout_empty": true }
+}

--- a/bench/scenarios/s31-branch-protect-blocks-push-u-main.json
+++ b/bench/scenarios/s31-branch-protect-blocks-push-u-main.json
@@ -1,0 +1,6 @@
+{
+  "name": "s31-branch-protect-blocks-push-u-main",
+  "hook": ".claude/hooks/branch-protect.sh",
+  "payload": { "tool_name": "Bash", "tool_input": { "command": "git push -u origin main" } },
+  "expect": { "exit_code": 2, "stdout_contains": ["BLOCKED"] }
+}

--- a/bench/scenarios/s32-branch-protect-blocks-refspec-dest-main.json
+++ b/bench/scenarios/s32-branch-protect-blocks-refspec-dest-main.json
@@ -1,0 +1,6 @@
+{
+  "name": "s32-branch-protect-blocks-refspec-dest-main",
+  "hook": ".claude/hooks/branch-protect.sh",
+  "payload": { "tool_name": "Bash", "tool_input": { "command": "git push origin feature:main" } },
+  "expect": { "exit_code": 2, "stdout_contains": ["BLOCKED"] }
+}

--- a/bench/scenarios/s33-branch-protect-blocks-git-c-push-main.json
+++ b/bench/scenarios/s33-branch-protect-blocks-git-c-push-main.json
@@ -1,0 +1,6 @@
+{
+  "name": "s33-branch-protect-blocks-git-c-push-main",
+  "hook": ".claude/hooks/branch-protect.sh",
+  "payload": { "tool_name": "Bash", "tool_input": { "command": "git -c color.ui=always push origin main" } },
+  "expect": { "exit_code": 2, "stdout_contains": ["BLOCKED"] }
+}

--- a/bench/scenarios/s34-branch-protect-allows-feature-branch.json
+++ b/bench/scenarios/s34-branch-protect-allows-feature-branch.json
@@ -1,0 +1,6 @@
+{
+  "name": "s34-branch-protect-allows-feature-branch",
+  "hook": ".claude/hooks/branch-protect.sh",
+  "payload": { "tool_name": "Bash", "tool_input": { "command": "git push -u origin feat/search" } },
+  "expect": { "exit_code": 0, "stdout_empty": true }
+}

--- a/bench/scenarios/s35-conventional-commit-blocks-am-badmsg.json
+++ b/bench/scenarios/s35-conventional-commit-blocks-am-badmsg.json
@@ -1,0 +1,6 @@
+{
+  "name": "s35-conventional-commit-blocks-am-badmsg",
+  "hook": ".claude/hooks/conventional-commit.sh",
+  "payload": { "tool_name": "Bash", "tool_input": { "command": "git commit -am \"updated stuff\"" } },
+  "expect": { "exit_code": 2, "stdout_contains": ["BLOCKED"] }
+}

--- a/bench/scenarios/s36-conventional-commit-allows-am-goodmsg.json
+++ b/bench/scenarios/s36-conventional-commit-allows-am-goodmsg.json
@@ -1,0 +1,6 @@
+{
+  "name": "s36-conventional-commit-allows-am-goodmsg",
+  "hook": ".claude/hooks/conventional-commit.sh",
+  "payload": { "tool_name": "Bash", "tool_input": { "command": "git commit -am \"feat: add search endpoint\"" } },
+  "expect": { "exit_code": 0, "stdout_empty": true }
+}

--- a/bench/scenarios/s37-loop-detect-blocks-on-repeated-edit.json
+++ b/bench/scenarios/s37-loop-detect-blocks-on-repeated-edit.json
@@ -1,0 +1,9 @@
+{
+  "name": "s37-loop-detect-blocks-on-repeated-edit",
+  "hook": ".claude/hooks/loop-detect.sh",
+  "setup_files": {
+    ".hook-state/loop-detect-session.log": "src/foo.ts\nsrc/foo.ts\nsrc/foo.ts\nsrc/foo.ts\nsrc/foo.ts\n"
+  },
+  "payload": { "tool_name": "Edit", "tool_input": { "file_path": "src/foo.ts" } },
+  "expect": { "exit_code": 2, "stdout_contains": ["BLOCKED"] }
+}

--- a/bench/scenarios/s38-loop-detect-quiet-on-first-edit.json
+++ b/bench/scenarios/s38-loop-detect-quiet-on-first-edit.json
@@ -1,0 +1,6 @@
+{
+  "name": "s38-loop-detect-quiet-on-first-edit",
+  "hook": ".claude/hooks/loop-detect.sh",
+  "payload": { "tool_name": "Edit", "tool_input": { "file_path": "src/bar.ts" } },
+  "expect": { "exit_code": 0, "stdout_empty": true }
+}

--- a/bin/cli.sh
+++ b/bin/cli.sh
@@ -24,13 +24,14 @@ Claude Code Kit — Staff-engineer discipline for AI coding agents
 Usage:
   claude-code-kit init [options]        Install kit into current directory
   claude-code-kit doctor                Check installation health
+  claude-code-kit skills                List available /skill commands
   claude-code-kit convert [target]      Export agents (cursor|windsurf|aider|agents-md|all)
   claude-code-kit generate agents-md    Generate AGENTS.md from project sources
 
 Init options:
   --upgrade              Upgrade existing installation
   --profile <name>       Installation profile (minimal|standard|strict)
-  --template <name>      Stack template (nextjs|node-api|python-fastapi)
+  --template <name>      Stack template (nextjs|node-api|python-fastapi|go|rust|django)
   --dest <path>          Target directory (default: current directory)
 
 Examples:
@@ -57,6 +58,27 @@ case "$CMD" in
       echo "Error: doctor.sh not found. Run 'claude-code-kit init' first."
       exit 1
     fi
+    ;;
+  skills)
+    SKILLS_DIR="./.claude/skills"
+    if [ ! -d "$SKILLS_DIR" ]; then
+      echo "Error: .claude/skills/ not found. Run 'claude-code-kit init' first."
+      exit 1
+    fi
+    count=0
+    echo "Available skills — invoke any with /<name>:"
+    echo ""
+    for d in "$SKILLS_DIR"/*/; do
+      [ -d "$d" ] || continue
+      name="$(basename "$d")"
+      case "$name" in _*) continue ;; esac   # skip _shared / _templates
+      [ -f "$d/SKILL.md" ] || continue
+      desc="$(sed -n '/^---$/,/^---$/p' "$d/SKILL.md" | grep -m1 '^description:' | sed 's/^description:[[:space:]]*//;s/^["'\'']//;s/["'\'']$//')"
+      printf '  /%-22s %s\n' "$name" "$desc"
+      count=$((count + 1))
+    done
+    echo ""
+    echo "$count skills. They also auto-load via Claude Code's semantic matching."
     ;;
   convert)
     shift

--- a/examples/django/CLAUDE.md
+++ b/examples/django/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md — Node.js API Project
+# CLAUDE.md — Django Project
 
 ## Session Boot (Tiered)
 At the start of every session, load context in tiers — not everything at once.
@@ -36,25 +36,19 @@ This is the single most important rule for long sessions.
 
 ## Tech-Specific Rules
 
-### Node.js / Express
-- Use async/await — never raw callbacks
-- All route handlers must have error handling (use error middleware)
-- Validate request input at the boundary (zod, joi, or similar)
-- Never trust `req.body`, `req.params`, or `req.query` without validation
-- Use environment variables for all config — never hardcode secrets
-- Keep controllers thin: validate input -> call service -> return response
+### Django
+- Fat models, thin views, skinny templates. Business logic lives in models or a `services.py`, not in views.
+- **Every model change is a migration.** Run `makemigrations`, review the generated migration, and never hand-edit applied migrations. Migrations are a protected change (see below).
+- ORM discipline: avoid N+1 queries — reach for `select_related` (FK) / `prefetch_related` (M2M/reverse). Don't pull whole tables into Python; filter in the DB.
+- Settings via environment, never hardcoded secrets. Keep `DEBUG = False` assumptions for prod code paths; split settings per environment if the project does.
+- Use the ORM and `QuerySet` methods over raw SQL; if raw SQL is unavoidable, parameterize it (never string-format user input).
+- Forms / DRF serializers do validation — don't trust request data in views. Use Django's auth + permissions; never roll your own password handling.
+- Prefer class-based views / DRF viewsets consistent with the project; match the existing app structure.
 
-### Database
-- All queries go through the service layer, never directly in routes
-- Use transactions for multi-step operations
-- Parameterized queries only — never string interpolation for SQL
-- Migrations must be reversible
-
-### API Design
-- RESTful conventions: `GET /users`, `POST /users`, `GET /users/:id`
-- Consistent error response format: `{ error: { code, message } }`
-- Use proper HTTP status codes (don't return 200 for everything)
-- Version the API if it has external consumers (`/api/v1/`)
+### Style
+- Follow the project's formatter/linter (`black` + `ruff`/`flake8`, `isort`). Match it exactly.
+- Tests: `pytest` + `pytest-django` or `manage.py test` — match what's there. Use factories (`factory_boy`) if present; otherwise fixtures.
+- Type hints where the project uses them; run `mypy` if configured.
 
 ---
 
@@ -75,20 +69,24 @@ For any task touching 3+ files, architectural decisions, new dependencies, or wo
 
 ## Protected Changes (Approval Required)
 Stop and request approval before:
-- New dependencies
-- Database schema / migration changes
-- API contract changes (new endpoints, changed response shapes)
-- Auth / permission middleware
-- Docker or deployment config changes
+- New dependencies (`pip install` / `requirements*.txt` / `pyproject.toml`)
+- **Model changes / migrations** (`makemigrations`, editing `models.py`)
+- `settings.py` changes (esp. `INSTALLED_APPS`, `MIDDLEWARE`, `DATABASES`, `AUTH_*`)
+- Auth / permission logic
+- URL contract changes (public routes, DRF API shape)
+- Celery / task-queue topology changes
+- Deployment / WSGI/ASGI config changes
 
 ---
 
 ## Verification (Mandatory Order)
-1. `npx tsc --noEmit` (typecheck)
-2. `npm run lint` (ESLint)
-3. `npm test` (unit + integration tests)
-4. Smoke test: `curl` the endpoint, verify response
-5. Optional before merge: `/review-pipeline` for multi-lens audit over the PR diff
+1. `python manage.py check` (system checks)
+2. `ruff check .` (or `flake8`) and `black --check .`
+3. `mypy .` (if the project uses it)
+4. `python manage.py makemigrations --check --dry-run` (no un-generated migrations)
+5. `pytest` (or `python manage.py test`)
+6. Smoke test: run `python manage.py runserver`, hit the view/endpoint, verify real behavior
+7. Optional before merge: `/review-pipeline` for multi-lens audit over the PR diff
 
 ---
 
@@ -118,10 +116,3 @@ Read only what's relevant to the current task:
 - Skills guide → `agent_docs/skills.md`
 - Task contracts (completion criteria) → `agent_docs/contracts.md`
 - Prompting & bias awareness → `agent_docs/prompting.md`
-
----
-
-## Project Overlay
-If `CLAUDE.project.md` exists, read it after this file. Project-specific rules override kit defaults.
-If `agent_docs/project/` contains docs, load them when relevant to the current task.
-Project hooks in `.claude/hooks/project/` are configured separately in settings and are never modified by kit upgrades.

--- a/examples/django/CODEBASE_MAP.md
+++ b/examples/django/CODEBASE_MAP.md
@@ -1,0 +1,74 @@
+# CODEBASE_MAP.md
+
+## What
+
+<!-- One paragraph: what this Django app does and who uses it. -->
+A Django [web app / REST API] that [does X for Y].
+
+## Why
+
+<!-- The problem it solves and the core constraints. -->
+
+## Tech Stack
+
+- **Framework**: Django <!-- version --> <!-- + Django REST Framework if API -->
+- **Python**: <!-- version, see requirements/pyproject -->
+- **Database**: <!-- PostgreSQL (recommended) / MySQL / SQLite -->
+- **Async / tasks**: <!-- Celery + Redis/RabbitMQ, or none -->
+- **Auth**: Django auth <!-- + DRF tokens / JWT / sessions -->
+- **Testing**: <!-- pytest + pytest-django, or manage.py test -->
+
+## Key Commands
+
+| Action | Command |
+|--------|---------|
+| Run dev server | `python manage.py runserver` |
+| System checks | `python manage.py check` |
+| Make migrations | `python manage.py makemigrations` |
+| Check for missing migrations | `python manage.py makemigrations --check --dry-run` |
+| Apply migrations | `python manage.py migrate` |
+| Tests | `pytest` (or `python manage.py test`) |
+| Lint / format | `ruff check . && black --check .` |
+| Shell | `python manage.py shell` |
+
+## Directory Structure
+
+```text
+.
+├── manage.py           # Django CLI entry point
+├── config/             # project package (settings, urls, wsgi/asgi)
+│   ├── settings/       # base.py / dev.py / prod.py (or settings.py)
+│   ├── urls.py         # root URL conf
+│   └── wsgi.py
+├── apps/               # your Django apps
+│   └── <app>/
+│       ├── models.py   # data model (migrations are protected)
+│       ├── views.py    # thin views
+│       ├── services.py # business logic (fat models / services)
+│       ├── serializers.py  # DRF (if API)
+│       └── migrations/
+├── requirements.txt    # dependencies (protected)
+└── pytest.ini / pyproject.toml
+```
+
+## Critical Files
+
+| File | Purpose |
+|------|---------|
+| `config/settings/` | Settings per environment (protected) |
+| `config/urls.py` | URL → view routing |
+| `apps/<app>/models.py` | Data model — changes require migrations (protected) |
+| `requirements.txt` | Dependency set (protected) |
+| <!-- add your core apps --> | |
+
+## Architecture
+
+<!-- App boundaries, request flow (URL → view → service → model), where business logic lives. -->
+
+## Known Constraints
+
+<!-- Django/Python version floor, DB engine assumptions, sync vs async, migration policy. -->
+
+## Environment
+
+<!-- Required env vars (SECRET_KEY, DATABASE_URL, ...), secrets management, local setup. -->

--- a/examples/go/CLAUDE.md
+++ b/examples/go/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md — Node.js API Project
+# CLAUDE.md — Go Project
 
 ## Session Boot (Tiered)
 At the start of every session, load context in tiers — not everything at once.
@@ -36,25 +36,19 @@ This is the single most important rule for long sessions.
 
 ## Tech-Specific Rules
 
-### Node.js / Express
-- Use async/await — never raw callbacks
-- All route handlers must have error handling (use error middleware)
-- Validate request input at the boundary (zod, joi, or similar)
-- Never trust `req.body`, `req.params`, or `req.query` without validation
-- Use environment variables for all config — never hardcode secrets
-- Keep controllers thin: validate input -> call service -> return response
+### Go
+- Target the module's Go version in `go.mod`; don't bump it without approval.
+- Errors are values: return them, wrap with `fmt.Errorf("...: %w", err)` to preserve the chain, and check every one. Never discard with `_` unless you document why.
+- No naked `panic` in library code — reserve panics for truly unrecoverable init. Recover only at well-defined boundaries.
+- Propagate `context.Context` as the first parameter through call chains; honor cancellation and deadlines. Never store a `Context` in a struct.
+- Keep interfaces small and define them at the consumer, not the producer. Accept interfaces, return concrete types.
+- Avoid package-level mutable state and `init()` side effects. Prefer explicit dependency injection.
+- Concurrency: a goroutine's lifetime must be owned by its caller. Guard shared state with a mutex or a channel; run `go test -race` on anything concurrent.
 
-### Database
-- All queries go through the service layer, never directly in routes
-- Use transactions for multi-step operations
-- Parameterized queries only — never string interpolation for SQL
-- Migrations must be reversible
-
-### API Design
-- RESTful conventions: `GET /users`, `POST /users`, `GET /users/:id`
-- Consistent error response format: `{ error: { code, message } }`
-- Use proper HTTP status codes (don't return 200 for everything)
-- Version the API if it has external consumers (`/api/v1/`)
+### Project layout & style
+- Follow the existing layout (`cmd/`, `internal/`, `pkg/`). Put non-exported app code under `internal/`.
+- `gofmt`/`goimports` is non-negotiable — match it exactly. Exported identifiers get doc comments starting with the identifier name.
+- Table-driven tests with subtests (`t.Run`). Use the standard `testing` package; match the project's assertion style (don't add testify if it isn't already used).
 
 ---
 
@@ -75,20 +69,24 @@ For any task touching 3+ files, architectural decisions, new dependencies, or wo
 
 ## Protected Changes (Approval Required)
 Stop and request approval before:
-- New dependencies
+- New dependencies (`go get`) or `go.mod` / `go.sum` changes
+- Bumping the Go version or build constraints
+- Public API changes to exported packages
 - Database schema / migration changes
-- API contract changes (new endpoints, changed response shapes)
-- Auth / permission middleware
-- Docker or deployment config changes
+- Auth / permission logic
+- Concurrency model changes (worker pools, channel topology)
+- `Dockerfile`, CI, or deployment config changes
 
 ---
 
 ## Verification (Mandatory Order)
-1. `npx tsc --noEmit` (typecheck)
-2. `npm run lint` (ESLint)
-3. `npm test` (unit + integration tests)
-4. Smoke test: `curl` the endpoint, verify response
-5. Optional before merge: `/review-pipeline` for multi-lens audit over the PR diff
+1. `gofmt -l .` (must print nothing) and `goimports -l .`
+2. `go vet ./...`
+3. `golangci-lint run` (if the project uses it)
+4. `go build ./...`
+5. `go test ./... -race` (tests + data-race detector)
+6. Smoke test: run the binary / hit the endpoint, verify real behavior
+7. Optional before merge: `/review-pipeline` for multi-lens audit over the PR diff
 
 ---
 
@@ -118,10 +116,3 @@ Read only what's relevant to the current task:
 - Skills guide → `agent_docs/skills.md`
 - Task contracts (completion criteria) → `agent_docs/contracts.md`
 - Prompting & bias awareness → `agent_docs/prompting.md`
-
----
-
-## Project Overlay
-If `CLAUDE.project.md` exists, read it after this file. Project-specific rules override kit defaults.
-If `agent_docs/project/` contains docs, load them when relevant to the current task.
-Project hooks in `.claude/hooks/project/` are configured separately in settings and are never modified by kit upgrades.

--- a/examples/go/CODEBASE_MAP.md
+++ b/examples/go/CODEBASE_MAP.md
@@ -1,0 +1,66 @@
+# CODEBASE_MAP.md
+
+## What
+
+<!-- One paragraph: what this service/CLI does and who uses it. -->
+A Go [service / CLI / library] that [does X for Y].
+
+## Why
+
+<!-- The problem it solves and the core constraints (latency, throughput, footprint). -->
+
+## Tech Stack
+
+- **Language**: Go (see `go.mod` for the pinned version)
+- **HTTP / RPC**: <!-- net/http, chi, gin, gRPC, connect — pick one and state it -->
+- **Persistence**: <!-- database/sql + pgx / sqlc / GORM, or none -->
+- **Config**: <!-- env vars, viper, flags -->
+- **Logging**: <!-- slog (stdlib), zap, zerolog -->
+- **Testing**: standard `testing` + `go test -race` <!-- + testify if used -->
+
+## Key Commands
+
+| Action | Command |
+|--------|---------|
+| Build | `go build ./...` |
+| Run | `go run ./cmd/<app>` |
+| Test (with race detector) | `go test ./... -race` |
+| Coverage | `go test ./... -cover` |
+| Vet | `go vet ./...` |
+| Lint | `golangci-lint run` |
+| Format | `gofmt -w . && goimports -w .` |
+| Tidy modules | `go mod tidy` |
+
+## Directory Structure
+
+```text
+.
+├── cmd/<app>/          # main packages (entry points)
+├── internal/           # private application code (not importable externally)
+│   ├── <domain>/       # domain logic
+│   └── platform/       # db, http, config wiring
+├── pkg/                # exported, reusable packages (if any)
+├── go.mod / go.sum     # module definition + checksums
+└── Makefile            # common task shortcuts (optional)
+```
+
+## Critical Files
+
+| File | Purpose |
+|------|---------|
+| `go.mod` | Module path, Go version, dependency set (protected) |
+| `cmd/<app>/main.go` | Process entry point + wiring |
+| `internal/platform/` | DB / HTTP / config bootstrap |
+| <!-- add your domain's core packages --> | |
+
+## Architecture
+
+<!-- Layering (handler → service → repository), context flow, concurrency model. -->
+
+## Known Constraints
+
+<!-- Go version floor, CGO on/off, deployment target, perf budgets. -->
+
+## Environment
+
+<!-- Required env vars, secrets management, local dev setup (docker-compose?). -->

--- a/examples/nextjs/CLAUDE.md
+++ b/examples/nextjs/CLAUDE.md
@@ -1,15 +1,23 @@
 # CLAUDE.md — Next.js Project
 
-## Session Boot
-At the start of every session:
+## Session Boot (Tiered)
+At the start of every session, load context in tiers — not everything at once.
+
+> _Partially enforced via_ `.claude/hooks/session-start.sh` _— it auto-injects pointers to Tier 1 files, the top rules, the active task, and the current branch. You still need to_ Read _the files themselves._
+
+**Tier 1 — Always (project awareness):**
 1. Read `CODEBASE_MAP.md`
 2. Read `CLAUDE.project.md` if it exists
-3. Read `tasks/lessons/_index.md` if it exists (Top Rules + index of lesson files)
-4. Read `tasks/decisions.md` if it exists
-5. Read the latest `tasks/handoff-*.md` if one exists
-6. Restate the current task in 1-2 sentences before doing anything
 
-Never start coding before this.
+**Tier 2 — If continuing work (active task context):**
+3. Read the latest `tasks/handoff-*.md` — only if one exists (indicates interrupted session)
+4. Read `tasks/todo.md` — only if active tasks exist
+
+**Tier 3 — On demand (load when relevant):**
+5. `tasks/lessons/_index.md` — read the `## Top Rules` section (first 15 lines). Read individual lesson files only when a decision could repeat a past mistake.
+6. `tasks/decisions.md` — read only when facing architectural choices or protected changes.
+
+Restate the current task in 1-2 sentences before doing anything. Never start coding before Tier 1 is loaded.
 
 ---
 
@@ -18,7 +26,9 @@ Context compaction can happen mid-session. When you detect a compaction (convers
 1. Re-read `tasks/todo.md` — restore awareness of the current task plan
 2. Re-read the specific files you were actively editing
 3. Re-read any contract file (`tasks/*_CONTRACT.md`) if one was active
-4. Do NOT continue coding until you've re-established context
+4. Re-read `tasks/lessons/_index.md` → `## Top Rules` section only
+5. Re-read `.hook-state/session-journal.md` if it exists — pre-compaction findings journaled with `/note` (lives only inside the current session; folded into the handoff at session end)
+6. Do NOT continue coding until you've re-established context
 
 This is the single most important rule for long sessions.
 

--- a/examples/python-fastapi/CLAUDE.md
+++ b/examples/python-fastapi/CLAUDE.md
@@ -1,15 +1,23 @@
 # CLAUDE.md — Python FastAPI Project
 
-## Session Boot
-At the start of every session:
+## Session Boot (Tiered)
+At the start of every session, load context in tiers — not everything at once.
+
+> _Partially enforced via_ `.claude/hooks/session-start.sh` _— it auto-injects pointers to Tier 1 files, the top rules, the active task, and the current branch. You still need to_ Read _the files themselves._
+
+**Tier 1 — Always (project awareness):**
 1. Read `CODEBASE_MAP.md`
 2. Read `CLAUDE.project.md` if it exists
-3. Read `tasks/lessons/_index.md` if it exists (Top Rules + index of lesson files)
-4. Read `tasks/decisions.md` if it exists
-5. Read the latest `tasks/handoff-*.md` if one exists
-6. Restate the current task in 1-2 sentences before doing anything
 
-Never start coding before this.
+**Tier 2 — If continuing work (active task context):**
+3. Read the latest `tasks/handoff-*.md` — only if one exists (indicates interrupted session)
+4. Read `tasks/todo.md` — only if active tasks exist
+
+**Tier 3 — On demand (load when relevant):**
+5. `tasks/lessons/_index.md` — read the `## Top Rules` section (first 15 lines). Read individual lesson files only when a decision could repeat a past mistake.
+6. `tasks/decisions.md` — read only when facing architectural choices or protected changes.
+
+Restate the current task in 1-2 sentences before doing anything. Never start coding before Tier 1 is loaded.
 
 ---
 
@@ -18,7 +26,9 @@ Context compaction can happen mid-session. When you detect a compaction (convers
 1. Re-read `tasks/todo.md` — restore awareness of the current task plan
 2. Re-read the specific files you were actively editing
 3. Re-read any contract file (`tasks/*_CONTRACT.md`) if one was active
-4. Do NOT continue coding until you've re-established context
+4. Re-read `tasks/lessons/_index.md` → `## Top Rules` section only
+5. Re-read `.hook-state/session-journal.md` if it exists — pre-compaction findings journaled with `/note` (lives only inside the current session; folded into the handoff at session end)
+6. Do NOT continue coding until you've re-established context
 
 This is the single most important rule for long sessions.
 

--- a/examples/rust/CLAUDE.md
+++ b/examples/rust/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md — Node.js API Project
+# CLAUDE.md — Rust Project
 
 ## Session Boot (Tiered)
 At the start of every session, load context in tiers — not everything at once.
@@ -36,25 +36,19 @@ This is the single most important rule for long sessions.
 
 ## Tech-Specific Rules
 
-### Node.js / Express
-- Use async/await — never raw callbacks
-- All route handlers must have error handling (use error middleware)
-- Validate request input at the boundary (zod, joi, or similar)
-- Never trust `req.body`, `req.params`, or `req.query` without validation
-- Use environment variables for all config — never hardcode secrets
-- Keep controllers thin: validate input -> call service -> return response
+### Rust
+- Honor the edition + toolchain pinned in `Cargo.toml` / `rust-toolchain.toml`; don't change them without approval.
+- Errors: return `Result<T, E>` with a typed error enum (`thiserror` for libraries, `anyhow` for binaries — match what the project uses). Propagate with `?`. **No `.unwrap()` / `.expect()` in non-test code** unless an invariant is documented inline.
+- Prefer borrowing over cloning. Don't sprinkle `.clone()` to silence the borrow checker — restructure ownership instead.
+- `unsafe` requires explicit approval and a `// SAFETY:` comment justifying every invariant.
+- Model state with the type system: use enums + exhaustive `match` over boolean flags; make illegal states unrepresentable.
+- Async: pick the runtime already in use (`tokio` / `async-std`); don't block the executor with sync I/O. Don't hold a non-`Send` guard across an `.await`.
+- Public items get `///` doc comments; keep modules cohesive and re-export a clean crate API from `lib.rs`.
 
-### Database
-- All queries go through the service layer, never directly in routes
-- Use transactions for multi-step operations
-- Parameterized queries only — never string interpolation for SQL
-- Migrations must be reversible
-
-### API Design
-- RESTful conventions: `GET /users`, `POST /users`, `GET /users/:id`
-- Consistent error response format: `{ error: { code, message } }`
-- Use proper HTTP status codes (don't return 200 for everything)
-- Version the API if it has external consumers (`/api/v1/`)
+### Style
+- `rustfmt` is non-negotiable — match it exactly.
+- Clippy is part of the definition of done: the build must be clean under `cargo clippy -- -D warnings`.
+- Tests live in `#[cfg(test)] mod tests` (unit) and `tests/` (integration). Use `assert_eq!` / `assert!` from std.
 
 ---
 
@@ -75,20 +69,24 @@ For any task touching 3+ files, architectural decisions, new dependencies, or wo
 
 ## Protected Changes (Approval Required)
 Stop and request approval before:
-- New dependencies
+- New dependencies or `Cargo.toml` / `Cargo.lock` changes
+- Editing the edition, `rust-toolchain`, or feature flags
+- Any `unsafe` block
+- Public crate API (signatures, trait bounds, re-exports) changes
 - Database schema / migration changes
-- API contract changes (new endpoints, changed response shapes)
-- Auth / permission middleware
-- Docker or deployment config changes
+- Auth / permission logic
+- `build.rs`, CI, or deployment config changes
 
 ---
 
 ## Verification (Mandatory Order)
-1. `npx tsc --noEmit` (typecheck)
-2. `npm run lint` (ESLint)
-3. `npm test` (unit + integration tests)
-4. Smoke test: `curl` the endpoint, verify response
-5. Optional before merge: `/review-pipeline` for multi-lens audit over the PR diff
+1. `cargo fmt --check`
+2. `cargo clippy --all-targets -- -D warnings`
+3. `cargo check --all-targets`
+4. `cargo test`
+5. `cargo build --release` (catches release-only issues)
+6. Smoke test: run the binary / hit the endpoint, verify real behavior
+7. Optional before merge: `/review-pipeline` for multi-lens audit over the PR diff
 
 ---
 
@@ -118,10 +116,3 @@ Read only what's relevant to the current task:
 - Skills guide → `agent_docs/skills.md`
 - Task contracts (completion criteria) → `agent_docs/contracts.md`
 - Prompting & bias awareness → `agent_docs/prompting.md`
-
----
-
-## Project Overlay
-If `CLAUDE.project.md` exists, read it after this file. Project-specific rules override kit defaults.
-If `agent_docs/project/` contains docs, load them when relevant to the current task.
-Project hooks in `.claude/hooks/project/` are configured separately in settings and are never modified by kit upgrades.

--- a/examples/rust/CODEBASE_MAP.md
+++ b/examples/rust/CODEBASE_MAP.md
@@ -1,0 +1,67 @@
+# CODEBASE_MAP.md
+
+## What
+
+<!-- One paragraph: what this crate/binary does and who uses it. -->
+A Rust [CLI / service / library crate] that [does X for Y].
+
+## Why
+
+<!-- The problem it solves and the core constraints (safety, latency, footprint). -->
+
+## Tech Stack
+
+- **Language**: Rust (edition + toolchain pinned in `Cargo.toml` / `rust-toolchain.toml`)
+- **Async runtime**: <!-- tokio / async-std / none -->
+- **Web / RPC**: <!-- axum, actix-web, tonic — or none -->
+- **Error handling**: <!-- thiserror (libs) / anyhow (bins) -->
+- **Persistence**: <!-- sqlx, diesel, sea-orm — or none -->
+- **Testing**: `cargo test` <!-- + proptest / insta if used -->
+
+## Key Commands
+
+| Action | Command |
+|--------|---------|
+| Build | `cargo build` |
+| Release build | `cargo build --release` |
+| Run | `cargo run` |
+| Test | `cargo test` |
+| Lint (deny warnings) | `cargo clippy --all-targets -- -D warnings` |
+| Format | `cargo fmt` |
+| Check | `cargo check --all-targets` |
+| Docs | `cargo doc --open` |
+
+## Directory Structure
+
+```text
+.
+├── src/
+│   ├── main.rs         # binary entry point (or lib.rs for a library)
+│   ├── lib.rs          # crate root + public API re-exports
+│   └── <module>/       # cohesive modules
+├── tests/              # integration tests
+├── benches/            # benchmarks (optional)
+├── Cargo.toml          # crate manifest + dependencies (protected)
+└── Cargo.lock          # pinned dependency graph
+```
+
+## Critical Files
+
+| File | Purpose |
+|------|---------|
+| `Cargo.toml` | Crate metadata, edition, dependencies (protected) |
+| `src/main.rs` / `src/lib.rs` | Entry point / crate API surface |
+| `src/error.rs` | Error enum(s) (`thiserror`) if centralized |
+| <!-- add your core modules --> | |
+
+## Architecture
+
+<!-- Module boundaries, ownership/lifetime strategy, async task structure. -->
+
+## Known Constraints
+
+<!-- MSRV (minimum supported Rust version), no_std?, unsafe policy, perf budgets. -->
+
+## Environment
+
+<!-- Required env vars, secrets, local dev setup, feature flags. -->

--- a/install.sh
+++ b/install.sh
@@ -454,6 +454,15 @@ generate_strict_settings() {
             "command": ".claude/hooks/conventional-commit.sh"
           }
         ]
+      },
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/subagent-pre.sh"
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -498,6 +507,15 @@ generate_strict_settings() {
             "command": ".claude/hooks/bash-budget.sh"
           }
         ]
+      },
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/subagent-post.sh"
+          }
+        ]
       }
     ],
     "Stop": [
@@ -520,6 +538,10 @@ generate_strict_settings() {
           {
             "type": "command",
             "command": ".claude/hooks/session-end.sh"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/journal-fold.sh"
           }
         ]
       }
@@ -576,7 +598,7 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --help|-h)
-      echo "Usage: install.sh [--template nextjs|node-api|python-fastapi] [--profile minimal|standard|strict] [--upgrade] [--diff]"
+      echo "Usage: install.sh [--template nextjs|node-api|python-fastapi|go|rust|django] [--profile minimal|standard|strict] [--upgrade] [--diff]"
       echo ""
       echo "Options:"
       echo "  --template, -t   Use a stack-specific template (nextjs, node-api, python-fastapi)"
@@ -610,8 +632,8 @@ done
 # Validate template if provided
 if [ -n "$TEMPLATE" ]; then
   case "$TEMPLATE" in
-    nextjs|node-api|python-fastapi) ;;
-    *) error "Unknown template: $TEMPLATE. Options: nextjs, node-api, python-fastapi" ;;
+    nextjs|node-api|python-fastapi|go|rust|django) ;;
+    *) error "Unknown template: $TEMPLATE. Options: nextjs, node-api, python-fastapi, go, rust, django" ;;
   esac
 fi
 
@@ -628,7 +650,15 @@ auto_detect_template() {
   for f in "next.config.js" "next.config.mjs" "next.config.ts"; do
     [ -f "$dest/$f" ] && echo "nextjs" && return
   done
-  # Python
+  # Go
+  [ -f "$dest/go.mod" ] && echo "go" && return
+  # Rust
+  [ -f "$dest/Cargo.toml" ] && echo "rust" && return
+  # Django (manage.py, or Django pinned in requirements) — before generic Python
+  if [ -f "$dest/manage.py" ] || { [ -f "$dest/requirements.txt" ] && grep -qiE '^django([=<>!~ ]|$)' "$dest/requirements.txt" 2>/dev/null; }; then
+    echo "django" && return
+  fi
+  # Python (FastAPI / generic)
   for f in "requirements.txt" "pyproject.toml" "Pipfile" "setup.py"; do
     [ -f "$dest/$f" ] && echo "python-fastapi" && return
   done
@@ -945,13 +975,21 @@ if [ "$PROFILE" != "minimal" ]; then
   # Copy skills
   if [ ! -d "$DEST/.claude/skills" ]; then
     mkdir -p "$DEST/.claude/skills"
-    for f in "$CLONE_DIR/.claude/skills/"*; do [ -e "$f" ] && cp -r "$f" "$DEST/.claude/skills/"; done
+    # Skip build-only assets (_shared/, _templates/) — end users don't run
+    # build-skills.sh, and sync-manifest.sh excludes _* so shipping them would
+    # also break the manifest --check.
+    for f in "$CLONE_DIR/.claude/skills/"*; do
+      [ -e "$f" ] || continue
+      case "$(basename "$f")" in _*) continue ;; esac
+      cp -r "$f" "$DEST/.claude/skills/"
+    done
     SKILL_COUNT=$(find "$DEST/.claude/skills" -mindepth 1 -maxdepth 1 -type d ! -name "_*" 2>/dev/null | wc -l | tr -d ' ')
     ok "Created .claude/skills/ ($SKILL_COUNT skills)"
     # Track skill files in manifest
     for skill_dir in "$DEST/.claude/skills/"*/; do
       [ -d "$skill_dir" ] || continue
       local_name=$(basename "$skill_dir")
+      case "$local_name" in _*) continue ;; esac
       manifest_add ".claude/skills/$local_name"
     done
   elif [ "$UPGRADE" = true ]; then
@@ -959,6 +997,7 @@ if [ "$PROFILE" != "minimal" ]; then
     for skill_dir in "$CLONE_DIR/.claude/skills/"*/; do
       [ -d "$skill_dir" ] || continue
       local_name=$(basename "$skill_dir")
+      case "$local_name" in _*) continue ;; esac
       manifest_add ".claude/skills/$local_name"
       if [ ! -d "$DEST/.claude/skills/$local_name" ]; then
         cp -r "$skill_dir" "$DEST/.claude/skills/$local_name"
@@ -969,6 +1008,7 @@ if [ "$PROFILE" != "minimal" ]; then
     warn "Skipped .claude/skills/ (already exists)"
     for skill_dir in "$DEST/.claude/skills/"*/; do
       [ -d "$skill_dir" ] || continue
+      case "$(basename "$skill_dir")" in _*) continue ;; esac
       manifest_add ".claude/skills/$(basename "$skill_dir")"
     done
   fi
@@ -1122,14 +1162,7 @@ if [ "$GITIGNORE" = true ]; then
       echo "CODEBASE_MAP.md"
       echo "agent_docs/"
       echo "tasks/"
-      echo "scripts/doctor.sh"
-      echo "scripts/validate.sh"
-      echo "scripts/statusline.sh"
-      echo "scripts/convert.sh"
-      echo "scripts/validate-skills.sh"
-      echo "scripts/build-skills.sh"
-      echo "scripts/gen-skill-docs.sh"
-      echo "scripts/lesson-graph.sh"
+      echo "scripts/"
       echo ".claude/"
       if [ "$WIKI" = true ]; then
         echo "WIKI.md"

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -50,7 +50,7 @@ fi
 
 if [ -d "agent_docs" ]; then
   pass "agent_docs/ exists"
-  EXPECTED_DOCS=(workflow.md debugging.md testing.md conventions.md subagents.md hooks.md skills.md contracts.md prompting.md)
+  EXPECTED_DOCS=(workflow.md debugging.md testing.md conventions.md subagents.md hooks.md skills.md contracts.md prompting.md architecture-language.md)
   for doc in "${EXPECTED_DOCS[@]}"; do
     if [ ! -f "agent_docs/$doc" ]; then
       warn "agent_docs/$doc missing"

--- a/scripts/run-bench.sh
+++ b/scripts/run-bench.sh
@@ -47,7 +47,7 @@ while [[ $# -gt 0 ]]; do
     --verbose|-v) VERBOSE=1; shift ;;
     --json) JSON_OUT=1; shift ;;
     --help|-h)
-      sed -n '1,/^set -uo pipefail/p' "$0" | head -n -1 | sed 's/^# \{0,1\}//'
+      sed -n '1,/^set -uo pipefail/p' "$0" | sed '$d' | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     *) echo "Unknown option: $1" >&2; exit 2 ;;

--- a/scripts/sync-manifest.sh
+++ b/scripts/sync-manifest.sh
@@ -117,7 +117,10 @@ if [ -d .claude/skills ]; then
 fi
 
 # --- Render --------------------------------------------------------------
-NEW_MANIFEST=$(printf '%s\n' "${entries[@]}" | sort -u)
+# LC_ALL=C makes collation byte-deterministic across platforms — without it the
+# manifest's sort order differs between macOS (BSD locale) and Linux CI, so a
+# manifest regenerated on one would fail --check on the other.
+NEW_MANIFEST=$(printf '%s\n' "${entries[@]}" | LC_ALL=C sort -u)
 
 if [ "$CHECK_ONLY" -eq 1 ]; then
   CURRENT=$(cat .kit-manifest 2>/dev/null || echo "")

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# test-install.sh — smoke test for install.sh / uninstall.sh on a throwaway project.
+#
+# Exercises the code path that actually mutates a user's filesystem — fresh
+# install, --upgrade idempotency, and clean uninstall — and asserts the
+# results. The hooks have KitBench; this gives the installer the same kind of
+# contract. CI runs it on ubuntu + macOS; runs locally too.
+#
+# Exit codes: 0 all assertions passed · 1 one or more failed
+#
+
+set -uo pipefail
+
+KIT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FAILS=0
+pass() { echo "  ✓ $1"; }
+fail() { echo "  ✗ $1"; FAILS=$((FAILS + 1)); }
+rel() { echo "${1#"$TMP"/}"; }
+assert_file()   { [ -f "$1" ] && pass "exists: $(rel "$1")"     || fail "missing file: $(rel "$1")"; }
+assert_dir()    { [ -d "$1" ] && pass "exists: $(rel "$1")/"    || fail "missing dir: $(rel "$1")"; }
+assert_absent() { [ ! -e "$1" ] && pass "absent: $(rel "$1")"   || fail "should be absent: $(rel "$1")"; }
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/cck-install-test.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+# Make it look like a Node project so a template auto-detects (node-api),
+# and so we can assert the user's own files survive uninstall.
+echo '{"name":"fixture","version":"1.0.0"}' > "$TMP/package.json"
+
+echo "== fresh install =="
+if ! ( cd "$TMP" && bash "$KIT_ROOT/install.sh" --local "$KIT_ROOT" >"$TMP/.install.log" 2>&1 ); then
+  echo "install.sh failed:"; cat "$TMP/.install.log"; exit 1
+fi
+assert_file "$TMP/CLAUDE.md"
+assert_file "$TMP/CODEBASE_MAP.md"
+assert_file "$TMP/.claude/settings.json"
+assert_file "$TMP/.kit-manifest"
+HOOKS=$(find "$TMP/.claude/hooks" -maxdepth 1 -name '*.sh' 2>/dev/null | wc -l | tr -d ' ')
+[ "$HOOKS" -ge 18 ] && pass "hooks installed ($HOOKS)" || fail "too few hooks ($HOOKS, expected >=18)"
+assert_dir "$TMP/.claude/skills"
+# CLA-67 regression: build-only assets must NOT ship to user projects
+assert_absent "$TMP/.claude/skills/_shared"
+assert_absent "$TMP/.claude/skills/_templates"
+
+echo "== doctor =="
+if ( cd "$TMP" && bash ./scripts/doctor.sh >"$TMP/.doctor.log" 2>&1 ); then
+  pass "doctor reports healthy"
+else
+  fail "doctor reported a failure"; tail -8 "$TMP/.doctor.log"
+fi
+
+echo "== upgrade (idempotent) =="
+if ( cd "$TMP" && bash "$KIT_ROOT/install.sh" --local "$KIT_ROOT" --upgrade >"$TMP/.upgrade.log" 2>&1 ); then
+  pass "upgrade ran clean"
+else
+  fail "upgrade failed"; tail -8 "$TMP/.upgrade.log"
+fi
+assert_file "$TMP/CLAUDE.md"
+
+echo "== uninstall --force =="
+if ! ( cd "$TMP" && bash "$KIT_ROOT/uninstall.sh" --force >"$TMP/.uninstall.log" 2>&1 ); then
+  fail "uninstall.sh errored"; tail -8 "$TMP/.uninstall.log"
+fi
+assert_absent "$TMP/CLAUDE.md"
+assert_absent "$TMP/.claude/hooks"
+assert_absent "$TMP/.kit-manifest"
+# the user's own file must survive
+assert_file "$TMP/package.json"
+
+echo ""
+if [ "$FAILS" -eq 0 ]; then
+  echo "install-test: ALL PASS"
+else
+  echo "install-test: $FAILS FAIL"
+  exit 1
+fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -252,6 +252,8 @@ fi
 
 CLAUDE_FILES_TO_REMOVE=()
 [ -f "$DEST/.claude/settings.json" ] && CLAUDE_FILES_TO_REMOVE+=(".claude/settings.json")
+# Kit owns only extensions/README.md; user-installed extensions are preserved.
+[ -f "$DEST/.claude/extensions/README.md" ] && CLAUDE_FILES_TO_REMOVE+=(".claude/extensions/README.md")
 
 # --- Nothing to remove? ---
 
@@ -313,6 +315,12 @@ if [ -d "$DEST/.claude" ]; then
     case "$basename" in
       hooks|agents|skills|settings.json|settings.local.json) continue ;;
       .DS_Store) continue ;;
+      extensions)
+        # kit owns only extensions/README.md; count as remaining only if the
+        # user installed their own extensions under it.
+        [ -n "$(ls -A "$item" 2>/dev/null | grep -vx 'README.md')" ] && REMAINING=$((REMAINING + 1))
+        continue
+        ;;
       *) REMAINING=$((REMAINING + 1)) ;;
     esac
   done
@@ -427,6 +435,12 @@ if [ ${#CLAUDE_FILES_TO_REMOVE[@]} -gt 0 ]; then
     rm -f "$DEST/$f"
     ok "Removed $f"
   done
+fi
+
+# Remove the extensions/ slot only if it's now empty (user extensions preserved).
+if [ -d "$DEST/.claude/extensions" ]; then
+  rm -f "$DEST/.claude/extensions/.DS_Store"
+  rmdir "$DEST/.claude/extensions" 2>/dev/null && ok "Removed empty .claude/extensions/" || true
 fi
 
 # Clean up empty .claude/ directory


### PR DESCRIPTION
## What

Fixes the audit findings (**CLA-53 – CLA-69**) surfaced in a review of the hooks, installer, scripts, and docs, and adds the follow-up gaps (**CLA-70 – CLA-73**). All verified locally; KitBench is **38/38** and the installer smoke test passes on macOS.

## Safety hooks (critical)
- **CLA-53** `block-dangerous-commands` now blocks `rm -rf` on `/`, `/*`, system dirs (`/etc`, `/usr`, `/var`, …), whole-home (`~`, `~/Documents`, `/home/<user>`), and `--no-preserve-root`. Deep project/temp paths stay allowed.
- **CLA-54** `branch-protect` now catches `git push -u origin main`, `--set-upstream`, refspec destinations (`:main`), and `git -c k=v push origin main`.
- **CLA-56** `loop-detect` is keyed on `CLAUDE_PROJECT_DIR` + `session_id` instead of `$PPID` — it now actually accumulates and fires.
- **CLA-58** `chmod/chown -R` false-positive fixed (only `/` + true system dirs block; `/srv/app`, `/var/www`, `/home/…` allowed).
- **CLA-62** `conventional-commit` validates combined short flags (`git commit -am "…"`).
- **CLA-61** +13 KitBench scenarios (`s26`–`s38`) lock all of the above. **25 → 38/38.**

## Install / uninstall
- **CLA-57** `--profile strict` wires all 22 hooks (was dropping `journal-fold`, `subagent-pre/post`).
- **CLA-59** `uninstall` removes the kit's `extensions/README.md`, **preserves user extensions**, cleans the slot if empty.
- **CLA-60** `--gitignore` emits a blanket `scripts/` entry (was 8 of 14).
- **CLA-67** `_shared`/`_templates` (build-only) no longer copied into user projects.
- **CLA-55** `.kit-manifest` regenerated → `sync-manifest --check` green (CI was red).

## Scripts / docs
- **CLA-63** `run-bench.sh --help` works on BSD/macOS · **CLA-64** `doctor.sh` checks `architecture-language.md` · **CLA-65** README tree + strict-profile claim · **CLA-66** `marketplace.json` drops the non-existent `security-review` skill · **CLA-69** example templates use the tiered session boot.

## New
- **CLA-73** `go` / `rust` / `django` stack templates + auto-detect (`go.mod`, `Cargo.toml`, `manage.py`).
- **CLA-70** `cck skills` — lists installed `/skill` commands.
- **CLA-71 / CLA-72** CI: macOS KitBench leg + an install → upgrade → uninstall smoke test (`scripts/test-install.sh`), both on ubuntu + macOS.

## Verification
- `./scripts/run-bench.sh` → 38/38 PASS
- `./scripts/sync-manifest.sh --check` → in sync
- `./scripts/test-install.sh` → ALL PASS (macOS)
- `./scripts/doctor.sh` / `validate-skills.sh` → healthy · `markdownlint` → 0 errors · `bash -n` all edited scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
