### PR TITLE
docs(web-read): MDX-safe upstream URL link

### DIFF
--- a/.claude/skills/web-read/SKILL.md
+++ b/.claude/skills/web-read/SKILL.md
@@ -80,4 +80,4 @@ Clean Markdown of the page's main content, with site chrome removed. Use it as t
 - Defuddle is a global CLI (`npm i -g defuddle`), not a project dependency — it never touches `package.json`, so it doesn't trip the Protected-Changes dependency gate. Surface the install anyway before running it.
 - The token win is real on heavy pages (docs sites, news, marketing): raw HTML through WebFetch carries layout, scripts, and nav that Defuddle drops.
 - Pairs with `/references-sync`, which can call this to extract vendor docs before writing `docs/references/<pkg>-llms.txt`.
-- Upstream: <https://github.com/kepano/defuddle>
+- Upstream: [github.com/kepano/defuddle](https://github.com/kepano/defuddle)


### PR DESCRIPTION
The `<https://…>` autolink added in #164 (to satisfy markdownlint MD034) breaks the docs-site MDX build — MDX parses `<https://…>` as a JSX tag (`82:20: Unexpected character /`). A standard `[text](url)` markdown link satisfies **both** markdownlint and MDX.

Found while building the web for deploy. Only one such autolink exists in skill bodies (`web-read`).

Follow-up candidate (not in this PR): have the web's skill→MDX generator sanitize `<url>` autolinks so a future skill author can't break the prod build this way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)