### PR TITLE
fix: doctor opt-in hook classification + KitBench doc drift (38 scenarios)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ See `agent_docs/hooks.md` for how to enable the opt-in hooks and write your own.
 
 ### KitBench — hooks are tested
 
-The hooks above aren't documentation, they're a contract. The kit ships [`bench/`](bench/README.md): a reproducible eval harness with 25 scenarios covering every blocking hook plus regression tests for past bugs (composer.lock slip-through, `EXIT_CODE=$?` after `|| true`, `.github/workflows/ci.yml` basename-with-slash miss, word-boundary regex rejecting "authentication", stale quality-gate verdict blocking a fresh session). Run it any time with `./scripts/run-bench.sh`; CI runs it on every PR.
+The hooks above aren't documentation, they're a contract. The kit ships [`bench/`](bench/README.md): a reproducible eval harness with 38 scenarios covering every blocking hook plus regression tests for past bugs (composer.lock slip-through, `EXIT_CODE=$?` after `|| true`, `.github/workflows/ci.yml` basename-with-slash miss, word-boundary regex rejecting "authentication", stale quality-gate verdict blocking a fresh session). Run it any time with `./scripts/run-bench.sh`; CI runs it on every PR.
 
 ```text
 KitBench
@@ -237,7 +237,7 @@ KitBench
   s03-protect-changes-blocks-package-json           PASS
   ...                                               PASS
 ========================================
-  25/25 PASS  0 FAIL
+  38/38 PASS  0 FAIL
 ```
 
 ## Agents

--- a/bench/README.md
+++ b/bench/README.md
@@ -47,6 +47,19 @@ Each scenario runs in a **fresh temp directory** — no shared state between sce
 | s23 | `protect-changes-build-config-blocks-in-strict` | `CCK_PROTECT_BUILD_CONFIGS=1` + edit `tsconfig.json` → exit 2 — CLA-48 |
 | s24 | `protect-changes-build-config-warns-in-standard` | Edit `tsconfig.json` without the env → exit 0 (advisory, no block) — CLA-48 |
 | s25 | `protect-changes-allows-ui-component` | Edit `src/components/auth/LoginForm.tsx` → not blocked (UI ≠ auth logic) — CLA-48 |
+| s26 | `block-dangerous-rm-system-path` | `sudo rm -rf /etc/nginx` → exit 2 (system path) |
+| s27 | `block-dangerous-rm-no-preserve-root` | `rm -rf --no-preserve-root /` → exit 2 |
+| s28 | `block-dangerous-allows-project-rm` | `rm -rf node_modules dist` → exit 0 (project-local, allowed) |
+| s29 | `block-dangerous-chmod-system` | `chmod -R 777 /etc` → exit 2 (system path) |
+| s30 | `block-dangerous-allows-chown-app` | `chown -R deploy:deploy /srv/app` → exit 0 (app path, allowed) |
+| s31 | `branch-protect-blocks-push-u-main` | `git push -u origin main` → exit 2 |
+| s32 | `branch-protect-blocks-refspec-dest-main` | `git push origin feature:main` → exit 2 (refspec destination is `main`) |
+| s33 | `branch-protect-blocks-git-c-push-main` | `git -c color.ui=always push origin main` → exit 2 (`-c` flag can't smuggle past the matcher) |
+| s34 | `branch-protect-allows-feature-branch` | `git push -u origin feat/search` → exit 0 (feature branch, allowed) |
+| s35 | `conventional-commit-blocks-am-badmsg` | `git commit -am "updated stuff"` → exit 2 (non-conventional message) |
+| s36 | `conventional-commit-allows-am-goodmsg` | `git commit -am "feat: add search endpoint"` → exit 0 (conventional message) |
+| s37 | `loop-detect-blocks-on-repeated-edit` | Repeated `Edit` to `src/foo.ts` (pre-seeded loop log) → exit 2 |
+| s38 | `loop-detect-quiet-on-first-edit` | First `Edit` to `src/bar.ts` → exit 0 (no loop yet) |
 
 ## Add a scenario
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -134,14 +134,20 @@ if [ -f ".claude/settings.json" ]; then
     warn "Cannot validate JSON (no python3 or node found)"
   fi
 
-  # Check for orphan hooks (hook files not referenced in settings.json)
+  # Check for orphan hooks (hook files not referenced in settings.json).
+  # Opt-in hooks ship enabled only in the strict profile, so they're
+  # intentionally absent from the standard settings.json — not orphans.
+  # Keep in sync with the profile table in agent_docs/hooks.md.
   if [ -d ".claude/hooks" ]; then
     SETTINGS_CONTENT=$(cat .claude/settings.json)
+    OPT_IN_HOOKS=" auto-lint.sh auto-format.sh skill-compliance.sh skill-extract-reminder.sh "
     for hook in .claude/hooks/*.sh; do
       [ -f "$hook" ] || continue
       basename=$(basename "$hook")
       if echo "$SETTINGS_CONTENT" | grep -qF "$basename"; then
         pass "$basename is referenced in settings.json"
+      elif [[ "$OPT_IN_HOOKS" == *" $basename "* ]]; then
+        info "$basename is opt-in, not in standard profile (enable per agent_docs/hooks.md)"
       else
         warn "$basename exists but is NOT in settings.json (orphan hook)"
       fi


### PR DESCRIPTION
Fixes three doc/diagnostic drifts caught in review.

## 1. KitBench doc sync (docs)
- `README.md` KitBench blurb said **25 scenarios** / **25/25 PASS**; the harness has shipped **38** since 1.17.0 (s26–s38: `block-dangerous`, `branch-protect`, `conventional-commit`, `loop-detect`). Bumped the count and the sample-output footer.
- `bench/README.md` "What's covered" table ended at s25 — added rows for **s26–s38**, with assertions derived from each scenario JSON.

## 2. doctor opt-in vs orphan (fix)
- `scripts/doctor.sh` flagged the strict-profile opt-in hooks (`auto-lint`, `auto-format`, `skill-compliance`, `skill-extract-reminder`) as **"orphan hook"** warnings, even though they're intentionally absent from the standard `settings.json`.
- They now report as an informational **opt-in** line (no WARN). Genuinely-unreferenced hooks still warn.

## Verification
- `./scripts/run-bench.sh` → **38/38 PASS** (0 fail)
- `markdownlint-cli2 README.md bench/README.md` → 0 errors
- `bash -n scripts/doctor.sh` clean; running `doctor.sh` shows the four hooks as blue `—` opt-in lines, no orphan warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
