### PR TITLE
feat(hooks): redact secret values before persisting notes/handoff

### DIFF
--- a/.claude/hooks/journal-fold.sh
+++ b/.claude/hooks/journal-fold.sh
@@ -26,6 +26,14 @@ ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
 JOURNAL="$ROOT/.hook-state/session-journal.md"
 AGENT_HANDOFF="$ROOT/.hook-state/agent-handoff.md"
 
+# Redact secret values before folding transient notes into the durable,
+# potentially-committed handoff (TAN-4733). Best-effort: source the shared lib,
+# fall back to a no-op passthrough if it isn't present.
+_REDACT_LIB="$(dirname "$0")/lib/redact-secrets.sh"
+# shellcheck source=/dev/null
+[ -f "$_REDACT_LIB" ] && . "$_REDACT_LIB"
+declare -F redact_secrets >/dev/null 2>&1 || redact_secrets() { cat; }
+
 # Extract session_id once (shared by both folds); fall back to a timestamp slug.
 SESSION_ID=""
 if command -v python3 >/dev/null 2>&1; then
@@ -51,7 +59,7 @@ if [ -f "$AGENT_HANDOFF" ] && [ -s "$AGENT_HANDOFF" ]; then
     echo ""
     echo "## Agent handoff — folded from agent-handoff.md on $NOW"
     echo ""
-    cat "$AGENT_HANDOFF"
+    redact_secrets < "$AGENT_HANDOFF"
     echo ""
   } >> "$HANDOFF"
 fi
@@ -88,7 +96,7 @@ mkdir -p "$ROOT/tasks"
   echo ""
   echo "## Journal — folded from session-journal.md on $NOW"
   echo ""
-  cat "$JOURNAL"
+  redact_secrets < "$JOURNAL"
   echo ""
   echo "**Counts:** findings: $FINDINGS · decisions: $DECISIONS · summaries: $SUMMARIES"
   echo ""

--- a/.claude/hooks/lib/redact-secrets.sh
+++ b/.claude/hooks/lib/redact-secrets.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# redact-secrets.sh — shared hook/skill library
+#
+# Defines redact_secrets(): reads stdin, writes stdout with secret VALUES
+# masked as «redacted». Used before agent-authored text is persisted to disk
+# where it could later be committed or synced:
+#   - scripts/note.sh          → .hook-state/session-journal.md
+#   - .claude/hooks/journal-fold.sh → tasks/handoff-<session-id>.md (durable)
+#
+# Design goals (see TAN-4733):
+#   - Mask the VALUE, not the whole line — prose stays readable.
+#   - Conservative — no false positives on words like "password reset flow"
+#     (an assignment separator [:=] or a `Bearer ` prefix is required for the
+#     key=value forms; standalone high-entropy token formats are masked on sight).
+#   - Portable — pure python3 with a `cat` passthrough fallback if python3 is
+#     absent (redaction is defense-in-depth, never a hard gate).
+#
+# Source it, then call:  redact_secrets < infile   |   printf '%s' "$x" | redact_secrets
+#
+
+# The redactor lives in python for reliable case-insensitive regex. The program
+# is captured into a variable via a quoted heredoc so it can contain any quote
+# character, and so real stdin stays free for the data being redacted.
+_REDACT_PY_PROG=''
+IFS='' read -r -d '' _REDACT_PY_PROG <<'PYEOF' || true
+import sys, re
+
+text = sys.stdin.read()
+R = "«redacted»"  # «redacted»
+
+# key = value / key: value / key => value — mask the value after the key token.
+# The separator requirement is what keeps prose ("password reset flow") safe.
+# Run this BEFORE the standalone patterns so a `key=<token>` value is consumed
+# whole (fixed-width token patterns would otherwise leave a trailing char).
+KEY = (
+    r'(?i)(\b(?:api[_-]?key|api[_-]?secret|auth[_-]?token|access[_-]?token'
+    r'|refresh[_-]?token|session[_-]?key|secret[_-]?key|client[_-]?secret'
+    r'|secret|password|passwd|pwd|private[_-]?key|token)\b\s*(?:=>|[:=])\s*)'
+)
+
+# (A1) Authorization: Bearer <token>
+text = re.sub(r'(?i)(\bBearer\s+)[A-Za-z0-9._~+/\-]{6,}=*', lambda m: m.group(1) + R, text)
+
+# (A2) quoted value — mask whatever is inside the quotes.
+text = re.sub(KEY + r'(["\'])(?:(?!\2).)+\2',
+              lambda m: m.group(1) + m.group(2) + R + m.group(2), text)
+
+# (A3) unquoted value — a contiguous secret-like run of >=6 token chars.
+# The length floor avoids masking short prose words after a colon.
+text = re.sub(KEY + r'[A-Za-z0-9._+/=~\-]{6,}', lambda m: m.group(1) + R, text)
+
+# (B) Standalone high-signal token formats — unambiguous, mask any that remain
+# (e.g. a token pasted without a key= prefix).
+for pat in (
+    r'AKIA[0-9A-Z]{16}',                                              # AWS access key id
+    r'(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}',                      # GitHub tokens
+    r'xox[bpars]-[A-Za-z0-9-]{10,}',                                  # Slack tokens
+    r'AIza[0-9A-Za-z_\-]{35}',                                        # Google API key
+    r'eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}',  # JWT
+    r'sk-[A-Za-z0-9]{20,}',                                           # OpenAI-style keys
+):
+    text = re.sub(pat, R, text)
+
+sys.stdout.write(text)
+PYEOF
+
+redact_secrets() {
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -c "$_REDACT_PY_PROG" 2>/dev/null || cat
+  else
+    cat
+  fi
+}

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ See `agent_docs/hooks.md` for how to enable the opt-in hooks and write your own.
 
 ### KitBench — hooks are tested
 
-The hooks above aren't documentation, they're a contract. The kit ships [`bench/`](bench/README.md): a reproducible eval harness with 43 scenarios covering every blocking hook plus regression tests for past bugs (composer.lock slip-through, `EXIT_CODE=$?` after `|| true`, `.github/workflows/ci.yml` basename-with-slash miss, word-boundary regex rejecting "authentication", stale quality-gate verdict blocking a fresh session). Run it any time with `./scripts/run-bench.sh`; CI runs it on every PR.
+The hooks above aren't documentation, they're a contract. The kit ships [`bench/`](bench/README.md): a reproducible eval harness with 44 scenarios covering every blocking hook plus regression tests for past bugs (composer.lock slip-through, `EXIT_CODE=$?` after `|| true`, `.github/workflows/ci.yml` basename-with-slash miss, word-boundary regex rejecting "authentication", stale quality-gate verdict blocking a fresh session). Run it any time with `./scripts/run-bench.sh`; CI runs it on every PR.
 
 ```text
 KitBench

--- a/bench/README.md
+++ b/bench/README.md
@@ -65,6 +65,7 @@ Each scenario runs in a **fresh temp directory** — no shared state between sce
 | s41 | `mcp-gate-inert-without-allowlist` | No allowlist file → exit 0, only the untrusted-input reminder fires |
 | s42 | `quality-gate-uses-declared-lint-fail` | `.claude/commands.json` declares `lint: false` → gate runs it, records `failed` |
 | s43 | `quality-gate-uses-declared-lint-pass` | `.claude/commands.json` declares `lint: true` → gate runs it, records `passed` |
+| s44 | `journal-fold-redacts-secrets` | `journal-fold.sh` masks secret values (`api_key=…`, `Bearer …`) before folding notes into the durable `tasks/handoff-*.md`, leaving prose intact — TAN-4733 |
 
 ## Add a scenario
 

--- a/bench/scenarios/s44-journal-fold-redacts-secrets.json
+++ b/bench/scenarios/s44-journal-fold-redacts-secrets.json
@@ -1,0 +1,23 @@
+{
+  "name": "s44-journal-fold-redacts-secrets",
+  "hook": ".claude/hooks/journal-fold.sh",
+  "setup_files": {
+    ".hook-state/session-journal.md": "2026-05-22T10:00:00Z [finding] leaked api_key=AKIAIOSFODNN7EXAMPLE while debugging the password reset flow\n2026-05-22T10:05:00Z [decision] rotate the key and keep the retry backoff loop\n"
+  },
+  "payload": {
+    "session_id": "kitbench-s44"
+  },
+  "expect": {
+    "exit_code": 0,
+    "file_grew": ["tasks/handoff-kitbench-s44.md"],
+    "file_contains": [
+      { "file": "tasks/handoff-kitbench-s44.md", "substr": "«redacted»" },
+      { "file": "tasks/handoff-kitbench-s44.md", "substr": "password reset flow" },
+      { "file": "tasks/handoff-kitbench-s44.md", "substr": "retry backoff loop" }
+    ],
+    "file_not_contains": [
+      { "file": "tasks/handoff-kitbench-s44.md", "substr": "AKIAIOSFODNN7EXAMPLE" }
+    ]
+  },
+  "notes": "TAN-4733: journal-fold.sh redacts secret values (via .claude/hooks/lib/redact-secrets.sh) before folding transient notes into the durable, committable handoff. Asserts the api_key value is masked to «redacted» and the raw key never reaches the handoff, while surrounding prose ('password reset flow', 'retry backoff loop') is untouched — no false positives."
+}

--- a/scripts/note.sh
+++ b/scripts/note.sh
@@ -38,6 +38,15 @@ case "$TAG" in
 esac
 
 ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# Redact secret values before the note is persisted (TAN-4733). Best-effort:
+# source the shared lib; fall back to a no-op passthrough if it isn't present.
+_REDACT_LIB="$ROOT/.claude/hooks/lib/redact-secrets.sh"
+# shellcheck source=/dev/null
+[ -f "$_REDACT_LIB" ] && . "$_REDACT_LIB"
+declare -F redact_secrets >/dev/null 2>&1 || redact_secrets() { cat; }
+TEXT=$(printf '%s' "$TEXT" | redact_secrets)
+
 STATE_DIR="$ROOT/.hook-state"
 mkdir -p "$STATE_DIR"
 [ -f "$STATE_DIR/.gitignore" ] || printf '*\n!.gitignore\n' >"$STATE_DIR/.gitignore"

--- a/scripts/run-bench.sh
+++ b/scripts/run-bench.sh
@@ -225,6 +225,24 @@ def run_scenario(scenario):
             if os.path.exists(full):
                 failures.append(f"file expected absent: {fa}")
 
+        # file_contains (a written file has a substring — e.g. a redaction marker)
+        for fc in scenario.get("expect", {}).get("file_contains", []):
+            full = os.path.join(workdir, fc["file"])
+            if not os.path.isfile(full):
+                failures.append(f"file expected to exist: {fc['file']}")
+                continue
+            content = open(full, encoding="utf-8", errors="replace").read()
+            if fc["substr"] not in content:
+                failures.append(f"file {fc['file']} missing substring {fc['substr']!r}")
+
+        # file_not_contains (a written file must NOT leak a substring — e.g. a secret)
+        for fc in scenario.get("expect", {}).get("file_not_contains", []):
+            full = os.path.join(workdir, fc["file"])
+            if os.path.isfile(full):
+                content = open(full, encoding="utf-8", errors="replace").read()
+                if fc["substr"] in content:
+                    failures.append(f"file {fc['file']} unexpectedly contains {fc['substr']!r}")
+
         return (not failures), failures, proc.stdout, proc.stderr
     finally:
         shutil.rmtree(workdir, ignore_errors=True)


### PR DESCRIPTION
## What

Adds a secret-redaction pass on the write paths that persist agent-authored text to disk.

- **`.claude/hooks/lib/redact-secrets.sh`** (new) — a shared `redact_secrets()` that masks secret **values** as `«redacted»`: `Bearer <token>`, `api_key=…` / `password:` / `token=…` style assignments, and standalone `AWS AKIA…` / `ghp_…` / `xox…` / `AIza…` / JWT / `sk-…` formats. Pure `python3` with a `cat` passthrough fallback if python3 is absent (defense-in-depth, never a hard gate).
- **`scripts/note.sh`** — redacts each note before appending to `.hook-state/session-journal.md`.
- **`.claude/hooks/journal-fold.sh`** — redacts the journal + the inter-agent handoff before folding into the durable, committable `tasks/handoff-<id>.md`.

Conservative by design: an assignment separator (`[:=]`/`=>`) or a `Bearer ` prefix is required for the key=value forms, and unquoted values must be a ≥6-char token run — so prose like *"password reset flow"* or *"the secret to success"* is left untouched.

## Why

From the WrongStack deep-dive (Linear **TAN-3919**, Tier 1): it scrubs turn text before it hits disk. CCK was writing `/note` journal + handoff files in the clear, so a pasted/echoed key could be persisted verbatim and later committed or synced. Tracked as **TAN-4733**.

## Test

- New KitBench scenario **s44** asserts the folded handoff masks an `api_key=` value (`file_contains «redacted»`, `file_not_contains AKIA…`) while keeping surrounding prose (`file_contains "password reset flow"`).
- Extends the bench runner with general-purpose `file_contains` / `file_not_contains` assertions (the schema had `file_grew` but no content check).
- **44/44 bench pass** (no regression); `note.sh` redaction verified end-to-end.

## Notes

- `.claude/hooks/lib/` is copied wholesale by `install.sh` and tracked as a directory entry in `.kit-manifest`, so the new lib ships without a manifest change. `bench/` isn't manifest-tracked. README scenario count bumped 43 → 44.
- Test data uses the canonical AWS docs example key (`AKIAIOSFODNN7EXAMPLE`), recognized as a non-secret by scanners.