### PR TITLE
docs(auto-mode): add "when to stop and ask" escalation taxonomy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ Asking the model to do deterministic work burns tokens _and_ introduces non-dete
 - Log unrelated issues under `tasks/todo.md → ## Not Now`
 - State every assumption explicitly before acting on it
 - If 2+ valid approaches exist with real tradeoffs: present them, don't decide silently
+- **Running autonomously (auto mode / `/loop`): escalate, don't stall and don't silently guess.** At the hard judgment points a hook can't catch — irreversible ops outside the guardrails, ambiguous requirements, scope growth, N failed tries — stop and ask. See `agent_docs/auto-mode.md → When to stop and ask`.
 
 ---
 

--- a/agent_docs/auto-mode.md
+++ b/agent_docs/auto-mode.md
@@ -57,6 +57,19 @@ In short: the two things the kit ships — a curated `deny` list and a set of `P
 
 ---
 
+## When to stop and ask (escalation points)
+
+Auto mode and `/loop` remove the *prompts*, not your *judgment*. The deterministic hooks already stop the **mechanical** cases: `protect-changes` gates dependency / auth / migration edits, `block-dangerous-commands` blocks destructive shells, `branch-protect` blocks pushes to `main`, `loop-detect` halts thrash on one file, and `stop-gate` blocks completion on a red gate. What no hook can catch is a **judgment** call. At these points, **escalate to the human — don't stall, and don't silently guess:**
+
+- **Irreversible or destructive actions outside the guardrails.** The hooks cover the common cases; a genuinely destructive action they *don't* — dropping a bucket, force-deleting a remote resource, a one-way data migration, rewriting published history — is a stop-and-ask, because there's no undo if the guess is wrong.
+- **Ambiguous requirements.** Two defensible readings with materially different outcomes → ask which one. A wrong interpretation is more expensive to unwind than the interruption is to make.
+- **Scope expansion.** The task grew past what was asked — a refactor the fix "needs", a second subsystem, a dependency bump → surface it and get a yes before spending the budget (CLAUDE.md → Scope Discipline: log it under `## Not Now`, don't fold it in silently).
+- **Repeated failed attempts.** N honest tries with no real progress, or you're circling → halt and surface the blocker rather than thrash or force an exit. For the loop-specific form of this — a red gate the loop is tempted to *game* into passing — see **Don't let the loop game the gate** below; this bullet is the general case.
+
+Escalation is not failure. A stalled loop that asks one sharp question beats a green-looking result built on a silent wrong guess — the kit's worst outcome (CLAUDE.md → Verification step 5). When you escalate, don't just stop: state the decision, the options, and your recommendation in one message so the human can unblock you in a single reply.
+
+---
+
 ## Scheduled autonomy: `/loop` and `loop.md`
 
 Auto mode removes the per-action prompts; `/loop` removes the per-iteration *you*. It's the bundled skill that re-runs a prompt on a schedule **inside the open session** — `/loop 15m <prompt>` for a fixed interval, `/loop <prompt>` to let Claude pace itself, or a bare `/loop` for the built-in maintenance prompt (continue unfinished work, tend the current PR, run cleanup). Requires Claude Code **v2.1.72+**; not available on Bedrock / Vertex / Foundry.


### PR DESCRIPTION
## What

Adds a documented **escalation taxonomy** for autonomous runs (auto mode, `/loop`, `/ship`): the hard judgment points where the agent must stop and ask the human instead of pushing through. From the AgentRQ deep-dive (TAN-4193, Tier 1) — capture the escalation *discipline* at the doc level, without AgentRQ's human-approval control-plane. **No new hook or runtime; prompt/doc-level only.**

## How

`agent_docs/auto-mode.md` gains a **"When to stop and ask (escalation points)"** section that opens by naming the hooks which already handle the *mechanical* cases (`protect-changes`, `block-dangerous-commands`, `branch-protect`, `loop-detect`, `stop-gate`), then enumerates the *judgment* cases a hook can't catch — one-line rationale each:

- **Irreversible / destructive actions outside the guardrails** — no undo if the guess is wrong.
- **Ambiguous requirements** — two defensible readings, materially different outcomes.
- **Scope expansion** — grew past what was asked.
- **Repeated failed attempts** — N honest tries, no progress; defers the loop-*gaming* case to the existing **Don't let the loop game the gate** section (TAN-4744) rather than duplicating it.

Framed **"escalate, don't stall and don't silently guess"**, closing with "escalation is not failure." `CLAUDE.md` gets a one-line Scope Discipline pointer into the section.

## Scope / non-duplication

- Cross-references the mechanical-subset hooks so the section scopes itself to judgment calls (AC).
- The repeated-attempts bullet explicitly hands the loop/red-gate specifics back to the TAN-4744 section — no overlap-duplication (AC).
- `AGENTS.md` is a curated subset of `CLAUDE.md` (it doesn't mirror the Scope Discipline bullets), so the sync gate stays green with no AGENTS.md change.

## Gates (green locally)

markdownlint ✓ · AGENTS.md-sync idempotent (no diff) ✓ · doc-only, so bench/counts/strict untouched.

## Acceptance criteria

- [x] `auto-mode.md` enumerates the escalation points with a one-line rationale each
- [x] Cross-references loop-detect / stop-gate / protect-changes (mechanical subset) to scope itself to judgment cases
- [x] No new hook or runtime — prompt/doc-level only
- [x] No overlap-duplication with TAN-4744

Closes TAN-4752

🤖 Generated with [Claude Code](https://claude.com/claude-code)