### PR TITLE
feat(hooks): compaction-aware session-start + Auto Mode recipe (TAN-3894)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -2,14 +2,27 @@
 #
 # session-start.sh — SessionStart hook
 #
-# Injects minimal Tier 1 context at the start of every session, replacing
-# the CLAUDE.md prompt rule "Read CODEBASE_MAP.md, CLAUDE.project.md, lessons,
-# active todo" — which depends on the agent voluntarily following it.
+# Runs on every SessionStart source: "startup" (new), "resume", "clear", and
+# "compact" (fired mid-session right after a context compaction). It does two
+# related jobs depending on the source:
 #
-# Output: JSON with `additionalContext` (Claude Code injects this into the
-# session before the first user turn).
+#   • startup / resume / clear — the beginning of a working session: reset the
+#     transient per-session state and inject minimal Tier 1 context (project map
+#     pointers, top rules, active task, branch + dirty-tree status). Replaces the
+#     CLAUDE.md rule "read Tier 1 files at session start", which depends on the
+#     agent voluntarily following it.
 #
-# Reads stdin but does not require any payload. Always exits 0.
+#   • compact — does NOT reset session state (counters, the session clock, and
+#     the handoff scratchpad belong to the whole session and must survive a
+#     mid-session compaction) and instead re-injects the working anchors the
+#     compaction summary may have blurred: active task, top rules, any active
+#     contract, and the session journal. This is the deterministic half of
+#     CLAUDE.md's "After Compaction" rule. SessionStart(source="compact") is
+#     Claude Code's purpose-built channel for it — unlike PreCompact/PostCompact,
+#     its additionalContext actually reaches the model.
+#
+# Output: JSON with `additionalContext` (Claude Code injects it before the next
+# turn). Reads stdin but requires no payload. Always exits 0.
 #
 
 set -euo pipefail
@@ -25,30 +38,41 @@ STATE_DIR="$ROOT/.hook-state"
 mkdir -p "$STATE_DIR" 2>/dev/null || true
 [ -f "$STATE_DIR/.gitignore" ] || printf '*\n!.gitignore\n' >"$STATE_DIR/.gitignore" 2>/dev/null || true
 
-# Reset transient session counters from any prior session. session-end.sh has
-# already consumed them (or, if the prior session crashed, the next aggregator
-# would otherwise double-count). New session starts at zero.
-reset_state "$STATE_DIR/hook-firings.json"
-reset_state "$STATE_DIR/quality-gate-history.json"
-reset_state "$STATE_DIR/bash-budget.json"
-# Also clear the verdict stop-gate.sh reads. quality-gate.sh only overwrites it
-# on a qualifying edit, so a "failed" verdict from a prior session would
-# otherwise persist and block completion of a new session that makes no code
-# edit (e.g. a Markdown-only or Q&A session). New session starts with no verdict.
-reset_state "$STATE_DIR/last_quality_gate.json"
+# "startup" | "resume" | "clear" | "compact". A compact-source start fires
+# mid-session after a compaction; every other source marks a fresh session.
+SOURCE=$(parse_json_field "source" 2>/dev/null || true)
 
-# Clear the inter-agent handoff scratchpad (CLA-37). It is per-session: each
-# sub-agent overwrites it with a <=5-line summary on exit, and journal-fold.sh
-# folds it into the session handoff at SessionEnd. Start every session empty.
-: > "$STATE_DIR/agent-handoff.md" 2>/dev/null || true
+if [ "$SOURCE" != "compact" ]; then
+  # New session (startup/resume/clear) — reset transient per-session state.
+  # Deliberately skipped on "compact": resetting counters or the session clock
+  # mid-session would corrupt the session's metrics and clear the stop-gate
+  # verdict (stop-gate.sh would stop blocking a still-failing gate until the
+  # next qualifying edit).
 
-# Write session metadata. session-end.sh reads it to compute
-# session_duration_seconds and propagate session_id into the scorecard.
-SESSION_ID=$(parse_json_field "session_id" 2>/dev/null || true)
-NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-NOW_EPOCH=$(date +%s)
-if command -v python3 &>/dev/null; then
-  python3 - "$STATE_DIR/session-meta.json" "${SESSION_ID:-}" "$NOW" "$NOW_EPOCH" <<'PY' 2>/dev/null || true
+  # Reset transient session counters from any prior session. session-end.sh has
+  # already consumed them (or, if the prior session crashed, the next aggregator
+  # would otherwise double-count). New session starts at zero.
+  reset_state "$STATE_DIR/hook-firings.json"
+  reset_state "$STATE_DIR/quality-gate-history.json"
+  reset_state "$STATE_DIR/bash-budget.json"
+  # Also clear the verdict stop-gate.sh reads. quality-gate.sh only overwrites it
+  # on a qualifying edit, so a "failed" verdict from a prior session would
+  # otherwise persist and block completion of a new session that makes no code
+  # edit (e.g. a Markdown-only or Q&A session). New session starts with no verdict.
+  reset_state "$STATE_DIR/last_quality_gate.json"
+
+  # Clear the inter-agent handoff scratchpad (CLA-37). It is per-session: each
+  # sub-agent overwrites it with a <=5-line summary on exit, and journal-fold.sh
+  # folds it into the session handoff at SessionEnd. Start every session empty.
+  : > "$STATE_DIR/agent-handoff.md" 2>/dev/null || true
+
+  # Write session metadata. session-end.sh reads it to compute
+  # session_duration_seconds and propagate session_id into the scorecard.
+  SESSION_ID=$(parse_json_field "session_id" 2>/dev/null || true)
+  NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  NOW_EPOCH=$(date +%s)
+  if command -v python3 &>/dev/null; then
+    python3 - "$STATE_DIR/session-meta.json" "${SESSION_ID:-}" "$NOW" "$NOW_EPOCH" <<'PY' 2>/dev/null || true
 import json, os, sys
 f, sid, now_iso, now_epoch = sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4])
 d = {"session_id": sid, "started_at": now_iso, "started_at_epoch": now_epoch}
@@ -57,6 +81,7 @@ with open(tmp, "w") as fh:
     json.dump(d, fh, indent=2)
 os.replace(tmp, f)
 PY
+  fi
 fi
 
 CONTEXT=""
@@ -64,7 +89,12 @@ CONTEXT=""
 append() { CONTEXT="${CONTEXT}${1}"; }
 append_line() { CONTEXT="${CONTEXT}${1}"$'\n'; }
 
-append_line "[Auto-injected by session-start.sh]"
+if [ "$SOURCE" = "compact" ]; then
+  append_line "[Context restored after compaction by session-start.sh]"
+  append_line "The conversation was just compacted; earlier detail may be lost. Re-establish context before continuing (CLAUDE.md → After Compaction)."
+else
+  append_line "[Auto-injected by session-start.sh]"
+fi
 append_line ""
 
 # 1. Project map pointer (don't dump the whole file — just confirm presence)
@@ -96,17 +126,48 @@ if [ -f "$TODO" ]; then
   fi
 fi
 
-# 4. Branch hint (cheap, helps the agent reason about ship/release context)
-if command -v git &>/dev/null && [ -d "$ROOT/.git" ]; then
+# 4. Compaction restore — re-inject the extra anchors the summary may have
+#    dropped: full-plan/edited-files nudge, any active contract, and the
+#    in-session journal. Fresh sessions don't need these (todo/lessons above are
+#    the boot context; the journal is empty at startup).
+if [ "$SOURCE" = "compact" ]; then
+  if [ -f "$TODO" ]; then
+    append_line ""
+    append_line "Re-read tasks/todo.md for the full plan, and re-read the files you were actively editing."
+  fi
+  if compgen -G "$ROOT/tasks/*_CONTRACT.md" >/dev/null 2>&1; then
+    append_line ""
+    append_line "Active contract(s) — re-read before continuing:"
+    for c in "$ROOT"/tasks/*_CONTRACT.md; do
+      append_line "- tasks/$(basename "$c")"
+    done
+  fi
+  JOURNAL="$STATE_DIR/session-journal.md"
+  if [ -f "$JOURNAL" ] && [ -s "$JOURNAL" ]; then
+    JOURNAL_TAIL=$(tail -n 60 "$JOURNAL" 2>/dev/null || true)
+    if [ -n "$JOURNAL_TAIL" ]; then
+      append_line ""
+      append_line "Session journal (.hook-state/session-journal.md) — pre-compaction notes:"
+      append_line "$JOURNAL_TAIL"
+    fi
+  fi
+  append_line ""
+  append_line "Do NOT resume coding until context is re-established."
+fi
+
+# 5. Branch + working-tree status — boot orientation only. Skipped on compact:
+#    the branch/tree haven't changed since the session began, and the agent
+#    already reconciled them at startup.
+if [ "$SOURCE" != "compact" ] && command -v git &>/dev/null && [ -d "$ROOT/.git" ]; then
   BRANCH=$(git -C "$ROOT" branch --show-current 2>/dev/null || true)
   if [ -n "$BRANCH" ]; then
     append_line ""
     append_line "Branch: $BRANCH"
   fi
 
-  # 5. Working tree status — flag dirty state so the agent reconciles against
-  # the active task before picking up uncommitted files as "in scope".
-  # Silent when the tree is clean (no noise on fresh sessions).
+  # Working tree status — flag dirty state so the agent reconciles against the
+  # active task before picking up uncommitted files as "in scope". Silent when
+  # the tree is clean (no noise on fresh sessions).
   PORCELAIN=$(git -C "$ROOT" status --porcelain 2>/dev/null || true)
   if [ -n "$PORCELAIN" ]; then
     MOD_COUNT=$(printf '%s\n' "$PORCELAIN" | grep -cE '^( M|M |MM|AM| A| D| R)' 2>/dev/null || true)
@@ -127,11 +188,13 @@ if command -v git &>/dev/null && [ -d "$ROOT/.git" ]; then
   fi
 fi
 
-# Nothing substantive? Skip the hook output entirely (don't pollute context).
-# We always emit the [Auto-injected] banner + blank line (2 lines), so only
-# proceed if there are at least 3 non-empty content lines beyond those.
+# Nothing substantive on a fresh session? Skip the hook output entirely (don't
+# pollute context). We always emit the banner + blank line (2 lines), so only
+# proceed if there are at least 3 non-empty content lines. The compact path
+# always emits — its "re-establish context" message is worth showing even when
+# todo/lessons are absent.
 NONEMPTY=$(printf '%s' "$CONTEXT" | grep -cE '^[^[:space:]]' || true)
-if [ "${NONEMPTY:-0}" -lt 3 ]; then
+if [ "$SOURCE" != "compact" ] && [ "${NONEMPTY:-0}" -lt 3 ]; then
   exit 0
 fi
 
@@ -141,8 +204,14 @@ if command -v python3 &>/dev/null; then
 elif command -v jq &>/dev/null; then
   printf '%s' "$CONTEXT" | jq -Rs '{additionalContext: .}'
 else
-  # Minimal escape: backslash, double-quote, newline
-  ESCAPED=$(printf '%s' "$CONTEXT" | sed 's/\\/\\\\/g; s/"/\\"/g' | awk 'BEGIN{ORS=""} {print; printf "\\n"}')
+  # No python3/jq: strip C0 control chars except tab/newline, escape backslash,
+  # double-quote, and tab, then convert newlines to \n. Keeps the fallback's JSON
+  # valid even when restored journal/todo/contract content carries tabs.
+  TAB=$(printf '\t')
+  ESCAPED=$(printf '%s' "$CONTEXT" \
+    | LC_ALL=C tr -d '\000-\010\013-\037' \
+    | sed 's/\\/\\\\/g; s/"/\\"/g; s/'"$TAB"'/\\t/g' \
+    | awk 'BEGIN{ORS=""} {print; printf "\\n"}')
   printf '{"additionalContext":"%s"}\n' "$ESCAPED"
 fi
 

--- a/.kit-manifest
+++ b/.kit-manifest
@@ -66,6 +66,7 @@ CODEBASE_MAP.md
 DESIGN.md
 VERSION
 agent_docs/architecture-language.md
+agent_docs/auto-mode.md
 agent_docs/contracts.md
 agent_docs/conventions.md
 agent_docs/debugging.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ Context compaction can happen mid-session. When you detect a compaction (convers
 
 This is the single most important rule for long sessions.
 
+> _Partially enforced via_ `.claude/hooks/session-start.sh` _— it fires again after a compaction (_`source=compact`_) and re-injects the active task, top rules, any active contract, and the session journal, without resetting session state._ `SessionStart(compact)` _is the only compaction-time event whose context reaches the model. You still need to re-read the specific files you were actively editing — the hook can't know which those are._
+
 ---
 
 ## Plan First
@@ -171,6 +173,7 @@ Read only what's relevant to the current task:
 - Code conventions → `agent_docs/conventions.md`
 - Testing guide → `agent_docs/testing.md`
 - Hooks guide → `agent_docs/hooks.md`
+- Auto mode (safe autonomy) → `agent_docs/auto-mode.md`
 - Skills guide → `agent_docs/skills.md`
 - Task contracts (completion criteria) → `agent_docs/contracts.md`
 - Prompting & bias awareness → `agent_docs/prompting.md`

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Hooks are shell scripts that run automatically — unlike CLAUDE.md rules (advis
 
 | Hook | Event | What it does |
 |------|------|-------------|
-| `session-start` | SessionStart | Injects Tier-1 pointers, top rules, active task, branch + dirty-tree status; resets session state |
+| `session-start` | SessionStart | New session: injects Tier-1 pointers, top rules, active task, branch + dirty-tree status, resets session state. After a compaction (`source=compact`): re-injects the working anchors without resetting state |
 | `prompt-router` | UserPromptSubmit | Injects a reminder when a prompt touches a sensitive inflection (auth, deps, schema) |
 | `secret-scan` | PostToolUse | Warns if API keys, tokens, or passwords are found |
 | `unicode-scan` | PostToolUse | Detects invisible Unicode (Glassworm supply-chain attack defense) |
@@ -239,6 +239,21 @@ KitBench
 ========================================
   38/38 PASS  0 FAIL
 ```
+
+## Auto Mode
+
+Claude Code's **auto mode** (`claude --permission-mode auto`, or `Shift+Tab` to it) auto-approves safe actions and stops only on the risky, irreversible ones — fewer prompts, without the blunt `--dangerously-skip-permissions`. The kit is the floor that makes it safe to turn on:
+
+- The `PreToolUse` blocking hooks (`protect-files`, `protect-changes`, `branch-protect`, `block-dangerous-commands`) fire **before** the auto-mode classifier and hard-block on `exit 2`.
+- The curated `permissions.deny` list (`curl`, `wget`, `npm publish`, `cat .env*`, …) resolves before the classifier and can't be overridden by it.
+
+The classifier can only *further* restrict — never un-block — what the kit denies. A repo can't grant itself auto mode (`defaultMode: "auto"` is ignored in project settings), so you opt in at the user level:
+
+```bash
+claude --permission-mode auto
+```
+
+For the full precedence model, the strict posture (`deny` floor + `disableBypassPermissionsMode`), and the classifier-tuning knobs, see [`agent_docs/auto-mode.md`](agent_docs/auto-mode.md).
 
 ## Agents
 

--- a/agent_docs/auto-mode.md
+++ b/agent_docs/auto-mode.md
@@ -1,0 +1,73 @@
+# Auto Mode (Safe Autonomy)
+
+Claude Code's **auto mode** is a permission middle-ground: instead of prompting on every action (default) or skipping all checks (`--dangerously-skip-permissions`), a classifier auto-approves safe actions and stops only on the risky, irreversible, or out-of-scope ones. It's the right setting for running with fewer interruptions — *if* you have a hard floor under it.
+
+The kit is that floor. This guide explains why the kit's existing hooks and permission lists make auto mode safe to turn on, and the posture to run it in.
+
+> **The kit does not — and cannot — enable auto mode for you.** `permissions.defaultMode: "auto"` is ignored in a project's `.claude/settings.json` / `.claude/settings.local.json` (Claude Code v2.1.142+), so a checked-in repo cannot grant itself elevated autonomy. Auto mode is something *you* opt into in your **user** settings; the kit's job is to make that opt-in safe.
+
+---
+
+## Enable it (user-level)
+
+```bash
+# Per session:
+claude --permission-mode auto
+
+# Or cycle to it mid-session with Shift+Tab (first time shows an opt-in prompt).
+```
+
+Persistent default — **only** honored in `~/.claude/settings.json` (user) or managed settings, never a project file:
+
+```json
+{
+  "permissions": { "defaultMode": "auto" }
+}
+```
+
+On Bedrock / Vertex / Foundry, auto mode is gated behind an env var (`CLAUDE_CODE_ENABLE_AUTO_MODE=1`); on the Anthropic API it's available by default. Requires Claude Code v2.1.83+.
+
+---
+
+## Why the kit makes auto mode safe
+
+Auto mode runs the full permission pipeline and then adds a classifier *after* it. That ordering is what the kit exploits — its guardrails sit **before** the classifier and can't be talked out of by it:
+
+| Layer (in precedence order) | Provided by | Holds under auto mode? |
+|---|---|---|
+| `PreToolUse` deny hook (`exit 2` / `permissionDecision: deny`) | kit hooks: `protect-files`, `protect-changes`, `branch-protect`, `block-dangerous-commands` | **Yes — hard block.** PreToolUse fires before the permission system *and* the classifier; the classifier can only further restrict, never un-block. |
+| `permissions.deny` | kit `settings.json` deny list (`curl`, `wget`, `npm publish`, `cat .env*`, …) | **Yes — unoverridable floor.** Resolves before the classifier; intent and `autoMode` config cannot override it. |
+| `autoMode.hard_deny` → `soft_deny` → classifier defaults | Claude Code classifier (server-side) | Yes — but `soft_deny` is clearable by explicit, specific user intent. |
+| `permissions.allow` / working-dir auto-approve | kit allow list (`npm test`, `git status`, …) | Pre-approves narrow commands. **Broad** allow rules (`Bash(*)`, wildcard interpreters) are auto-dropped on entering auto mode — the kit's allow list is already narrow, so it survives intact. |
+
+In short: the two things the kit ships — a curated `deny` list and a set of `PreToolUse` blocking hooks — are exactly the two layers that sit *above* the auto-mode classifier and cannot be overridden. That's the safety net.
+
+---
+
+## Recommended strict posture
+
+1. **Keep the `deny` floor.** The kit's `permissions.deny` list blocks before the classifier and can't be overridden. Treat it as the non-negotiable boundary; extend it for project-specific "never" commands.
+2. **Lean on the `PreToolUse` hooks.** `protect-files`, `protect-changes`, `branch-protect`, and `block-dangerous-commands` `exit 2` to hard-block — they fire ahead of the classifier under auto mode. This is the programmable half of the net (all four ship in the **standard** profile; only `minimal` omits `protect-changes`).
+3. **Close the bypass gap.** The docs do *not* guarantee hooks run under `bypassPermissions` (which skips the permission layer entirely). If you administer the machine, disable it in **managed** settings so the gap can't be reached:
+   ```json
+   { "permissions": { "disableBypassPermissionsMode": "disable" } }
+   ```
+4. **Don't rely on conversational boundaries.** Saying "don't push" is re-read from the transcript each check and is **lost on compaction**. Encode hard guarantees as `permissions.deny` or `autoMode.hard_deny`, not as a chat instruction.
+5. **Tune the classifier in user/managed settings, not the repo.** The `autoMode` block (`environment` / `allow` / `soft_deny` / `hard_deny` — prose arrays, with `"$defaults"` splicing in the built-ins) is read only from user / local / managed settings. Keep `"$defaults"` in every array (omitting it *replaces* the built-in safety list). Inspect with `claude auto-mode config` and `claude auto-mode critique`.
+
+---
+
+## Gotchas
+
+- **Auto mode is a research preview.** Per the docs it "reduces prompts but does not guarantee safety." The kit raises the floor; it doesn't make autonomy risk-free. Review diffs.
+- **`CLAUDE_CODE_AUTO_COMPACT_WINDOW` is unrelated.** Despite the name, it governs the context **auto-compaction** token window, not the permission auto mode. Don't conflate them in config.
+- **The classifier costs tokens.** It's a separate server-side model call per non-trivial action.
+- **Subagents are checked too** — at spawn, per-action, and on return; a subagent's `permissionMode` frontmatter is ignored under auto mode.
+
+---
+
+## See also
+
+- `agent_docs/hooks.md` — the `PreToolUse` blocking hooks that form the programmable safety net, and the hook profiles.
+- `.claude/settings.json` — the `permissions.deny` floor and the narrow `allow` list.
+- README → **Auto Mode** — the short version of this recipe.

--- a/agent_docs/hooks.md
+++ b/agent_docs/hooks.md
@@ -8,19 +8,19 @@ Philosophy: **Use prompts for guidance. Use hooks for behavior that should run e
 
 ## Included Hooks
 
-### SessionStart (runs once, at the start of a session)
+### SessionStart (runs at session start — and again after each compaction)
+
+SessionStart fires with a `source`: `startup` / `resume` / `clear` for a fresh session, and `compact` mid-session right after a context compaction.
 
 | Hook | File | What it does |
 |------|------|-------------|
-| **session-start** | `.claude/hooks/session-start.sh` | Auto-injects Tier 1 context: confirms CODEBASE_MAP/CLAUDE.project presence, top rules from `tasks/lessons/_index.md`, active task from `tasks/todo.md`, current git branch, and **working-tree status** (modified/untracked file counts + branch-ahead distance when the tree is dirty, with a "plan check" nudge to reconcile against the active task). Replaces the prompt rule "read Tier 1 files at session start". Silent on clean trees. |
+| **session-start** | `.claude/hooks/session-start.sh` | **On a new session** (`startup`/`resume`/`clear`): auto-injects Tier 1 context — confirms CODEBASE_MAP/CLAUDE.project presence, top rules from `tasks/lessons/_index.md`, active task from `tasks/todo.md`, current git branch, and **working-tree status** (modified/untracked counts + branch-ahead distance when dirty, with a "plan check" nudge). Resets the transient per-session state files. Silent on clean trees. **After a compaction** (`source=compact`): re-injects the working anchors the summary may have blurred — active task, top rules, any active `tasks/*_CONTRACT.md`, and the session journal — and does **not** reset session state (counters and the session clock must survive the compaction). This is the deterministic half of CLAUDE.md → After Compaction; `SessionStart(compact)` is the only compaction-time event whose `additionalContext` reaches the model (`PreCompact`/`PostCompact` cannot inject context). |
 
 ### UserPromptSubmit (runs before the model sees each user prompt)
 
 | Hook | File | What it does |
 |------|------|-------------|
 | **prompt-router** | `.claude/hooks/prompt-router.sh` | Keyword-based context injection. If the prompt mentions auth, billing, migrations, deploy, or dependencies, it injects a one-line reminder for that domain. |
-| **skill-extract-reminder** | `.claude/hooks/skill-extract-reminder.sh` | Strict profile only. Nudges the agent to consider extracting a skill if it discovered something non-obvious. |
-
 ### PreToolUse (runs BEFORE a tool executes)
 
 | Hook | File | What it does |

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -50,7 +50,7 @@ fi
 
 if [ -d "agent_docs" ]; then
   pass "agent_docs/ exists"
-  EXPECTED_DOCS=(workflow.md debugging.md testing.md conventions.md subagents.md hooks.md skills.md contracts.md prompting.md architecture-language.md)
+  EXPECTED_DOCS=(workflow.md debugging.md testing.md conventions.md subagents.md hooks.md auto-mode.md skills.md contracts.md prompting.md architecture-language.md)
   for doc in "${EXPECTED_DOCS[@]}"; do
     if [ ! -f "agent_docs/$doc" ]; then
       warn "agent_docs/$doc missing"


### PR DESCRIPTION
Tier 1 from the *"How Boris Uses Claude Code" × claude-code-kit* analysis (the report was written against v1.3.0; re-evaluated against current v1.17.2). Two low-risk additions that strengthen the kit's existing philosophy, plus a latent-bug fix found in review.

## A — Compaction-aware context restore

CLAUDE.md's **After Compaction** rule was advisory; this makes it deterministic. `SessionStart` re-fires with `source="compact"` after a mid-session compaction, and (verified against `code.claude.com/docs/en/hooks`) its `additionalContext` reaches the model — **unlike `PreCompact`/`PostCompact`, which cannot inject context at all.** So `session-start.sh` is now `source`-aware:

- **new session** (`startup`/`resume`/`clear`): resets per-session state + injects boot context (unchanged behavior).
- **`compact`**: skips the resets and re-injects the working anchors — active task, top rules, any active `tasks/*_CONTRACT.md`, and the session journal — plus a "re-establish context before resuming" nudge.

### Latent bug fixed (found in adversarial review)
`session-start.sh` previously ran its **full destructive boot body on every compaction** (no source gate): it clobbered the session counters, reset the session clock (`session-meta.json` → wrong `session_duration_seconds`), truncated the agent-handoff scratchpad, and cleared the stop-gate verdict mid-session. State now survives a compaction.

## B — Auto Mode recipe

New `agent_docs/auto-mode.md` + README **## Auto Mode** section documenting how the kit's existing rails make Claude Code **auto mode** safe to enable: `PreToolUse` deny hooks fire *before* the classifier and hard-block on `exit 2`; the curated `permissions.deny` list is an unoverridable floor. Honestly scoped: the kit **cannot** grant itself auto mode (`defaultMode:"auto"` is ignored in project settings since v2.1.142) — it only makes the user-level opt-in safe.

## Design note — what changed mid-implementation
The first pass implemented this as a `PreCompact` marker hook + a `UserPromptSubmit` restore hook. An adversarial review caught that **`SessionStart(source=compact)` wipes the marker before `UserPromptSubmit` runs**, making it a guaranteed no-op — and that `SessionStart(compact)` is Claude Code's purpose-built channel for exactly this. Pivoted to the simpler, idiomatic, single-hook design (no new hook files; hook count stays 22).

## Validation
- Functional test: `compact` path injects restore content + **preserves** state; `startup` path resets + boots. Both emit valid JSON.
- KitBench **38/38 PASS** · doctor.sh **0 failed** · validate-skills **0 failed** · `.kit-manifest` in sync · `bash -n` clean.
- `install.sh` + `.claude/settings.json` are byte-identical to `main` (the marker-design wiring was added then fully reverted).
- Hardened the no-python3/jq JSON fallback against control chars (the compact path now injects arbitrary file content).

## Not in this PR (noted)
- Optional `session-journal.md` reset on fresh start (would subtly change `/clear` semantics; pre-existing hygiene asymmetry).
- The identical bash JSON fallback in other hooks (e.g. `prompt-router.sh`) — lower exposure (fixed strings); candidate for a separate kit-wide pass.

Refs TAN-3894

🤖 Generated with [Claude Code](https://claude.com/claude-code)