### PR TITLE
test(install): assert strict profile wires notify-waiting (5 opt-in hooks)

### DIFF
--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -96,8 +96,8 @@ if json_valid "$STRICT_SETTINGS"; then
 else
   fail "strict settings.json is INVALID JSON"
 fi
-# The strict delta: 4 opt-in hooks + the build-config hard-block flag.
-for needle in skill-extract-reminder.sh auto-lint.sh auto-format.sh skill-compliance.sh CCK_PROTECT_BUILD_CONFIGS; do
+# The strict delta: 5 opt-in hooks + the build-config hard-block flag.
+for needle in skill-extract-reminder.sh auto-lint.sh auto-format.sh skill-compliance.sh notify-waiting.sh CCK_PROTECT_BUILD_CONFIGS; do
   grep -q "$needle" "$STRICT_SETTINGS" && pass "strict enables $needle" || fail "strict missing $needle"
 done
 


### PR DESCRIPTION
## Summary
- `scripts/test-install.sh` strict-profile assertion predates 1.21.0: it verifies the four original opt-in hooks but not `notify-waiting.sh` (added in #192), so a regression in `scripts/gen-strict-settings.sh` dropping the new Notification hook would pass CI silently.
- Adds `notify-waiting.sh` to the strict needle list and fixes the stale "4 opt-in hooks" comment (now 5).

## Test plan
- [x] `bash scripts/test-install.sh` — ALL PASS, including the new `strict enables notify-waiting.sh` assertion.

Follow-up to the 1.21.0 doc-count sync (#194).

🤖 Generated with [Claude Code](https://claude.com/claude-code)