### PR TITLE
docs(debugging): sharpen the re-attack rung of the verify loop

### DIFF
--- a/agent_docs/debugging.md
+++ b/agent_docs/debugging.md
@@ -17,6 +17,7 @@ Before touching any code, confirm the bug exists and is consistent.
 - Run the exact command/action that triggers the bug
 - Note the exact error message, stack trace, or wrong behavior
 - Confirm it's reproducible (not a one-time flake)
+- **Capture the trigger as a reusable artifact** — the exact command, input, or payload, and ideally a *failing test* that encodes it. This is the thing you will re-run **unchanged** in Step 4 (Verify). If you can't re-run the identical trigger afterward, you can't prove the fix — only assert it. A failing regression test is the strongest form: it makes the trigger permanent (CLAUDE.md → Plan First: "write a test that reproduces it, then make it pass").
 
 If you can't reproduce it, you can't fix it. Ask for more context.
 
@@ -71,7 +72,7 @@ Apply the smallest correct change.
 
 Confirm the fix works and nothing else broke.
 
-1. Run the exact reproduction steps — bug should be gone
+1. **Re-attack: re-run the captured trigger from Step 1, unchanged.** The verdict is the command's exit code / the test result — **not** "it looks fixed." A patch that suppresses the symptom (or fixes a neighbour) sails through a casual re-read but fails the real input. In Anthropic's defending-code-reference-harness, ~60% of patches pass a build-and-reproduce check yet **under 15% survive re-running the original attack** — "looks fixed" is usually wrong. If you had to change the trigger to make it pass, you haven't fixed the bug (see `agent_docs/auto-mode.md → Don't let the loop game the gate`).
 2. Run the test suite — no new failures
 3. Think about edge cases the fix might affect
 4. Check if similar bugs could exist in related code


### PR DESCRIPTION
## What

Sharpens the **Verify** rung of the debugging loop in `agent_docs/debugging.md`:

- **Step 1 (Reproduce)** — new bullet: *capture the trigger as a reusable artifact* (exact command/input, ideally a failing test). It's the thing you re-run **unchanged** in Step 4; if you can't re-run the identical trigger, you can only *assert* a fix, not prove it.
- **Step 4 (Verify)** — first check reframed as an explicit **re-attack**: re-run the captured trigger; the verdict is the exit code / test result (mechanical), **not** "it looks fixed."

## Why

From the defending-code-reference-harness deep-dive (Linear **TAN-3927**): its patch ladder ends in a **re-attack** rung (re-run the original failure-triggering input against the patched build, oracle decides — no model judgment). Reported numbers: ~60% of patches pass build+reproduce but **under 15% survive re-attack**. CCK's Step 4 already said "run the exact reproduction steps," but didn't stress capturing the trigger up front or that the verdict must be mechanical — that's the gap this closes. Tracked as **TAN-4745**.

## Notes

- Cross-links the anti-gaming guidance added in #184 (`auto-mode.md → Don't let the loop game the gate`). It's a prose reference, not a markdown link (link-check unaffected), but **#184 should merge first** so it resolves cleanly.
- Docs-only. `sync-manifest.sh --check` in sync (no files added/removed); AGENTS.md derives only from `conventions.md`; markdownlint config permits the prose.