### PR TITLE
feat(skills): add allowed-tools scoping convention + validator check

### DIFF
--- a/.claude/skills/architecture-review/SKILL.md
+++ b/.claude/skills/architecture-review/SKILL.md
@@ -2,6 +2,7 @@
 name: architecture-review
 description: Review codebase architecture for SOLID violations, dependency health, module boundaries, and structural issues. Use when assessing whole-system structure or coupling. For single-module depth use /deepening-review; for a concrete refactor plan use /refactoring-guide.
 user-invocable: true
+allowed-tools: Read, Grep, Glob
 ---
 
 # Architecture Review

--- a/.claude/skills/performance-audit/SKILL.md
+++ b/.claude/skills/performance-audit/SKILL.md
@@ -2,6 +2,7 @@
 name: performance-audit
 description: Identify performance bottlenecks — rendering, startup, memory, and I/O — across any stack. Use when the app is slow, before perf-sensitive releases, or when the user mentions latency, jank, or memory growth.
 user-invocable: true
+allowed-tools: Read, Grep, Glob
 ---
 
 # Performance Audit

--- a/agent_docs/skills.md
+++ b/agent_docs/skills.md
@@ -147,6 +147,24 @@ This pass produces **candidates**, not findings. Treat counts as leads for deepe
 <phase-specific content>
 ```
 
+### 5. Tool scoping (`allowed-tools`) — optional, defense-in-depth
+
+A skill may declare an `allowed-tools` frontmatter field to scope which tools it can use while active. Absence means "inherit the session's tools", so this is **opt-in**, never forced. Reach for it on skills whose job is bounded: a read-only audit/review has no business calling `Write`, `Edit`, or spawning sub-agents; a skill that only fetches a URL shouldn't hold file-mutation tools. If a skill — or the untrusted content it ingests — is ever prompt-injected, a tight scope is the wall the injected instruction runs into.
+
+```yaml
+---
+name: architecture-review
+description: …
+allowed-tools: Read, Grep, Glob
+---
+```
+
+- **Inline, comma-separated** — the Claude Code form. Entries are tool names (`Read`, `Grep`, `Bash`) and may be command-scoped (`Bash(git log:*)`).
+- **Scope to what the skill demonstrably uses.** A read-and-report audit needs `Read, Grep, Glob`; add `Bash` only if it runs read-only shell, `Edit`/`Write` only if it persists output. An over-tight scope silently disables a capability the skill relies on — match reality, don't aspire.
+- **Complements, doesn't replace, the hooks.** `allowed-tools` gates at the *tool* level; command-level safety (no `rm -rf /`, no push to `main`, no editing `.env`) still comes from the `PreToolUse` hooks and the `permissions.deny` floor. Both layers hold — see `agent_docs/subagents.md → Permission Posture — Delegated & Auto Work` and `hooks.md`.
+
+`validate-skills.sh` checks the field is well-formed when present (a declared-but-empty scope fails); it does **not** require it, and deliberately doesn't validate tool *names* against a fixed list — Claude Code forms like `Bash(git log:*)` would trip a naive pattern, and any hardcoded tool list ages.
+
 ### Anti-staleness: defer to `--help`
 
 Skills that wrap a CLI (`ship`, `references-sync`, `web-read`) should point the agent at the tool's own `--help` / `help` output rather than hardcoding an exhaustive flag list:

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -64,7 +64,10 @@ for skill_dir in "$SKILLS_DIR"/*/; do
   SKILL_COUNT=$((SKILL_COUNT + 1))
 
   # --- Check YAML frontmatter ---
-  if head -1 "$SKILL_FILE" | grep -q '^---$'; then
+  # Exact-match the first line rather than `head | grep -q` — under `set -o
+  # pipefail` a quiet grep can close the pipe early and surface the writer's
+  # SIGPIPE as the pipeline status, which made section checks flake (TAN-4746).
+  if [ "$(head -1 "$SKILL_FILE")" = "---" ]; then
     pass "Has YAML frontmatter"
 
     # Extract frontmatter (between first --- and second ---)
@@ -90,11 +93,25 @@ for skill_dir in "$SKILLS_DIR"/*/; do
         pass "description: $FM_DESC"
       fi
       # Router-style nudge: the description should say WHEN to fire, not just what it does
-      if ! echo "$FM_DESC" | grep -qiE 'use (when|for|to|it|right|once|at|before|after|as|during|instead)|when the user|distinct from|do not use|triggers? on'; then
+      if ! grep -qiE 'use (when|for|to|it|right|once|at|before|after|as|during|instead)|when the user|distinct from|do not use|triggers? on' <<< "$FM_DESC"; then
         warn "Description has no 'Use when…' trigger clause — router-style descriptions match better (see agent_docs/skills.md → Skill Conventions → Router-style description)"
       fi
     else
       fail "Missing 'description' in frontmatter"
+    fi
+
+    # --- Check allowed-tools scoping (optional, defense-in-depth — TAN-4746) ---
+    # Opt-in: absence never fails. When declared inline it must carry a value;
+    # token syntax is intentionally NOT validated against a fixed list — Claude
+    # Code allows forms like `Bash(git log:*)` a naive pattern would reject, and
+    # a hardcoded tool list ages. See agent_docs/skills.md → Tool scoping.
+    if grep -qE '^allowed-tools:' <<< "$FRONTMATTER"; then
+      FM_TOOLS=$(echo "$FRONTMATTER" | grep -E '^allowed-tools:' | sed 's/^allowed-tools:[[:space:]]*//')
+      if [ -n "$FM_TOOLS" ]; then
+        pass "allowed-tools scoped: $FM_TOOLS"
+      else
+        fail "allowed-tools declared but empty — list the tools inline (e.g. 'Read, Grep, Glob'), or remove the key"
+      fi
     fi
   else
     fail "No YAML frontmatter (must start with ---)"
@@ -111,7 +128,7 @@ for skill_dir in "$SKILLS_DIR"/*/; do
   # For skill-extractor, sections are different (it's a meta-skill)
   if [ "$skill_name" = "skill-extractor" ]; then
     for section in "When to Extract" "When NOT to Extract" "Extraction Process" "Quality Gates"; do
-      if echo "$CONTENT" | grep -q "## $section"; then
+      if grep -q "## $section" <<< "$CONTENT"; then
         pass "Has section: $section"
       else
         warn "Missing section: $section"
@@ -120,7 +137,7 @@ for skill_dir in "$SKILLS_DIR"/*/; do
   elif [ -n "$IS_USER_INVOCABLE" ]; then
     # User-invocable skills (audits, guides) use When to Use / Process / Output Format
     for section in "When to Use" "Process" "Output Format"; do
-      if echo "$CONTENT" | grep -q "## $section"; then
+      if grep -q "## $section" <<< "$CONTENT"; then
         pass "Has section: $section"
       else
         fail "Missing required section: $section"
@@ -129,7 +146,7 @@ for skill_dir in "$SKILLS_DIR"/*/; do
 
     # Optional but recommended sections for user-invocable skills
     for section in "Notes"; do
-      if echo "$CONTENT" | grep -q "## $section"; then
+      if grep -q "## $section" <<< "$CONTENT"; then
         pass "Has section: $section"
       else
         warn "Missing optional section: $section"
@@ -137,7 +154,7 @@ for skill_dir in "$SKILLS_DIR"/*/; do
     done
   else
     for section in "Problem" "Solution" "Verification"; do
-      if echo "$CONTENT" | grep -q "## $section"; then
+      if grep -q "## $section" <<< "$CONTENT"; then
         pass "Has section: $section"
       else
         fail "Missing required section: $section"
@@ -146,7 +163,7 @@ for skill_dir in "$SKILLS_DIR"/*/; do
 
     # Optional but recommended sections
     for section in "Context" "Notes"; do
-      if echo "$CONTENT" | grep -q "## $section"; then
+      if grep -q "## $section" <<< "$CONTENT"; then
         pass "Has section: $section"
       else
         warn "Missing optional section: $section"
@@ -155,7 +172,7 @@ for skill_dir in "$SKILLS_DIR"/*/; do
   fi
 
   # --- Check Core Rule (v1.11+ pattern, codex-inspired) ---
-  if echo "$CONTENT" | grep -q "^## Core Rule$"; then
+  if grep -q "^## Core Rule$" <<< "$CONTENT"; then
     pass "Has Core Rule"
   else
     warn "Missing ## Core Rule section (one-sentence ethical scope — see agent_docs/skills.md)"
@@ -167,15 +184,15 @@ for skill_dir in "$SKILLS_DIR"/*/; do
   # are meta or interactive and don't need the same patterns.
   case "$skill_name" in
     code-quality-audit|performance-audit|architecture-review|accessibility-audit|testing-audit|dependency-audit|documentation-audit|design-review|project-health-report|dead-code-audit|quality-audit|doc-gardening|references-sync)
-      if echo "$CONTENT" | grep -q "^## Default Behavior$"; then
+      if grep -q "^## Default Behavior$" <<< "$CONTENT"; then
         pass "Has Default Behavior (audit skill)"
       else
         warn "Missing ## Default Behavior section (audit skill should autonomously act on 'audit/scan/review' requests)"
       fi
 
-      if echo "$CONTENT" | grep -q "^### Phase 1: Inventory (first-pass leads)$"; then
+      if grep -q "^### Phase 1: Inventory (first-pass leads)$" <<< "$CONTENT"; then
         pass "Phase 1 uses standard Inventory naming"
-      elif echo "$CONTENT" | grep -q "^### Phase 1:"; then
+      elif grep -q "^### Phase 1:" <<< "$CONTENT"; then
         warn "Phase 1 not standardized as 'Inventory (first-pass leads)' — see agent_docs/skills.md"
       fi
       ;;


### PR DESCRIPTION
## What

Adds an opt-in **`allowed-tools` frontmatter convention** for scoping a skill's tools, plus enforcement:

- **`agent_docs/skills.md`** — new convention "5. Tool scoping (`allowed-tools`)": what it is, when to reach for it (bounded read-only audits shouldn't hold `Write`/`Edit`/`Task`), that it's **opt-in** (absence inherits the session's tools), and that it *complements* — doesn't replace — the command-level `PreToolUse` hooks + `permissions.deny` floor.
- **Two worked examples** — `architecture-review` and `performance-audit` (both read-and-report, verified no disk writes) scoped to `Read, Grep, Glob`.
- **`validate-skills.sh`** — validates the field **when present** (a declared-but-empty scope fails). It deliberately does **not** validate token *names* against a fixed list: Claude Code forms like `Bash(git log:*)` would trip a naive pattern, and any hardcoded tool list ages (same anti-staleness principle the kit already follows).

## Why

From the defending-code-reference-harness deep-dive (Linear **TAN-3927**): its interactive skills scope `allowed-tools` in frontmatter so capability matches need. Pairs with **TAN-4734** (allowlist-default for subagents). Tracked as **TAN-4746**.

## Bonus: fixes a pre-existing validator flake

While adding the check I found `validate-skills.sh` failing spuriously ~1 run in 3. Root cause: under `set -o pipefail`, `echo "$VAR" | grep -q` lets `grep` close the pipe on first match, so the writer catches **SIGPIPE (141)** and pipefail surfaces it as the pipeline status → the `if` reads "section missing" and fails a section that's actually present. Converted the 11 quiet-grep pipes to here-strings and the frontmatter probe to an exact match.

## Test

- **15/15 runs now deterministic**: `361 passed, 0 failed, 4 warnings` every time (was flaking to 1–2 spurious failures before).
- Negative test: a skill with a bare `allowed-tools:` fails as intended.
- `sync-manifest.sh --check` in sync; `check-counts.sh` OK (no skills added/removed).