### PR TITLE
refactor(manifest): consolidate manifest logic into scripts/lib/manifest.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,17 +26,10 @@ CLONE_DIR=""
 MANIFEST_FILE=".kit-manifest"
 MANIFEST_ENTRIES=()
 
-# Track a file in the manifest (kit-managed)
+# Track a file in the manifest (kit-managed). manifest_write() is provided by
+# scripts/lib/manifest.sh, sourced once the kit source tree is available below.
 manifest_add() {
   MANIFEST_ENTRIES+=("$1")
-}
-
-# Write manifest to disk
-manifest_write() {
-  local dest="$1"
-  if [ ${#MANIFEST_ENTRIES[@]} -gt 0 ]; then
-    printf '%s\n' "${MANIFEST_ENTRIES[@]}" | sort -u > "$dest/$MANIFEST_FILE"
-  fi
 }
 
 # Create wiki index.md template
@@ -542,6 +535,15 @@ else
     info "Downloading Claude Code Kit (latest)..."
     git clone --quiet --depth 1 "$REPO" "$CLONE_DIR" 2>/dev/null || error "Failed to clone repository"
   fi
+fi
+
+# Source the shared manifest library from the kit source (single home for the
+# manifest write logic — same code scripts/sync-manifest.sh uses). It only ships
+# with the kit source, so it's available here regardless of curl|bash vs npx.
+if [ -f "$CLONE_DIR/scripts/lib/manifest.sh" ]; then
+  . "$CLONE_DIR/scripts/lib/manifest.sh"
+else
+  error "Missing scripts/lib/manifest.sh in the kit source — cannot write the manifest"
 fi
 
 # Read version from downloaded kit

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "agent_docs/",
     ".claude/",
     "tasks/",
+    "scripts/lib/manifest.sh",
     "scripts/convert.sh",
     "scripts/doctor.sh",
     "scripts/gen-agents-md.sh",

--- a/scripts/lib/manifest.sh
+++ b/scripts/lib/manifest.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# manifest.sh — shared manifest primitives for Claude Code Kit.
+#
+# `.kit-manifest` is the record of which files the kit ships into a user's
+# project. This library is the single home for the read/write/enumerate logic
+# that used to be reimplemented across install.sh, scripts/sync-manifest.sh, and
+# uninstall.sh.
+#
+# Consumers:
+#   - scripts/sync-manifest.sh  — sources this to enumerate + write the repo copy
+#   - install.sh                — sources this (from the cloned/--local source,
+#                                 after the source tree is available) to write
+#                                 the per-project manifest
+#   - uninstall.sh              — does NOT source this: it runs standalone via
+#                                 `curl … | bash` with no library beside it, so
+#                                 it reads the `.kit-manifest` *artifact* this
+#                                 code produces (the same single source) with a
+#                                 trivial inline read.
+#
+# Source it, then call the functions:  . "<dir>/scripts/lib/manifest.sh"
+#
+
+# Guard against double-sourcing (install.sh also defines MANIFEST_FILE).
+if [ -n "${_CCK_MANIFEST_LIB_LOADED:-}" ]; then
+  return 0 2>/dev/null || true
+fi
+_CCK_MANIFEST_LIB_LOADED=1
+
+MANIFEST_FILE=".kit-manifest"
+
+# manifest_write <dest_dir> — write the entries in the MANIFEST_ENTRIES array to
+# <dest_dir>/.kit-manifest, sorted and de-duplicated. No-op if the array is empty.
+# Writes atomically (temp + mv). LC_ALL=C makes collation byte-deterministic
+# across macOS (BSD) and Linux.
+manifest_write() {
+  local dest="$1"
+  [ "${#MANIFEST_ENTRIES[@]}" -gt 0 ] || return 0
+  local tmp
+  tmp=$(mktemp "$dest/.kit-manifest.XXXXXX" 2>/dev/null) || tmp=$(mktemp)
+  printf '%s\n' "${MANIFEST_ENTRIES[@]}" | LC_ALL=C sort -u > "$tmp"
+  mv "$tmp" "$dest/$MANIFEST_FILE"
+}
+
+# manifest_read <manifest_path> — emit the manifest's entries, one per line,
+# skipping blank lines. Used to drive manifest-based operations.
+manifest_read() {
+  local path="$1"
+  [ -f "$path" ] || return 0
+  grep -v '^[[:space:]]*$' "$path" || true
+}
+
+# kit_manifest_entries — emit the exact set of paths install.sh ships under the
+# default (standard) profile, relative to the current directory (caller cd's to
+# the kit root first). Order doesn't matter — callers sort. Same inclusion rule
+# as install.sh's unconditional manifest_add calls: conditional payloads
+# (WIKI.md, ARTIFACTS.md, DESIGN.md, harness docs, extensions/README.md) are
+# excluded so the manifest reflects the default install.
+kit_manifest_entries() {
+  local entries=() f d base
+
+  # --- Top-level files (always shipped) ---------------------------------
+  local top
+  for top in CLAUDE.md CODEBASE_MAP.md VERSION .kit-manifest; do
+    [ -f "$top" ] && entries+=("$top")
+  done
+
+  # --- agent_docs/ (.md files, exclude project overlay folder) ----------
+  if [ -d agent_docs ]; then
+    for f in agent_docs/*.md; do
+      [ -f "$f" ] && entries+=("$f")
+    done
+  fi
+
+  # --- scripts/ (all *.sh) ----------------------------------------------
+  if [ -d scripts ]; then
+    for f in scripts/*.sh; do
+      [ -f "$f" ] && entries+=("$f")
+    done
+  fi
+
+  # --- tasks/ — only the default top-level files (lessons/specs are dynamic)
+  if [ -d tasks ]; then
+    for f in tasks/decisions.md tasks/handoff.md tasks/todo.md; do
+      [ -f "$f" ] && entries+=("$f")
+    done
+    # Lessons template + index ship; per-day lesson files are user-owned.
+    if [ -d tasks/lessons ]; then
+      for f in tasks/lessons/_TEMPLATE.md tasks/lessons/_index.md; do
+        [ -f "$f" ] && entries+=("$f")
+      done
+    fi
+  fi
+
+  # --- .claude/agents/ --------------------------------------------------
+  if [ -d .claude/agents ]; then
+    for f in .claude/agents/*.md; do
+      [ -f "$f" ] && entries+=("$f")
+    done
+  fi
+
+  # --- .claude/hooks/ (all *.sh + lib dir) ------------------------------
+  if [ -d .claude/hooks ]; then
+    for f in .claude/hooks/*.sh; do
+      [ -f "$f" ] && entries+=("$f")
+    done
+    [ -d .claude/hooks/lib ] && entries+=(".claude/hooks/lib")
+  fi
+
+  # --- .claude/settings.json --------------------------------------------
+  [ -f .claude/settings.json ] && entries+=(".claude/settings.json")
+
+  # --- .claude/skills/ (each skill dir, exclude _shared/_templates) -----
+  if [ -d .claude/skills ]; then
+    for d in .claude/skills/*/; do
+      [ -d "$d" ] || continue
+      base=$(basename "$d")
+      case "$base" in
+        _*) continue ;;
+      esac
+      entries+=(".claude/skills/$base")
+    done
+  fi
+
+  [ "${#entries[@]}" -gt 0 ] && printf '%s\n' "${entries[@]}"
+}

--- a/scripts/sync-manifest.sh
+++ b/scripts/sync-manifest.sh
@@ -5,8 +5,8 @@
 # The manifest is the source of truth for which files install.sh ships to a
 # user's project. install.sh builds the manifest at install-time via
 # `manifest_add`, but the *repo* copy at `.kit-manifest` is what
-# `uninstall.sh --upgrade` and `--diff` consult, and what humans read to see
-# what kit ships.
+# `uninstall.sh` and `--diff` consult, and what humans read to see what kit
+# ships.
 #
 # This script keeps the repo copy in sync with the directory tree. The CI job
 # in .github/workflows/validate.yml runs it with `--check` and fails the build
@@ -16,115 +16,31 @@
 #   ./scripts/sync-manifest.sh           # rewrite .kit-manifest
 #   ./scripts/sync-manifest.sh --check   # exit 1 if rewrite would change it
 #
-# The set of entries mirrors install.sh's `manifest_add` calls — anything
-# install.sh copies into the user's project belongs here. Files repo uses
-# internally (bench/, examples/, html-module/, install.sh itself, scripts that
-# only the maintainer runs) are deliberately excluded.
+# The enumeration + read/write logic lives in scripts/lib/manifest.sh so it has
+# exactly one home (shared with install.sh's write path). Anything install.sh
+# ships unconditionally belongs in `kit_manifest_entries`; conditional payloads
+# (WIKI.md, ARTIFACTS.md, DESIGN.md, harness docs, extensions/README.md) are
+# excluded so the manifest reflects the default install.
 #
 
 set -uo pipefail
 
 KIT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$KIT_ROOT"
+. "$KIT_ROOT/scripts/lib/manifest.sh"
 
 CHECK_ONLY=0
 if [ "${1:-}" = "--check" ]; then
   CHECK_ONLY=1
 fi
 
-# Collect entries that install.sh's manifest_add path would produce.
-# Order doesn't matter — we sort at the end. Same rule for inclusion: if a path
-# is unconditionally shipped by install.sh, it goes in. Conditional paths (e.g.
-# WIKI.md, ARTIFACTS.md, DESIGN.md, harness docs, extensions/README.md) are
-# excluded so the manifest reflects the default install. DESIGN.md is an opt-in
-# design-system template (CLAUDE.md uses it only "if it exists"); install.sh does
-# not ship it, so it must not be in the manifest.
-
-entries=()
-
-add_if_file() {
-  [ -f "$1" ] && entries+=("$1")
-}
-
-add_glob_files() {
-  local pattern="$1"
-  local f
-  for f in $pattern; do
-    [ -f "$f" ] && entries+=("$f")
-  done
-}
-
-# --- Top-level files (always shipped) -----------------------------------
-add_if_file CLAUDE.md
-add_if_file CODEBASE_MAP.md
-add_if_file VERSION
-add_if_file .kit-manifest
-
-# --- agent_docs/ (.md files, exclude project overlay folder) ------------
-if [ -d agent_docs ]; then
-  for f in agent_docs/*.md; do
-    [ -f "$f" ] && entries+=("$f")
-  done
-fi
-
-# --- scripts/ (all *.sh) ------------------------------------------------
-if [ -d scripts ]; then
-  for f in scripts/*.sh; do
-    [ -f "$f" ] && entries+=("$f")
-  done
-fi
-
-# --- tasks/ — only the default top-level files (lessons/specs are dynamic)
-if [ -d tasks ]; then
-  for f in tasks/decisions.md tasks/handoff.md tasks/todo.md; do
-    [ -f "$f" ] && entries+=("$f")
-  done
-  # Lessons template + index ship; per-day lesson files are user-owned.
-  if [ -d tasks/lessons ]; then
-    for f in tasks/lessons/_TEMPLATE.md tasks/lessons/_index.md; do
-      [ -f "$f" ] && entries+=("$f")
-    done
-  fi
-fi
-
-# --- .claude/agents/ ----------------------------------------------------
-if [ -d .claude/agents ]; then
-  for f in .claude/agents/*.md; do
-    [ -f "$f" ] && entries+=("$f")
-  done
-fi
-
-# --- .claude/hooks/ (all *.sh + lib dir) --------------------------------
-if [ -d .claude/hooks ]; then
-  for f in .claude/hooks/*.sh; do
-    [ -f "$f" ] && entries+=("$f")
-  done
-  [ -d .claude/hooks/lib ] && entries+=(".claude/hooks/lib")
-fi
-
-# --- .claude/settings.json ----------------------------------------------
-add_if_file .claude/settings.json
-
-# --- .claude/skills/ (each skill dir, exclude _shared/_templates) -------
-if [ -d .claude/skills ]; then
-  for d in .claude/skills/*/; do
-    [ -d "$d" ] || continue
-    base=$(basename "$d")
-    case "$base" in
-      _*) continue ;;
-    esac
-    entries+=(".claude/skills/$base")
-  done
-fi
-
-# --- Render --------------------------------------------------------------
 # LC_ALL=C makes collation byte-deterministic across platforms — without it the
 # manifest's sort order differs between macOS (BSD locale) and Linux CI, so a
 # manifest regenerated on one would fail --check on the other.
-NEW_MANIFEST=$(printf '%s\n' "${entries[@]}" | LC_ALL=C sort -u)
+NEW_MANIFEST=$(kit_manifest_entries | LC_ALL=C sort -u)
 
 if [ "$CHECK_ONLY" -eq 1 ]; then
-  CURRENT=$(cat .kit-manifest 2>/dev/null || echo "")
+  CURRENT=$(manifest_read "$MANIFEST_FILE" | LC_ALL=C sort -u)
   if [ "$NEW_MANIFEST" != "$CURRENT" ]; then
     echo ".kit-manifest is out of sync with the repo's directory tree." >&2
     echo "" >&2
@@ -138,10 +54,12 @@ if [ "$CHECK_ONLY" -eq 1 ]; then
   exit 0
 fi
 
-# Write atomically.
-TMP=$(mktemp)
-printf '%s\n' "$NEW_MANIFEST" > "$TMP"
-mv "$TMP" .kit-manifest
+# Rewrite via the shared writer (atomic, sorted, de-duplicated).
+MANIFEST_ENTRIES=()
+while IFS= read -r line; do
+  [ -n "$line" ] && MANIFEST_ENTRIES+=("$line")
+done <<< "$NEW_MANIFEST"
+manifest_write "$KIT_ROOT"
 
 LINES=$(printf '%s\n' "$NEW_MANIFEST" | grep -c '^' 2>/dev/null || echo 0)
 echo "Regenerated .kit-manifest with $LINES entries."

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -75,6 +75,9 @@ fi
 assert_absent "$TMP/CLAUDE.md"
 assert_absent "$TMP/.claude/hooks"
 assert_absent "$TMP/.kit-manifest"
+# The manifest backstop sweeps kit files the path-based detection misses (e.g.
+# .claude/*.example), so .claude/ is left fully clean — no orphaned kit files.
+assert_absent "$TMP/.claude"
 # the user's own file must survive
 assert_file "$TMP/package.json"
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -92,6 +92,19 @@ HAS_USER_DATA=false
 HAS_WIKI_USER_DATA=false
 HAS_ARTIFACTS_USER_DATA=false
 
+# Read the install manifest — the single record of what install.sh actually
+# shipped (scripts/lib/manifest.sh writes it). The path-based detection below is
+# coarse (whole directories); the manifest sweep at the end backstops it against
+# drift, so a file type a future kit version adds can't survive uninstall just
+# because this script's hardcoded paths weren't updated. Captured up front
+# because .kit-manifest is itself removed during uninstall.
+KIT_MANIFEST_ENTRIES=()
+if [ -f "$DEST/.kit-manifest" ]; then
+  while IFS= read -r _entry; do
+    [ -n "$_entry" ] && KIT_MANIFEST_ENTRIES+=("$_entry")
+  done < "$DEST/.kit-manifest"
+fi
+
 # Root files
 [ -f "$DEST/VERSION" ] && FILES_TO_REMOVE+=("VERSION")
 [ -f "$DEST/.kit-manifest" ] && FILES_TO_REMOVE+=(".kit-manifest")
@@ -255,9 +268,53 @@ CLAUDE_FILES_TO_REMOVE=()
 # Kit owns only extensions/README.md; user-installed extensions are preserved.
 [ -f "$DEST/.claude/extensions/README.md" ] && CLAUDE_FILES_TO_REMOVE+=(".claude/extensions/README.md")
 
+# --- Manifest backstop set ---
+# Anything the manifest recorded that the coarse path-based detection above does
+# NOT already cover (drift: files a kit version ships but this script's hardcoded
+# paths don't remove — e.g. .claude/*.example templates). Honors the --keep-*
+# groups. Computed here so it shows in --dry-run and is removed for real alike.
+manifest_entry_covered() {
+  local p="$1" r pre ext
+  for r in ${FILES_TO_REMOVE[@]+"${FILES_TO_REMOVE[@]}"} ${CLAUDE_FILES_TO_REMOVE[@]+"${CLAUDE_FILES_TO_REMOVE[@]}"}; do
+    [ "$p" = "$r" ] && return 0
+  done
+  for r in ${DIRS_TO_REMOVE[@]+"${DIRS_TO_REMOVE[@]}"} ${CLAUDE_DIRS_TO_REMOVE[@]+"${CLAUDE_DIRS_TO_REMOVE[@]}"}; do
+    case "$r" in
+      */\*.sh|*/\*.md)
+        # A glob entry (e.g. .claude/hooks/*.sh, kept whole under --keep-project)
+        # covers only DIRECT children matching the pattern — NOT subdirs such as
+        # the manifest's .claude/hooks/lib, which the backstop must still remove.
+        pre="${r%/*}"; ext="${r##*.}"
+        case "$p" in
+          "$pre"/*/*) ;;                 # deeper than a direct child — not covered
+          "$pre"/*.$ext) return 0 ;;     # direct child with the pattern's extension
+        esac
+        ;;
+      *)
+        # A whole-directory entry covers everything beneath it.
+        pre="${r%/}"
+        case "$p" in "$pre"/*) return 0 ;; esac
+        ;;
+    esac
+  done
+  return 1
+}
+
+BACKSTOP_TO_REMOVE=()
+for _entry in ${KIT_MANIFEST_ENTRIES[@]+"${KIT_MANIFEST_ENTRIES[@]}"}; do
+  case "$_entry" in
+    tasks/*)      [ "$KEEP_TASKS" = true ] && continue ;;
+    WIKI.md)      [ "$KEEP_WIKI" = true ] && continue ;;
+    ARTIFACTS.md) [ "$KEEP_ARTIFACTS" = true ] && continue ;;
+  esac
+  [ -e "$DEST/$_entry" ] || continue
+  manifest_entry_covered "$_entry" && continue
+  BACKSTOP_TO_REMOVE+=("$_entry")
+done
+
 # --- Nothing to remove? ---
 
-TOTAL=$(( ${#FILES_TO_REMOVE[@]} + ${#DIRS_TO_REMOVE[@]} + ${#CLAUDE_DIRS_TO_REMOVE[@]} + ${#CLAUDE_FILES_TO_REMOVE[@]} ))
+TOTAL=$(( ${#FILES_TO_REMOVE[@]} + ${#DIRS_TO_REMOVE[@]} + ${#CLAUDE_DIRS_TO_REMOVE[@]} + ${#CLAUDE_FILES_TO_REMOVE[@]} + ${#BACKSTOP_TO_REMOVE[@]} ))
 
 if [ "$TOTAL" -eq 0 ]; then
   info "No Claude Code Kit files found in $(pwd)"
@@ -303,6 +360,12 @@ if [ ${#CLAUDE_FILES_TO_REMOVE[@]} -gt 0 ]; then
   done
 fi
 
+if [ ${#BACKSTOP_TO_REMOVE[@]} -gt 0 ]; then
+  for f in "${BACKSTOP_TO_REMOVE[@]}"; do
+    echo -e "    ${RED}✕${NC} $f ${DIM}(manifest)${NC}"
+  done
+fi
+
 # Check if .claude/ will be empty after removal
 CLAUDE_WILL_BE_EMPTY=false
 if [ -d "$DEST/.claude" ]; then
@@ -321,7 +384,14 @@ if [ -d "$DEST/.claude" ]; then
         [ -n "$(ls -A "$item" 2>/dev/null | grep -vx 'README.md')" ] && REMAINING=$((REMAINING + 1))
         continue
         ;;
-      *) REMAINING=$((REMAINING + 1)) ;;
+      *)
+        # A .claude/ item the manifest backstop will remove doesn't count as remaining.
+        _rel=".claude/$basename"; _covered=0
+        for _b in ${BACKSTOP_TO_REMOVE[@]+"${BACKSTOP_TO_REMOVE[@]}"}; do
+          case "$_b" in "$_rel"|"$_rel"/*) _covered=1; break ;; esac
+        done
+        [ "$_covered" -eq 1 ] || REMAINING=$((REMAINING + 1))
+        ;;
     esac
   done
   if [ "$REMAINING" -eq 0 ]; then
@@ -434,6 +504,17 @@ if [ ${#CLAUDE_FILES_TO_REMOVE[@]} -gt 0 ]; then
   for f in "${CLAUDE_FILES_TO_REMOVE[@]}"; do
     rm -f "$DEST/$f"
     ok "Removed $f"
+  done
+fi
+
+# Manifest backstop — remove drift the path-based detection above didn't cover.
+if [ ${#BACKSTOP_TO_REMOVE[@]} -gt 0 ]; then
+  for f in "${BACKSTOP_TO_REMOVE[@]}"; do
+    rm -rf "$DEST/$f"
+    ok "Removed $f (manifest)"
+    # Tidy an immediate parent dir the sweep may have emptied (e.g. a new top-level dir).
+    _parent="${f%/*}"
+    [ "$_parent" != "$f" ] && rmdir "$DEST/$_parent" 2>/dev/null || true
   done
 fi
 


### PR DESCRIPTION
Closes TAN-4697. Was blocked by TAN-4689 (done — install.sh already shrunk).

> Top of the stack (#179 → #178 → #177 → #176 → #175). Base retargets as they merge; review the top commit only.

## Problem
"What the kit ships" was encoded **three ways**: `install.sh`'s manifest write, `sync-manifest.sh`'s enumeration (its header admitted it "mirrors install.sh"), and `uninstall.sh`'s hardcoded removal paths.

## What changed
**`scripts/lib/manifest.sh`** — single home for `MANIFEST_FILE`, `manifest_write` (atomic, `LC_ALL=C` sorted), `manifest_read`, and `kit_manifest_entries` (the default-install enumeration, moved verbatim from `sync-manifest.sh`).

- **`sync-manifest.sh`** sources the lib → `kit_manifest_entries` + `manifest_read`. `.kit-manifest` byte-identical; `--check` unchanged.
- **`install.sh`** sources the lib from the cloned/`--local` source and uses its `manifest_write` (inline copy deleted). The lib ships in the tarball but is **never** copied into user projects or listed in `.kit-manifest`.
- **`uninstall.sh`** reads `.kit-manifest` up front and, after its path-based removal, **sweeps any manifest entry the hardcoded paths missed** (drift backstop, honoring `--keep-*`).

## A real bug this surfaced
The backstop caught two files `install.sh` ships but `uninstall.sh` **never removed** — `.claude/commands.json.example` and `.claude/mcp-allowlist.txt.example` — so uninstall now leaves `.claude/` fully clean (new `test-install.sh` assertion locks this in).

## Design constraint (documented)
`install.sh` and `uninstall.sh` both run standalone via `curl … | bash`, so a sourced lib isn't reliably available to them. `install.sh` sources it post-clone (from `CLONE_DIR`); `uninstall.sh` consumes the `.kit-manifest` **artifact** (the same single source) rather than sourcing. This is why uninstall keeps its coarse dir-removal + keep-flag/user-data policy (the manifest is per-file and can't express those) and adds the manifest as a backstop.

## Verification
- `sync-manifest.sh --check`: byte-identical
- `test-install.sh` (install→upgrade→uninstall + strict) and `test-cli.sh`: **ALL PASS**
- **Tarball round-trip** (pack→extract→install→uninstall): clean; lib present in pkg, not leaked to project, not in manifest
- `--keep-tasks` / `--keep-wiki` / `--keep-artifacts` / `--keep-project` all honored; user-installed `.claude/extensions/*` preserved; `.claude/hooks/lib` correctly removed under `--keep-project`
- dry-run removal set vs pre-change baseline: **0 lines removed** (strictly additive — the drift fix)
- `run-bench.sh` 43/43. **Adversarially reviewed** (one low-severity `--keep-project` gap found and fixed).

## Acceptance criteria
- [x] Manifest read/write/enumerate logic exists in one place (`scripts/lib/manifest.sh`); install + sync consume it; uninstall consumes the `.kit-manifest` artifact it produces
- [x] `sync-manifest.sh --check` still enforces drift in CI
- [x] `test-install.sh` (install → upgrade → uninstall) passes on both OSes

🤖 Generated with [Claude Code](https://claude.com/claude-code)