### PR TITLE
feat(skills): /capabilities onboarding briefing skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
     {
       "name": "claude-code-kit",
       "source": "./",
-      "description": "Plan → Confirm → Implement → Verify discipline for Claude Code. Tiered session boot, deterministic hooks (quality gate, protect-changes, branch-protect, secret-scan, conventional-commit, loop-detect, and more), 37 user-invocable skills across audit / workflow / meta / wiki categories, 6 review agents (code-reviewer, security-reviewer, qa-reviewer, planner, dead-code-remover, wiki-maintainer), a CLAUDE.md ruleset, lessons-as-memory, ADR decisions, and optional wiki + HTML-artifacts modules.",
+      "description": "Plan → Confirm → Implement → Verify discipline for Claude Code. Tiered session boot, deterministic hooks (quality gate, protect-changes, branch-protect, secret-scan, conventional-commit, loop-detect, and more), 38 user-invocable skills across audit / workflow / meta / wiki categories, 6 review agents (code-reviewer, security-reviewer, qa-reviewer, planner, dead-code-remover, wiki-maintainer), a CLAUDE.md ruleset, lessons-as-memory, ADR decisions, and optional wiki + HTML-artifacts modules.",
       "version": "1.18.0",
       "author": {
         "name": "tansuasici",

--- a/.claude/skills/capabilities/SKILL.md
+++ b/.claude/skills/capabilities/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: capabilities
+description: Summarize what the kit makes available in this project — user-invocable skills, review agents, active hooks, and enabled modules — as a one-shot onboarding briefing read live from disk. Use when you start in a kit-enabled project or ask "what's available here / what can I do". Do NOT use for install health (that's scripts/doctor.sh) or terminal skill listing (npx @tansuasici/claude-code-kit skills).
+user-invocable: true
+---
+
+# Capabilities
+
+## Core Rule
+
+When asked what the kit offers, enumerate the *actually installed* capabilities from the filesystem — never recite a memorized list, it drifts as the kit evolves. Read what is present under `.claude/` and the project root, group it, and present one scannable briefing.
+
+## When to Use
+
+When you (or the user) need a fast map of what this kit-enabled project can do:
+
+- Starting a session in a project that has the kit installed — "what do I have here?"
+- The user asks "what can this kit do / which skills / agents / hooks are available / what's enabled".
+- Onboarding a teammate, or a fresh session, to the project's setup.
+
+Do NOT use for:
+
+- Installation health, orphan hooks, or unfilled placeholders → run `scripts/doctor.sh`.
+- Listing skills from a terminal, outside a session → `npx @tansuasici/claude-code-kit skills`.
+- A portable capability file for other agents/tools → `npx @tansuasici/claude-code-kit generate agents-md`.
+
+## Process
+
+Harvest live, then summarize. Don't dump full file bodies — names + one-liners only.
+
+1. **Skills.** Enumerate `.claude/skills/*/SKILL.md` (skip `_`-prefixed infra dirs like `_shared`, `_templates`). For each, read `name`, the first sentence of `description`, and whether it is `user-invocable: true`. Include the wiki module (`wiki-module/.claude/skills/*`) when `WIKI.md` is present.
+
+   ```bash
+   for f in .claude/skills/*/SKILL.md; do
+     name=$(awk '/^name:/{sub(/^name:[[:space:]]*/,""); print; exit}' "$f")
+     desc=$(awk '/^description:/{sub(/^description:[[:space:]]*/,""); print; exit}' "$f" | sed 's/\. .*/./')
+     inv=$(grep -q '^user-invocable:[[:space:]]*true' "$f" && echo "/" || echo "·")
+     printf '%s %s — %s\n' "$inv" "$name" "$desc"
+   done
+   ```
+
+2. **Agents.** List `.claude/agents/*.md`; read each `name` and its one-line role.
+3. **Active hooks.** Read `.claude/settings.json` → `hooks`; report the wired events and the scripts under each (what runs automatically). Flag any hook file in `.claude/hooks/` that is present but *not* wired — those are opt-in (see `agent_docs/hooks.md` → Hook Profiles).
+4. **Modules & overlay.** Detect by marker file and report active vs available:
+
+   ```bash
+   for m in "WIKI.md:Knowledge wiki" "ARTIFACTS.md:HTML artifacts" \
+            "docs/ARCHITECTURE.md:Harness docs" "DESIGN.md:Design system" \
+            "CLAUDE.project.md:Project overlay"; do
+     f="${m%%:*}"; label="${m#*:}"
+     [ -e "$f" ] && echo "✓ $label" || echo "· $label (not enabled)"
+   done
+   ```
+
+5. **Version.** Read `VERSION` (or `.claude-plugin/plugin.json`) for the installed kit version.
+6. Present the briefing (see Output Format).
+
+## Output Format
+
+A single scannable briefing:
+
+- **Kit** — version + which optional modules are on.
+- **Skills** — grouped by purpose (audit · review · workflow · docs · meta · wiki), each as `/name — one-liner`. Mark agent-facing (non-invocable) ones distinctly.
+- **Agents** — `name — role`.
+- **Hooks** — by event (what runs automatically), plus any opt-in hooks available but not wired.
+- **Modules & overlay** — active vs available.
+- **Next steps** — 1–2 concrete suggestions for this project (e.g. fill `CODEBASE_MAP.md`, then `/office-hours` to scope or `/feature-cycle` to build from a spec).
+
+## Notes
+
+- Read from disk every time → never stale; new skills/agents/hooks show up automatically.
+- Hooks run deterministically in the background. This lists them for *awareness*; it does not enable/disable them — edit `.claude/settings.json` (see `agent_docs/hooks.md`).
+- Complements, not replaces, the Claude Code `/` slash menu and `npx @tansuasici/claude-code-kit skills`.
+- Pairs with `scripts/doctor.sh`: capabilities = "what you have", doctor = "is it set up correctly".

--- a/.kit-manifest
+++ b/.kit-manifest
@@ -29,6 +29,7 @@
 .claude/settings.json
 .claude/skills/accessibility-audit
 .claude/skills/architecture-review
+.claude/skills/capabilities
 .claude/skills/code-quality-audit
 .claude/skills/constitution
 .claude/skills/dead-code-audit

--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ User-invocable audit and guide skills — run with `/skill-name`:
 | `/references-sync` | Populates `docs/references/<package>-llms.txt` so the agent reads curated library docs on demand *(supports `mode:headless`)* |
 | `/doc-gardening` | Prunes stale docs, fixes drift, and refreshes cross-references *(supports `mode:headless`)* |
 | `/web-read` | Extracts clean markdown from a URL via the Defuddle CLI to cut tokens vs WebFetch — falls back to WebFetch if the CLI isn't installed |
+| `/capabilities` | One-shot briefing of everything the kit makes available here — skills, agents, active hooks, enabled modules — read live from disk |
 | `/wiki-ingest` | Ingest source into knowledge wiki — summarize, cross-reference, update index *(requires `--wiki`)* |
 | `/wiki-lint` | Health-check the knowledge wiki — contradictions, orphans, stale content *(requires `--wiki`)* |
 | `/wiki-briefing` | Morning briefing from the wiki — recent activity, new sources, open items *(requires `--wiki`)* |


### PR DESCRIPTION
Adds a user-invocable **`/capabilities`** skill: a one-shot, in-session briefing of everything the kit makes available in the current project — skills (grouped, with invocable vs agent-facing), review agents, active hooks (by event) + opt-in available, enabled modules (wiki / HTML artifacts / harness / overlay), and kit version.

**Design:** enumerates **live from disk** (`.claude/skills`, `.claude/agents`, `.claude/settings.json`, marker files) — never a hardcoded list, so it can't drift as the kit evolves (the kit's anti-staleness convention). Router-style description; `When to Use` carves it out from `scripts/doctor.sh` (health), `npx … skills` (terminal), and `npx … generate agents-md` (portable export).

Answers the common "what can I do in this kit-enabled project?" without leaving the session.

**Counts:** marketplace 37 → 38 user-invocable skills · README skills table row added · `.kit-manifest` regenerated.
**Validation:** `validate-skills` clean · `doctor.sh` 0 failed (35 base skills) · manifest in sync.

**Follow-up (separate, before deploy):** web `skills-data.ts` regen (37 → 38) + the 3 hardcoded web counts — same mechanical sync as #48 (web-read).

Refs: capabilities discovery skill (this-session request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)