### PR TITLE
fix(hooks): harden json-parse.sh against field-name code injection

### DIFF
--- a/.claude/hooks/lib/json-parse.sh
+++ b/.claude/hooks/lib/json-parse.sh
@@ -11,17 +11,56 @@
 #   TOOL_NAME=$(parse_json_field "tool_name")
 #   FILE_PATH=$(parse_json_field "file_path")
 #
+#
+# Security contract:
+# - INPUT is expected to be one Claude hook JSON object. Invalid JSON, non-object
+#   JSON, missing fields, or unsupported values produce empty output.
+# - Field names must be simple keys: [A-Za-z_][A-Za-z0-9_]*. Do not pass jq
+#   filters, dotted paths, shell fragments, or user-controlled expressions.
+# - parse_json_field never evaluates field names as code; parser-specific queries
+#   receive the field as data.
 
 # Requires INPUT to be set by the calling script
 : "${INPUT:?json-parse.sh: INPUT variable must be set before sourcing}"
 
 parse_json_field() {
-  local field="$1"
+  local field="${1:-}"
+
+  if ! [[ "$field" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+    return 0
+  fi
+
   if command -v jq &>/dev/null; then
-    echo "$INPUT" | jq -r "(.tool_input.${field} // .${field}) // empty" 2>/dev/null || true
+    printf '%s' "$INPUT" | jq -r --arg field "$field" \
+      'if type == "object" then ((.tool_input? | objects | .[$field]) // .[$field] // empty) else empty end' \
+      2>/dev/null || true
   elif command -v python3 &>/dev/null; then
-    echo "$INPUT" | python3 -c "import sys,json;d=json.load(sys.stdin);v=d.get('tool_input',d);print(v.get('${field}',d.get('${field}','')))" 2>/dev/null || true
+    printf '%s' "$INPUT" | python3 -c '
+import json
+import sys
+
+field = sys.argv[1]
+try:
+    data = json.load(sys.stdin)
+    if not isinstance(data, dict):
+        sys.exit(0)
+    tool_input = data.get("tool_input")
+    if isinstance(tool_input, dict) and field in tool_input:
+        value = tool_input.get(field)
+    else:
+        value = data.get(field, "")
+    if value is None:
+        sys.exit(0)
+    if isinstance(value, bool):
+        sys.stdout.write("true" if value else "false")
+    elif isinstance(value, (dict, list)):
+        sys.stdout.write(json.dumps(value, separators=(",", ":")))
+    else:
+        sys.stdout.write(str(value))
+except (json.JSONDecodeError, OSError, TypeError):
+    pass
+' "$field" 2>/dev/null || true
   else
-    echo "$INPUT" | grep -oE "\"${field}\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | head -1 | sed 's/.*:[[:space:]]*"//;s/"$//' || true
+    printf '%s' "$INPUT" | grep -oE "\"${field}\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | head -1 | sed 's/.*:[[:space:]]*"//;s/"$//' || true
   fi
 }


### PR DESCRIPTION
## Problem

`.claude/hooks/lib/json-parse.sh` `parse_json_field()` interpolates the caller-supplied `${field}` straight into the `python3 -c` program and the `jq` filter:

```bash
python3 -c "import sys,json;d=json.load(sys.stdin);v=d.get('tool_input',d);print(v.get('${field}',d.get('${field}','')))"
jq -r "(.tool_input.${field} // .${field}) // empty"
```

That's a **command/code-injection pattern** — a `${field}` carrying a Python payload would be evaluated. The `security-guidance` review of a downstream consumer flagged it **HIGH**. Current callers only pass hardcoded literals (`"tool_name"`, `"file_path"`, …) so it isn't reachable today, but this is a shared primitive and must not treat field names as code.

## Fix

Replace with the hardened implementation (this is the version several downstream repos already pinned locally before `init --upgrade` clobbered it back to the vulnerable one):

- **Validate** `field` against `^[A-Za-z_][A-Za-z0-9_]*$` → return empty for anything else.
- Pass `field` as **data**, not code: `jq --arg field "$field"` and `python3 -c '…' "$field"` (read via `sys.argv[1]`).
- Proper type handling: bool → `true`/`false`, dict/list → compact JSON, `null`/missing → empty.
- Restore the **Security contract** doc block.
- The `grep` fallback keeps `${field}` only *after* the validation gate has constrained it to a safe identifier.

## Verification

```
$ bash -n json-parse.sh            # syntax OK
parse command   = [ls -la]         # normal parse unchanged
parse tool_name = [Bash]
parse "x');import os;os.system(...)#" = []   # injection blocked → empty
```

## Why this matters downstream

`init --upgrade` copies this file over locally-hardened versions, silently re-introducing the pattern on every upgrade. Shipping the hardened version in the kit stops the regression at the source.