### PR TITLE
feat(skills): router-style descriptions + web-read skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
     {
       "name": "claude-code-kit",
       "source": "./",
-      "description": "Plan → Confirm → Implement → Verify discipline for Claude Code. Tiered session boot, deterministic hooks (quality gate, protect-changes, branch-protect, secret-scan, conventional-commit, loop-detect, and more), 36 user-invocable skills across audit / workflow / meta / wiki categories, 6 review agents (code-reviewer, security-reviewer, qa-reviewer, planner, dead-code-remover, wiki-maintainer), a CLAUDE.md ruleset, lessons-as-memory, ADR decisions, and optional wiki + HTML-artifacts modules.",
+      "description": "Plan → Confirm → Implement → Verify discipline for Claude Code. Tiered session boot, deterministic hooks (quality gate, protect-changes, branch-protect, secret-scan, conventional-commit, loop-detect, and more), 37 user-invocable skills across audit / workflow / meta / wiki categories, 6 review agents (code-reviewer, security-reviewer, qa-reviewer, planner, dead-code-remover, wiki-maintainer), a CLAUDE.md ruleset, lessons-as-memory, ADR decisions, and optional wiki + HTML-artifacts modules.",
       "version": "1.17.2",
       "author": {
         "name": "tansuasici",

--- a/.claude/skills/_templates/code-quality-audit.tmpl
+++ b/.claude/skills/_templates/code-quality-audit.tmpl
@@ -1,6 +1,6 @@
 ---
 name: code-quality-audit
-description: Audits codebase for code smells, error handling gaps, and maintainability issues with actionable fix recommendations
+description: Audit code for smells, error-handling gaps, and maintainability issues with actionable fixes. Use for a general code-quality pass not tied to project rules. To audit against the project's golden-principles.yaml use /quality-audit instead.
 user-invocable: true
 ---
 

--- a/.claude/skills/_templates/dead-code-audit.tmpl
+++ b/.claude/skills/_templates/dead-code-audit.tmpl
@@ -1,6 +1,6 @@
 ---
 name: dead-code-audit
-description: Detects unused code including unreferenced functions, dead imports, orphan files, and unreachable branches
+description: Detect unused code — unreferenced functions, dead imports, orphan files, and unreachable branches. Use when hunting dead code before a cleanup or release, or when the user suspects code is unused.
 user-invocable: true
 ---
 

--- a/.claude/skills/_templates/testing-audit.tmpl
+++ b/.claude/skills/_templates/testing-audit.tmpl
@@ -1,6 +1,6 @@
 ---
 name: testing-audit
-description: Audits test suite for coverage gaps, test quality, flaky tests, and testing strategy alignment
+description: Audit the test suite for coverage gaps, test quality, flaky tests, and strategy alignment. Use when assessing test health before a release, or when tests feel weak, slow, or flaky.
 user-invocable: true
 ---
 

--- a/.claude/skills/accessibility-audit/SKILL.md
+++ b/.claude/skills/accessibility-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: accessibility-audit
-description: Audits UI code for WCAG 2.1 AA compliance including semantics, keyboard navigation, color contrast, and ARIA usage
+description: Audit UI code for WCAG 2.1 AA compliance — semantics, keyboard navigation, color contrast, and ARIA. Use when auditing accessibility or the user mentions a11y, screen readers, WCAG, or keyboard support. For visual/design quality use /design-review instead.
 user-invocable: true
 ---
 

--- a/.claude/skills/architecture-review/SKILL.md
+++ b/.claude/skills/architecture-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: architecture-review
-description: Reviews codebase architecture for SOLID violations, dependency health, module boundaries, and structural issues
+description: Review codebase architecture for SOLID violations, dependency health, module boundaries, and structural issues. Use when assessing whole-system structure or coupling. For single-module depth use /deepening-review; for a concrete refactor plan use /refactoring-guide.
 user-invocable: true
 ---
 

--- a/.claude/skills/code-quality-audit/SKILL.md
+++ b/.claude/skills/code-quality-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-quality-audit
-description: Audits codebase for code smells, error handling gaps, and maintainability issues with actionable fix recommendations
+description: Audit code for smells, error-handling gaps, and maintainability issues with actionable fixes. Use for a general code-quality pass not tied to project rules. To audit against the project's golden-principles.yaml use /quality-audit instead.
 user-invocable: true
 ---
 

--- a/.claude/skills/constitution/SKILL.md
+++ b/.claude/skills/constitution/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: constitution
-description: Author or extend the project's golden-principles.yaml — interactively for new repos, or by inferring + confirming candidates from existing code. Pairs with /quality-audit which reads the file.
+description: Author or extend the project's golden-principles.yaml — interactively for new repos, or by inferring and confirming candidates from existing code. Use when defining project coding principles or quality gates. Pairs with /quality-audit, which reads the file.
 user-invocable: true
 ---
 

--- a/.claude/skills/dead-code-audit/SKILL.md
+++ b/.claude/skills/dead-code-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dead-code-audit
-description: Detects unused code including unreferenced functions, dead imports, orphan files, and unreachable branches
+description: Detect unused code — unreferenced functions, dead imports, orphan files, and unreachable branches. Use when hunting dead code before a cleanup or release, or when the user suspects code is unused.
 user-invocable: true
 ---
 

--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debug
-description: Systematic root-cause debugging with evidence-before-fix enforcement and regression test generation
+description: Systematic root-cause debugging with evidence-before-fix enforcement and regression-test generation. Use when chasing a bug, failing test, error, crash, or unexpected behavior — before attempting a fix.
 user-invocable: true
 ---
 

--- a/.claude/skills/deepening-review/SKILL.md
+++ b/.claude/skills/deepening-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deepening-review
-description: Surface shallow modules as deepening candidates, then grill the chosen one interactively — depth/seam paradigm. Use for testability and AI-navigability when modules feel pass-through or fragmented.
+description: Surface shallow, pass-through modules as deepening candidates, then grill the chosen one interactively (Ousterhout depth/seam paradigm). Use when modules feel thin, fragmented, or hard to navigate. For whole-system structure use /architecture-review.
 user-invocable: true
 ---
 

--- a/.claude/skills/dependency-audit/SKILL.md
+++ b/.claude/skills/dependency-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dependency-audit
-description: Audits project dependencies for security vulnerabilities, outdated versions, license risks, and bloat
+description: Audit dependencies for security vulnerabilities, outdated versions, license risks, and bloat. Use when reviewing third-party packages, before a release, or when the user asks about CVEs, updates, or supply-chain risk.
 user-invocable: true
 ---
 

--- a/.claude/skills/design-review/SKILL.md
+++ b/.claude/skills/design-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design-review
-description: Reviews UI implementation for design consistency, visual quality, AI slop detection, and responsive behavior
+description: Review UI implementation for design consistency, visual quality, AI-slop detection, and responsive behavior. Use when evaluating how a built UI looks and feels. For accessibility use /accessibility-audit; to build new components use /ui-component-builder.
 user-invocable: true
 ---
 

--- a/.claude/skills/doc-gardening/SKILL.md
+++ b/.claude/skills/doc-gardening/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doc-gardening
-description: Cross-checks docs/ against current code — flags stale file paths, broken cross-references, removed APIs, and outdated examples
+description: Cross-check docs/ against current code — flag stale file paths, broken cross-references, removed APIs, and outdated examples. Use when docs may have drifted after code changes. For doc completeness and quality use /documentation-audit instead.
 user-invocable: true
 ---
 

--- a/.claude/skills/documentation-audit/SKILL.md
+++ b/.claude/skills/documentation-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: documentation-audit
-description: Audits code documentation quality including inline comments, API docs, README completeness, and doc-code sync
+description: Audit documentation quality — inline comments, API docs, README completeness, and doc-code sync. Use when assessing whether docs are good and complete. To catch docs that have gone stale versus the code use /doc-gardening instead.
 user-invocable: true
 ---
 

--- a/.claude/skills/feature-cycle/SKILL.md
+++ b/.claude/skills/feature-cycle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: feature-cycle
-description: End-to-end orchestrator that chains spec, plan, implement, verify, review, and ship from a local spec source. Runs the whole CLAUDE.md lifecycle as one command.
+description: End-to-end orchestrator chaining spec → plan → implement → verify → review → ship from a local spec — the whole CLAUDE.md lifecycle as one command. Use to drive a complete feature from a ready spec. To validate what to build first use /office-hours.
 user-invocable: true
 ---
 

--- a/.claude/skills/harness-init/SKILL.md
+++ b/.claude/skills/harness-init/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-init
-description: Scaffold a `docs/` harness structure (ARCHITECTURE, DESIGN, PLANS, QUALITY_SCORE, RELIABILITY + design-docs/, exec-plans/, references/). Idempotent — never overwrites existing files.
+description: Scaffold a docs/ harness (ARCHITECTURE, DESIGN, PLANS, QUALITY_SCORE, RELIABILITY plus design-docs/, exec-plans/, references/). Idempotent — never overwrites. Use once when adopting the harness pattern in a repo lacking docs/ structure.
 user-invocable: true
 ---
 

--- a/.claude/skills/interface-design/SKILL.md
+++ b/.claude/skills/interface-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: interface-design
-description: Design It Twice — spawn 3-4 parallel sub-agents producing radically different interfaces for a module, then compare on depth, locality, and seam placement. Use before committing to a new interface.
+description: Design It Twice — spawn 3-4 parallel sub-agents producing radically different interfaces for a module, then compare on depth, locality, and seam placement. Use before committing to a new interface or public API.
 user-invocable: true
 ---
 

--- a/.claude/skills/lesson-refresh/SKILL.md
+++ b/.claude/skills/lesson-refresh/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lesson-refresh
-description: Periodic refresh of tasks/lessons/ — decide keep/update/promote/encode/archive per lesson based on relevance, recency, and whether the rule was already encoded elsewhere. Headless-capable.
+description: Periodic maintenance of tasks/lessons/ — decide keep/update/promote/encode/archive per lesson by relevance, recency, and prior encoding. Use to prune lesson rot. To recall dormant lessons for the current task use /lesson-resurface instead.
 user-invocable: true
 ---
 

--- a/.claude/skills/lesson-resurface/SKILL.md
+++ b/.claude/skills/lesson-resurface/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lesson-resurface
-description: Surface archived or superseded lessons whose canonical topic tags match the current task — returns pointers (paths only), never lesson bodies. Used to recover dormant context without bloating Tier 1 boot or polluting Top Rules.
+description: Surface archived or superseded lessons whose topic tags match the current task — returns pointers (paths only), never bodies. Use when a task touches an area past sessions may have covered, to recover dormant context without bloating boot.
 user-invocable: true
 ---
 

--- a/.claude/skills/note/SKILL.md
+++ b/.claude/skills/note/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: note
-description: Append a timestamped mid-session note to the session journal — finding/decision/summary tags for across-compaction memory. The journal is folded to handoff at session end by .claude/hooks/journal-fold.sh.
+description: Append a timestamped mid-session note to the session journal — finding/decision/summary tags for across-compaction memory. Use when you discover something the session must remember past /compact. Folded to the handoff at session end.
 user-invocable: true
 ---
 

--- a/.claude/skills/office-hours/SKILL.md
+++ b/.claude/skills/office-hours/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: office-hours
-description: Pre-coding product validation using forcing functions — clarify what to build and why before writing any code
+description: Pre-coding product validation using forcing functions — clarify what to build and why before any code. Use at the start of a feature when scope or value is fuzzy. To turn a validated idea into a spec use /shape-spec; to run the build use /feature-cycle.
 user-invocable: true
 ---
 

--- a/.claude/skills/performance-audit/SKILL.md
+++ b/.claude/skills/performance-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: performance-audit
-description: Identifies performance bottlenecks including rendering, startup, memory, and I/O issues across any tech stack
+description: Identify performance bottlenecks — rendering, startup, memory, and I/O — across any stack. Use when the app is slow, before perf-sensitive releases, or when the user mentions latency, jank, or memory growth.
 user-invocable: true
 ---
 

--- a/.claude/skills/project-health-report/SKILL.md
+++ b/.claude/skills/project-health-report/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-health-report
-description: Generates a comprehensive project health report covering code quality, architecture, testing, dependencies, and documentation
+description: Comprehensive whole-project health report across code quality, architecture, testing, dependencies, and documentation. Use for a breadth-first snapshot of the entire repo. For PR-scope diffs use /review-pipeline; for one dimension use the specific /*-audit.
 user-invocable: true
 ---
 

--- a/.claude/skills/pulse/SKILL.md
+++ b/.claude/skills/pulse/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pulse
-description: Time-windowed pulse report on what shipped, broke, was learned, and is open. Saves to tasks/pulses/ as a timeline. Distinct from /retro (process) and /project-health-report (whole-project).
+description: Time-windowed pulse report on what shipped, broke, was learned, and is open — saved to tasks/pulses/ as a timeline. Use to summarize a recent period of work. Distinct from /retro (process) and /project-health-report (whole-project code health).
 user-invocable: true
 ---
 

--- a/.claude/skills/quality-audit/SKILL.md
+++ b/.claude/skills/quality-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quality-audit
-description: Audits codebase against project-defined golden-principles.yaml — runs deterministic detection rules and updates docs/QUALITY_SCORE.md
+description: Audit the codebase against the project's golden-principles.yaml — runs deterministic detection rules and updates docs/QUALITY_SCORE.md. Use to enforce project-specific principles. For a generic smell pass with no rules file use /code-quality-audit.
 user-invocable: true
 ---
 

--- a/.claude/skills/refactoring-guide/SKILL.md
+++ b/.claude/skills/refactoring-guide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: refactoring-guide
-description: Provides Fowler-based refactoring recommendations with specific techniques, risk assessment, and step-by-step execution plans
+description: Fowler-based refactoring recommendations with specific techniques, risk assessment, and step-by-step plans. Use when code needs restructuring and you want a safe execution plan. To first locate structural issues use /architecture-review.
 user-invocable: true
 ---
 

--- a/.claude/skills/references-sync/SKILL.md
+++ b/.claude/skills/references-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: references-sync
-description: Syncs llms.txt-style dependency reference docs into docs/references/ so the agent has library docs in-context — scans package manifests and fetches known vendor references
+description: Sync llms.txt-style dependency reference docs into docs/references/ so the agent has library docs in-context — scans package manifests and fetches known vendor references. Use when working with a third-party library whose docs aren't yet local.
 user-invocable: true
 ---
 

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: retro
-description: Weekly retrospective with session analytics, LOC metrics, pattern detection, and persistent history
+description: Weekly retrospective with session analytics, LOC metrics, pattern detection, and persistent history. Use to reflect on how work went over a week. For what shipped/broke as a timeline use /pulse; for raw session numbers use /scorecard.
 user-invocable: true
 ---
 

--- a/.claude/skills/review-pipeline/SKILL.md
+++ b/.claude/skills/review-pipeline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-pipeline
-description: Run multiple audits in parallel over a PR-scope diff, dedupe across auditors, and produce a confidence-gated report. Distinct from /project-health-report (whole-project, breadth-first).
+description: Run multiple audits in parallel over a PR-scope diff, dedupe across auditors, and produce a confidence-gated report. Use to review a change or PR before merge. Distinct from /project-health-report (whole-project, breadth-first).
 user-invocable: true
 ---
 

--- a/.claude/skills/scorecard/SKILL.md
+++ b/.claude/skills/scorecard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scorecard
-description: Aggregate recent session scorecards from reports/session-audit.log into a per-session + windowed-summary report. Pure numbers, fed by the SessionEnd hook.
+description: Aggregate recent session scorecards from reports/session-audit.log into per-session and windowed summaries — pure numbers, fed by the SessionEnd hook. Use to see quantitative session trends. For narrative reflection use /retro instead.
 user-invocable: true
 ---
 

--- a/.claude/skills/shape-spec/SKILL.md
+++ b/.claude/skills/shape-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shape-spec
-description: Creates a timestamped feature spec folder with structured plan, decisions, and references for multi-session features
+description: Create a timestamped feature-spec folder with structured plan, decisions, and references for multi-session features. Use to capture a spec before building something non-trivial. To validate the idea first use /office-hours; to execute it use /feature-cycle.
 user-invocable: true
 ---
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship
-description: Full deployment pipeline — tests, coverage audit, CHANGELOG generation, bisectable commits, and PR creation
+description: Full deployment pipeline — tests, coverage audit, CHANGELOG generation, bisectable commits, and PR creation. Use when a change is verified and ready to ship as a pull request.
 user-invocable: true
 ---
 

--- a/.claude/skills/skill-extractor/SKILL.md
+++ b/.claude/skills/skill-extractor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-extractor
-description: Extracts non-obvious knowledge discovered during sessions into reusable SKILL.md files
+description: Extract non-obvious knowledge discovered during a session into a reusable SKILL.md. Use right after learning something hard-won — a framework quirk, a verified fix. To generate skills proactively from stack analysis use /skill-generator instead.
 user-invocable: true
 ---
 
@@ -78,7 +78,7 @@ Before saving a skill, verify:
 - [ ] The solution has been tested in this session
 - [ ] The skill doesn't duplicate existing knowledge in `CLAUDE.md` or `tasks/lessons/`
 - [ ] The YAML frontmatter has accurate `name` and `description`
-- [ ] The description is specific enough for semantic matching to work
+- [ ] The description is router-style: capability + a "Use when…" trigger (+ a negative trigger when it overlaps a sibling) — see agent_docs/skills.md
 - [ ] The skill includes a concrete "Why" with the problem it solves
 - [ ] At least one "what goes wrong without this" example is included
 - [ ] The rationale was confirmed by the user, not inferred by the agent

--- a/.claude/skills/skill-extractor/resources/skill-template.md
+++ b/.claude/skills/skill-extractor/resources/skill-template.md
@@ -1,6 +1,6 @@
 ---
 name: <kebab-case-name>
-description: <one-line description for semantic matching>
+description: <capability + "Use when…" trigger; add "Do NOT use… / use /X instead" if it overlaps another skill>
 user-invocable: false
 ---
 

--- a/.claude/skills/skill-generator/SKILL.md
+++ b/.claude/skills/skill-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-generator
-description: Generates project-specific coding skills by analyzing tech stack, architecture, and constraints
+description: Generate project-specific coding skills by analyzing tech stack, architecture, and constraints. Use when bootstrapping skills for a new project. To capture a single insight discovered mid-session use /skill-extractor instead.
 user-invocable: true
 ---
 
@@ -139,7 +139,7 @@ Generate skills from these categories as relevant:
 Before saving any generated skill:
 
 - [ ] Follows the kit skill template format
-- [ ] YAML description is specific enough for semantic matching
+- [ ] YAML description is router-style: capability + a "Use when…" trigger (+ "Do NOT use… / use /X instead" when it overlaps another skill)
 - [ ] Does not duplicate existing CLAUDE.md rules or skills
 - [ ] Code examples use the project's actual stack and versions
 - [ ] Rules are testable (can be verified by lint, test, or review)

--- a/.claude/skills/testing-audit/SKILL.md
+++ b/.claude/skills/testing-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing-audit
-description: Audits test suite for coverage gaps, test quality, flaky tests, and testing strategy alignment
+description: Audit the test suite for coverage gaps, test quality, flaky tests, and strategy alignment. Use when assessing test health before a release, or when tests feel weak, slow, or flaky.
 user-invocable: true
 ---
 

--- a/.claude/skills/ui-component-builder/SKILL.md
+++ b/.claude/skills/ui-component-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ui-component-builder
-description: Build production-ready UI components with accessibility, loading/empty/error states, responsive behavior, and reusable prop design — not retrofitted polish
+description: Build production-ready UI components with accessibility, loading/empty/error states, responsive behavior, and reusable props — not retrofitted polish. Use when creating a new component. To review an existing UI use /design-review instead.
 user-invocable: true
 ---
 

--- a/.claude/skills/web-read/SKILL.md
+++ b/.claude/skills/web-read/SKILL.md
@@ -80,4 +80,4 @@ Clean Markdown of the page's main content, with site chrome removed. Use it as t
 - Defuddle is a global CLI (`npm i -g defuddle`), not a project dependency — it never touches `package.json`, so it doesn't trip the Protected-Changes dependency gate. Surface the install anyway before running it.
 - The token win is real on heavy pages (docs sites, news, marketing): raw HTML through WebFetch carries layout, scripts, and nav that Defuddle drops.
 - Pairs with `/references-sync`, which can call this to extract vendor docs before writing `docs/references/<pkg>-llms.txt`.
-- Upstream: https://github.com/kepano/defuddle
+- Upstream: <https://github.com/kepano/defuddle>

--- a/.claude/skills/web-read/SKILL.md
+++ b/.claude/skills/web-read/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: web-read
+description: Extract clean, readable markdown from a web page with the Defuddle CLI — strips nav, ads, and boilerplate to cut tokens versus WebFetch. Use when given a URL to read or analyze (docs, articles, blogs, changelogs, RFCs). Do NOT use for .md or JSON/API URLs — use WebFetch directly.
+user-invocable: true
+---
+
+# Web Read
+
+## Core Rule
+
+When handed a content URL to read, extract clean markdown with the Defuddle CLI instead of pulling raw HTML through WebFetch — it strips nav, ads, cookie banners, and boilerplate, so the same content costs far fewer tokens. Never silently install a global tool: if Defuddle is missing, surface the one-line install and fall back to WebFetch so the task isn't blocked.
+
+## When to Use
+
+When the user gives a URL to read, summarize, or analyze:
+
+- Documentation pages, API guides, RFCs, specs
+- Articles, blog posts, release notes, changelogs
+- Any standard, content-heavy web page
+
+Do NOT use for:
+
+- URLs ending in `.md` / `.txt` — already clean; use WebFetch directly
+- JSON / API endpoints — use WebFetch or `curl`
+- Pages behind auth — Defuddle fetches anonymously; use an authenticated path instead
+- Vendoring library docs into `docs/references/` — that's `/references-sync`'s job (it may call this skill to do the extraction step)
+
+## Prerequisites
+
+Check once per session:
+
+```bash
+command -v defuddle >/dev/null && echo ok || echo missing
+```
+
+If missing, tell the user the install and ask before running it — a global install is a tool change worth surfacing:
+
+```bash
+npm install -g defuddle
+```
+
+While it's unavailable, fall back to `WebFetch` rather than blocking.
+
+## Process
+
+1. Extract clean markdown:
+
+   ```bash
+   defuddle parse <url> --md
+   ```
+
+2. For long pages, save to a file and read only the slice you need instead of inlining the whole thing:
+
+   ```bash
+   defuddle parse <url> --md -o /tmp/<slug>.md
+   ```
+
+3. Pull a single metadata field when that's all you need:
+
+   ```bash
+   defuddle parse <url> -p title
+   defuddle parse <url> -p description
+   ```
+
+Run `defuddle --help` for the current flag set — prefer it over memorized options, it stays in sync with the installed version.
+
+## Output Format
+
+Clean Markdown of the page's main content, with site chrome removed. Use it as the source for summaries, extraction, or analysis; when you quote the page, quote from this cleaned text.
+
+| Flag | Output |
+|------|--------|
+| `--md` | Markdown — default choice |
+| `--json` | JSON with both HTML and markdown |
+| `-p <name>` | A single metadata field (`title`, `description`, `domain`) |
+| (none) | Raw HTML — rarely what you want |
+
+## Notes
+
+- Defuddle is a global CLI (`npm i -g defuddle`), not a project dependency — it never touches `package.json`, so it doesn't trip the Protected-Changes dependency gate. Surface the install anyway before running it.
+- The token win is real on heavy pages (docs sites, news, marketing): raw HTML through WebFetch carries layout, scripts, and nav that Defuddle drops.
+- Pairs with `/references-sync`, which can call this to extract vendor docs before writing `docs/references/<pkg>-llms.txt`.
+- Upstream: https://github.com/kepano/defuddle

--- a/.kit-manifest
+++ b/.kit-manifest
@@ -60,6 +60,7 @@
 .claude/skills/skill-generator
 .claude/skills/testing-audit
 .claude/skills/ui-component-builder
+.claude/skills/web-read
 .kit-manifest
 CLAUDE.md
 CODEBASE_MAP.md

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ User-invocable audit and guide skills — run with `/skill-name`:
 | `/harness-init` | Scaffolds the harness docs pattern (`docs/ARCHITECTURE.md`, design docs, references) without overwriting existing files *(supports `mode:headless`)* |
 | `/references-sync` | Populates `docs/references/<package>-llms.txt` so the agent reads curated library docs on demand *(supports `mode:headless`)* |
 | `/doc-gardening` | Prunes stale docs, fixes drift, and refreshes cross-references *(supports `mode:headless`)* |
+| `/web-read` | Extracts clean markdown from a URL via the Defuddle CLI to cut tokens vs WebFetch — falls back to WebFetch if the CLI isn't installed |
 | `/wiki-ingest` | Ingest source into knowledge wiki — summarize, cross-reference, update index *(requires `--wiki`)* |
 | `/wiki-lint` | Health-check the knowledge wiki — contradictions, orphans, stale content *(requires `--wiki`)* |
 | `/wiki-briefing` | Morning briefing from the wiki — recent activity, new sources, open items *(requires `--wiki`)* |

--- a/agent_docs/skills.md
+++ b/agent_docs/skills.md
@@ -86,14 +86,14 @@ Every skill — whether hand-written or generated — should follow these princi
 - [ ] Problem is clear to someone unfamiliar with the context
 - [ ] Solution has been verified in this session
 - [ ] Doesn't duplicate `CLAUDE.md` rules or existing lessons
-- [ ] YAML `description` is specific enough for semantic matching
+- [ ] YAML `description` is router-style — capability + a `Use when…` trigger (+ `Do NOT use… / use /X instead` when it overlaps another skill). See § Skill Conventions → Router-style description
 - [ ] Includes verification steps
 - [ ] Every rule has a rationale (WHY, not just WHAT)
 - [ ] Code examples use the project's actual stack and versions
 
 ## Skill Conventions (v1.11.0+)
 
-Three conventions all skills should follow. The `scripts/validate-skills.sh` validator warns when these are missing.
+Four conventions all skills should follow. The `scripts/validate-skills.sh` validator warns when these are missing.
 
 ### 1. Core Rule (required for every skill)
 
@@ -107,7 +107,21 @@ Form a single hypothesis at a time. Validate with a falsifiable test before fixi
 
 Goes immediately after the title (and the optional intro paragraph), before any other `##` section. The rule states what must be preserved or what's forbidden — the deal-breaker that distinguishes this skill from a free-form prompt. Inspired by [codex-complexity-optimizer](https://github.com/Kappaemme-git/codex-complexity-optimizer).
 
-### 2. Default Behavior (required for audit-class skills)
+### 2. Router-style description (required for every skill)
+
+The `description` is the skill's router — Claude reads it (not the body) to decide whether to fire. Write it as **capability + trigger**, not a bare capability statement:
+
+- **Capability** — what the skill does, in one clause.
+- **`Use when…`** — the concrete situations, user phrasings, or file types that should trigger it.
+- **`Do NOT use… / use /other-skill instead`** — a negative trigger whenever the skill overlaps a sibling. This is what stops the wrong skill from firing.
+
+```markdown
+description: Audit code for smells, error-handling gaps, and maintainability issues with actionable fixes. Use for a general code-quality pass not tied to project rules. To audit against the project's golden-principles.yaml use /quality-audit instead.
+```
+
+Keep it under ~500 characters (the validator warns past that). A capability-only description like "Systematic root-cause debugging" matches far worse than one that also says *when* to reach for it. For overlapping families — the `*-audit` skills, `retro` / `pulse` / `scorecard`, `skill-extractor` / `skill-generator`, `doc-gardening` / `documentation-audit` — the negative trigger is mandatory, not optional. Pattern borrowed from [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills), whose descriptions read as explicit routing instructions.
+
+### 3. Default Behavior (required for audit-class skills)
 
 Audit-class skills (skills with `## Output Format` that produce a structured report) include a `## Default Behavior` section telling the agent what to do **autonomously** when invoked. This removes friction from "audit / scan / review / give me a report" requests.
 
@@ -121,7 +135,7 @@ Only modify files when the user explicitly requests implement / fix / apply / re
 
 The 10 audit-class skills today: `code-quality-audit`, `performance-audit`, `architecture-review`, `accessibility-audit`, `testing-audit`, `dependency-audit`, `documentation-audit`, `design-review`, `project-health-report`, `dead-code-audit`.
 
-### 3. Phase 1 Inventory naming (audit-class skills)
+### 4. Phase 1 Inventory naming (audit-class skills)
 
 Audit-class skills use uniform Phase 1 naming and an explicit "candidates, not findings" framing — discouraging the agent from reporting raw scanner output as final findings.
 
@@ -132,6 +146,16 @@ This pass produces **candidates**, not findings. Treat counts as leads for deepe
 
 <phase-specific content>
 ```
+
+### Anti-staleness: defer to `--help`
+
+Skills that wrap a CLI (`ship`, `references-sync`, `web-read`) should point the agent at the tool's own `--help` / `help` output rather than hardcoding an exhaustive flag list:
+
+```markdown
+Run `<tool> --help` for the current flags — it stays in sync with the installed version.
+```
+
+A hardcoded command catalog rots the moment the tool updates; the tool's own help never does. Document the 3–5 common invocations inline for muscle memory, and defer the long tail to `--help`. Pattern borrowed from [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills) (`obsidian-cli`: *"Run `obsidian help`… This is always up to date."*).
 
 ### Reusable Shared Blocks
 

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -82,12 +82,16 @@ for skill_dir in "$SKILLS_DIR"/*/; do
     FM_DESC=$(echo "$FRONTMATTER" | grep -E '^description:' | sed 's/^description:[[:space:]]*//' || echo "")
     if [ -n "$FM_DESC" ]; then
       DESC_LEN=${#FM_DESC}
-      if [ "$DESC_LEN" -lt 10 ]; then
-        warn "Description too short ($DESC_LEN chars) — may not match semantically"
-      elif [ "$DESC_LEN" -gt 200 ]; then
-        warn "Description too long ($DESC_LEN chars) — keep under 200 chars"
+      if [ "$DESC_LEN" -lt 40 ]; then
+        warn "Description very short ($DESC_LEN chars) — router-style descriptions pair a capability with a 'Use when…' trigger"
+      elif [ "$DESC_LEN" -gt 500 ]; then
+        warn "Description too long ($DESC_LEN chars) — keep under ~500; move detail into the body"
       else
         pass "description: $FM_DESC"
+      fi
+      # Router-style nudge: the description should say WHEN to fire, not just what it does
+      if ! echo "$FM_DESC" | grep -qiE 'use (when|for|to|it|right|once|at|before|after|as|during|instead)|when the user|distinct from|do not use|triggers? on'; then
+        warn "Description has no 'Use when…' trigger clause — router-style descriptions match better (see agent_docs/skills.md → Skill Conventions → Router-style description)"
       fi
     else
       fail "Missing 'description' in frontmatter"


### PR DESCRIPTION
Adopts the router-description pattern from [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills) across the kit, and adds a clean-web-read skill.

## What changed
- **All 33 skill descriptions → router style**: capability + `Use when…` trigger, with `Do NOT use… / use /X instead` disambiguation for overlapping families (code-quality↔quality-audit, documentation-audit↔doc-gardening, skill-extractor↔skill-generator, the `*-audit` set). Bidirectional refs verified.
- **New `/web-read` skill**: clean-markdown URL extraction via the Defuddle CLI to cut tokens vs WebFetch. Dependency is **opt-in** (surfaces the global install, falls back to WebFetch) — no Protected-Changes breach.
- **Doctrine**: `agent_docs/skills.md` gains convention "Router-style description" + "Anti-staleness: defer to `--help`"; both skill checklists and the canonical template updated.
- **Validator**: description ceiling 200 → ~500 (router clauses are longer); added a "Use when…" trigger-clause nudge.
- Regenerated `.kit-manifest`; bumped hardcoded skill count 36 → 37.

## Review
- `validate-skills.sh`: **334 passed / 0 failed** (2 pre-existing optional-`Notes` warnings, unrelated)
- `build-skills.sh` 0 warnings · `doctor.sh` 57 passed / 0 failed · `bash -n` clean · manifest `--check` in sync
- Cross-ref integrity: no dangling `/skill` refs · `.tmpl`↔SKILL.md and SKILL.md↔skills-data.ts in sync

Not deployed. Web-side counterpart: tansuasici/claude-code-kit-web#48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
