### PR TITLE
docs(auto-mode): guard against loops gaming the quality gate

### DIFF
--- a/agent_docs/auto-mode.md
+++ b/agent_docs/auto-mode.md
@@ -78,6 +78,16 @@ That makes it inherently **project-specific**, so the kit does not ship one:
 
 If you do write one, keep it goal-checked: state the done-condition in one line ("if everything is green and quiet, say so and stop") so the loop converges instead of churning, and lean on the Verification gate rather than re-describing it.
 
+### Don't let the loop game the gate
+
+An unattended loop runs under standing pressure to reach its exit condition, and the failure mode isn't laziness — it's a model that "succeeds" by lowering the bar. The gates are deterministic, but what you *tell* the loop to do around them isn't, so make the boundary explicit in the prompt (or `loop.md`):
+
+- **The `SKIP_QUALITY_GATE` escape hatch is for broken infra, not a red gate you caused.** `stop-gate` clears on `SKIP_QUALITY_GATE=1`; that bypass exists for failures *unrelated* to the change — a flaky harness, a pre-existing break. Using it to walk past a failure your own edit introduced defeats the gate. If you set it, record why in `tasks/decisions.md`; an unexplained bypass reads as gaming.
+- **Never edit the thing you're graded on to make it pass.** Don't weaken, skip, `xfail`, or delete the failing test; don't relax the check declared in `.claude/commands.json`; don't narrow the lint config to silence the error. Fix the code, or stop. `loop-detect` blocks the 6th repeat-edit of one file, but it can't catch a check quietly rewritten to be trivial — that guardrail has to be in the prompt.
+- **A red gate after N honest tries is a stop, not a shortcut.** If the done-condition isn't genuinely met after a few real attempts — or you're circling — halt and surface the blocker. Forcing an exit (declaring done, committing over the failure) is worse than an unfinished loop: it hides the failure behind a green-looking result, the kit's worst outcome (CLAUDE.md → Verification step 5).
+
+When you write a `loop.md` done-condition, phrase it so it can only be satisfied honestly — "if the suite is green **and** the feature actually runs, say so and stop," not "stop when the errors go away," which a deleted test also satisfies.
+
 ---
 
 ## Gotchas

--- a/agent_docs/hooks.md
+++ b/agent_docs/hooks.md
@@ -117,7 +117,7 @@ Some hooks block actions or completion. When they get in the way (broken test in
 | Variable | Effect |
 |----------|--------|
 | `CLAUDE_APPROVED=1` | `protect-changes.sh` skips its block. Record the rationale in `tasks/decisions.md` (ADR template) — that is the agreed audit trail. |
-| `SKIP_QUALITY_GATE=1` | `stop-gate.sh` allows completion even with a failed gate. Use sparingly; the failure is still recorded in `.hook-state/last_quality_gate.json`. |
+| `SKIP_QUALITY_GATE=1` | `stop-gate.sh` allows completion even with a failed gate. **For failures unrelated to your change only** (broken infra, intentional WIP) — not to walk past a red gate your own edit caused; that's gaming the gate (see `agent_docs/auto-mode.md → Don't let the loop game the gate`). Use sparingly; the failure is still recorded in `.hook-state/last_quality_gate.json`. |
 | `CLAUDE_SKIP_QUALITY_GATE=1` | Alias for the above. |
 | `BASH_BUDGET_THRESHOLD=<n>` | Overrides the default 50000-token threshold used by `bash-budget.sh`. Set to a high number (e.g. 999999999) to suppress the warning entirely; set lower to surface it earlier. |
 | `READ_BUDGET_THRESHOLD=<n>` | Overrides the default 100000-token threshold used by `read-budget.sh` (cumulative file-read cost). Same semantics as `BASH_BUDGET_THRESHOLD`. |


### PR DESCRIPTION
## What

Adds a **"Don't let the loop game the gate"** subsection to `agent_docs/auto-mode.md` (scheduled-autonomy section) and cross-links it from the `SKIP_QUALITY_GATE` row in `agent_docs/hooks.md`.

An unattended `/loop` runs under standing pressure to reach its exit condition; the failure mode isn't laziness but a model that "succeeds" by lowering the bar. The gates (`quality-gate` → `stop-gate`, `loop-detect`) are deterministic, but the prompt around them isn't — so the guardrail has to be stated:

- `SKIP_QUALITY_GATE=1` is for infra failures **unrelated** to your change, not a red gate your own edit caused.
- Never weaken/skip/`xfail`/delete the failing test or relax the check declared in `.claude/commands.json` to make a red gate green.
- A red gate after N honest tries is a **stop**, not a shortcut — forcing an exit hides the failure behind a green-looking result (CLAUDE.md → Verification step 5).

## Why

From the loops.elorm.xyz deep-dive (Linear **TAN-3926**): its "Hardened" loops ship explicit anti-gaming guardrails. CCK's gates are already stronger (real exit-2 hooks vs advisory prompt-hooks), but nothing told the model *not to game them*. This closes that prompt-side gap. Tracked as **TAN-4744**.

## Verification

- `scripts/sync-manifest.sh --check` → in sync (no files added/removed; `.kit-manifest` is a path list).
- markdownlint config (`.markdownlint.json`) has MD013/MD022/MD031/MD032 disabled — standard prose passes.
- `AGENTS.md` is generated only from `agent_docs/conventions.md` (`gen-agents-md.sh`), so agents-md-sync is unaffected.
- No new links → link-check unaffected.

Docs-only; no code paths touched.