### PR TITLE
fix(hooks,scripts): stop losing grep matches to SIGPIPE under pipefail

### DIFF
--- a/.claude/hooks/block-dangerous-commands.sh
+++ b/.claude/hooks/block-dangerous-commands.sh
@@ -42,69 +42,69 @@ RM_RECURSIVE='rm\s+(-[a-zA-Z]*r[a-zA-Z]*\s+(-[a-zA-Z]+\s+)*|-r\s+-f\s+|-f\s+-r\s
 RM_SYS_DIRS='etc|usr|var|bin|sbin|lib|lib64|opt|boot|dev|proc|sys|root|srv|System|Library|Applications|private|Network|Volumes|cores'
 
 # rm -rf /   or   rm -rf /*   (whole filesystem)
-if echo "$COMMAND" | grep -qE "${RM_RECURSIVE}/(\\*|[[:space:]]*($|[;&|]))"; then
+if grep -qE "${RM_RECURSIVE}/(\\*|[[:space:]]*($|[;&|]))" <<< "$COMMAND"; then
   BLOCKED=true
   REASON="Recursive delete on root directory"
 fi
 
 # rm -rf /etc , /usr/local , sudo rm -rf /etc/nginx — any system path
-if echo "$COMMAND" | grep -qE "${RM_RECURSIVE}/(${RM_SYS_DIRS})(/|[[:space:]]|[;&|]|$)"; then
+if grep -qE "${RM_RECURSIVE}/(${RM_SYS_DIRS})(/|[[:space:]]|[;&|]|$)" <<< "$COMMAND"; then
   BLOCKED=true
   REASON="Recursive delete on a system directory"
 fi
 
 # Whole home directory: ~ , ~/Documents , \$HOME , /home/<user> , /Users/<user>.
 # Deeper paths (~/proj/dist, /home/u/app/node_modules) remain allowed.
-if echo "$COMMAND" | grep -qE "${RM_RECURSIVE}(~|\\\$HOME|\\\$\{HOME\})(/[^/[:space:];&|]+)?([[:space:]]|[;&|]|$)"; then
+if grep -qE "${RM_RECURSIVE}(~|\\\$HOME|\\\$\{HOME\})(/[^/[:space:];&|]+)?([[:space:]]|[;&|]|$)" <<< "$COMMAND"; then
   BLOCKED=true
   REASON="Recursive delete on home directory"
 fi
 
-if echo "$COMMAND" | grep -qE "${RM_RECURSIVE}/(home|Users)(/[^/[:space:];&|]+)?([[:space:]]|[;&|]|$)"; then
+if grep -qE "${RM_RECURSIVE}/(home|Users)(/[^/[:space:];&|]+)?([[:space:]]|[;&|]|$)" <<< "$COMMAND"; then
   BLOCKED=true
   REASON="Recursive delete on home directory"
 fi
 
-if echo "$COMMAND" | grep -qE "${RM_RECURSIVE}\\.\s*($|[;&|])"; then
+if grep -qE "${RM_RECURSIVE}\\.\s*($|[;&|])" <<< "$COMMAND"; then
   BLOCKED=true
   REASON="Recursive delete on current directory"
 fi
 
-if echo "$COMMAND" | grep -qE "${RM_RECURSIVE}\\*"; then
+if grep -qE "${RM_RECURSIVE}\\*" <<< "$COMMAND"; then
   BLOCKED=true
   REASON="Recursive delete with wildcard"
 fi
 
 # --no-preserve-root exists only to defeat rm's built-in root guard
-if echo "$COMMAND" | grep -qE -- '--no-preserve-root'; then
+if grep -qE -- '--no-preserve-root' <<< "$COMMAND"; then
   BLOCKED=true
   REASON="rm --no-preserve-root bypasses root protection"
 fi
 
 # Git history destruction
-if echo "$COMMAND" | grep -qE 'git\s+reset\s+--hard'; then
+if grep -qE 'git\s+reset\s+--hard' <<< "$COMMAND"; then
   BLOCKED=true
   REASON="git reset --hard discards all uncommitted changes"
 fi
 
-if echo "$COMMAND" | grep -qE 'git\s+clean\s+(-[a-zA-Z]*f[a-zA-Z]*d|-[a-zA-Z]*d[a-zA-Z]*f|-[a-zA-Z]*f\s+-[a-zA-Z]*d|-[a-zA-Z]*d\s+-[a-zA-Z]*f)'; then
+if grep -qE 'git\s+clean\s+(-[a-zA-Z]*f[a-zA-Z]*d|-[a-zA-Z]*d[a-zA-Z]*f|-[a-zA-Z]*f\s+-[a-zA-Z]*d|-[a-zA-Z]*d\s+-[a-zA-Z]*f)' <<< "$COMMAND"; then
   BLOCKED=true
   REASON="git clean -fd permanently deletes untracked files"
 fi
 
 # Database destruction
-if echo "$COMMAND" | grep -qiE 'DROP\s+(TABLE|DATABASE|SCHEMA)\b'; then
+if grep -qiE 'DROP\s+(TABLE|DATABASE|SCHEMA)\b' <<< "$COMMAND"; then
   BLOCKED=true
   REASON="SQL DROP statement — destructive database operation"
 fi
 
-if echo "$COMMAND" | grep -qiE 'TRUNCATE\s+TABLE\b'; then
+if grep -qiE 'TRUNCATE\s+TABLE\b' <<< "$COMMAND"; then
   BLOCKED=true
   REASON="SQL TRUNCATE — deletes all rows permanently"
 fi
 
 # Docker destruction
-if echo "$COMMAND" | grep -qE 'docker\s+system\s+prune\s+-a'; then
+if grep -qE 'docker\s+system\s+prune\s+-a' <<< "$COMMAND"; then
   BLOCKED=true
   REASON="Docker system prune -a removes all unused images and containers"
 fi
@@ -112,7 +112,7 @@ fi
 # chmod/chown -R on the filesystem root or a system directory. Recursive perms
 # on app/home paths (/srv/app, /var/www, /home/u/app) stay allowed — those are
 # routine for deploys and were false-positives under the old `.*\s+/` matcher.
-if echo "$COMMAND" | grep -qE '(chmod|chown)\s+-R\s+([^;&|]*\s)?/((etc|usr|bin|sbin|lib|lib64|boot|dev|proc|sys|root|System|Library)(/|[[:space:]]|[;&|]|$)|[[:space:]]*($|[;&|]))'; then
+if grep -qE '(chmod|chown)\s+-R\s+([^;&|]*\s)?/((etc|usr|bin|sbin|lib|lib64|boot|dev|proc|sys|root|System|Library)(/|[[:space:]]|[;&|]|$)|[[:space:]]*($|[;&|]))' <<< "$COMMAND"; then
   BLOCKED=true
   REASON="Recursive permission change on a system directory"
 fi

--- a/.claude/hooks/branch-protect.sh
+++ b/.claude/hooks/branch-protect.sh
@@ -39,9 +39,9 @@ GIT_PUSH='git\s+(-c\s+\S+\s+)*push'
 
 # Check for force push (check first — always block regardless of branch)
 # Allow --force-with-lease (safer alternative) but block --force and -f
-if echo "$COMMAND" | grep -qE "${GIT_PUSH}\s+.*--force-with-lease"; then
+if grep -qE "${GIT_PUSH}\s+.*--force-with-lease" <<< "$COMMAND"; then
   : # Allow --force-with-lease (only overwrites if remote matches expectations)
-elif echo "$COMMAND" | grep -qE "${GIT_PUSH}\s+.*--force|${GIT_PUSH}\s+.*-f\b"; then
+elif grep -qE "${GIT_PUSH}\s+.*--force|${GIT_PUSH}\s+.*-f\b" <<< "$COMMAND"; then
   bump_branch_block
   echo "BLOCKED: Force push detected"
   echo ""
@@ -58,8 +58,8 @@ fi
 #   2. a refspec whose DESTINATION is protected:  HEAD:main | local:master |
 #      main:main   (pushing TO main). `git push origin main:feature` is allowed —
 #      that pushes local main to a feature branch, not to remote main.
-if echo "$COMMAND" | grep -qE "${GIT_PUSH}\s+(\S+\s+)*(main|master)([[:space:]]|[;&|]|$)" \
-  || echo "$COMMAND" | grep -qE "${GIT_PUSH}\s+.*:(main|master)([[:space:]]|[;&|]|$)"; then
+if grep -qE "${GIT_PUSH}\s+(\S+\s+)*(main|master)([[:space:]]|[;&|]|$)" <<< "$COMMAND" \
+  || grep -qE "${GIT_PUSH}\s+.*:(main|master)([[:space:]]|[;&|]|$)" <<< "$COMMAND"; then
   bump_branch_block
   echo "BLOCKED: Direct push to main/master branch"
   echo ""
@@ -70,7 +70,7 @@ if echo "$COMMAND" | grep -qE "${GIT_PUSH}\s+(\S+\s+)*(main|master)([[:space:]]|
 fi
 
 # Check for `git push <remote> HEAD` when on main/master
-if echo "$COMMAND" | grep -qE "${GIT_PUSH}\s+\S+\s+HEAD\b"; then
+if grep -qE "${GIT_PUSH}\s+\S+\s+HEAD\b" <<< "$COMMAND"; then
   CURRENT_BRANCH=$(git branch --show-current 2>/dev/null) || CURRENT_BRANCH=""
   if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ]; then
     bump_branch_block
@@ -85,7 +85,7 @@ fi
 
 # Check for bare `git push` (no branch given) while on main/master. Tolerates
 # `-u`/`--set-upstream` and an explicit remote: `git push`, `git push -u origin`.
-if echo "$COMMAND" | grep -qE "(^|[;&|]\s*)${GIT_PUSH}(\s+(-u|--set-upstream))?(\s+origin)?\s*($|[;&|])"; then
+if grep -qE "(^|[;&|]\s*)${GIT_PUSH}(\s+(-u|--set-upstream))?(\s+origin)?\s*($|[;&|])" <<< "$COMMAND"; then
   CURRENT_BRANCH=$(git branch --show-current 2>/dev/null) || CURRENT_BRANCH=""
   if [ -z "$CURRENT_BRANCH" ]; then
     exit 0  # Cannot determine branch, allow the push

--- a/.claude/hooks/conventional-commit.sh
+++ b/.claude/hooks/conventional-commit.sh
@@ -22,7 +22,7 @@ COMMAND=$(parse_json_field "command")
 [ -z "$COMMAND" ] && exit 0
 
 # Only check git commit commands
-if ! echo "$COMMAND" | grep -qE 'git\s+commit'; then
+if ! grep -qE 'git\s+commit' <<< "$COMMAND"; then
   exit 0
 fi
 
@@ -47,7 +47,7 @@ FIRST_LINE=$(echo "$MSG" | head -1)
 # Validate conventional commit format
 VALID_TYPES="feat|fix|refactor|test|docs|chore|perf|ci|build|style"
 
-if ! echo "$FIRST_LINE" | grep -qE "^($VALID_TYPES)(\(.+\))?: .+"; then
+if ! grep -qE "^($VALID_TYPES)(\(.+\))?: .+" <<< "$FIRST_LINE"; then
   echo "BLOCKED: Commit message doesn't follow conventional commit format"
   echo ""
   echo "  Got:      $FIRST_LINE"

--- a/.claude/hooks/mcp-gate.sh
+++ b/.claude/hooks/mcp-gate.sh
@@ -58,7 +58,8 @@ if [ ! -f "$ALLOWLIST" ]; then
 fi
 
 # Allowlist present → enforce. Empty server name can't be matched; block to be safe.
-if [ -n "$SERVER" ] && grep -vE '^[[:space:]]*(#|$)' "$ALLOWLIST" | grep -qxF "$SERVER"; then
+ALLOWED_SERVERS=$(grep -vE '^[[:space:]]*(#|$)' "$ALLOWLIST" || true)
+if [ -n "$SERVER" ] && grep -qxF "$SERVER" <<< "$ALLOWED_SERVERS"; then
   remind_once
   exit 0
 fi

--- a/.claude/hooks/prompt-router.sh
+++ b/.claude/hooks/prompt-router.sh
@@ -40,27 +40,27 @@ append() { REMINDERS="${REMINDERS}${1}"$'\n'; }
 # "deployment" (deploy + ment). Trailing characters are allowed.
 
 # Auth / security
-if printf '%s' "$LOWER" | grep -qE '\b(auth|login|signin|sign-in|session|jwt|oauth|password|credential|permission|rbac|acl)'; then
+if grep -qE '\b(auth|login|signin|sign-in|session|jwt|oauth|password|credential|permission|rbac|acl)' <<< "$LOWER"; then
   append "[Auth/security context] This touches authentication or authorization. Treat token handling, session expiry, and permission checks as required test cases. Avoid logging secrets, sessions, or credentials."
 fi
 
 # Payments / billing
-if printf '%s' "$LOWER" | grep -qE '\b(payment|billing|invoice|refund|checkout|stripe|subscription|charge)'; then
+if grep -qE '\b(payment|billing|invoice|refund|checkout|stripe|subscription|charge)' <<< "$LOWER"; then
   append "[Billing context] Customer-visible behavior — update tests with any behavior change. Never log full card data or PII. Reconcile any state change with the source of truth (DB, Stripe, ledger)."
 fi
 
 # Migrations / schema
-if printf '%s' "$LOWER" | grep -qE '\b(migration|schema|alter table|drop table|rename column|backfill)'; then
+if grep -qE '\b(migration|schema|alter table|drop table|rename column|backfill)' <<< "$LOWER"; then
   append "[Migration context] Migrations are protected changes. Stop and present a plan with rollback. Confirm read/write impact on production data, lock duration, and whether a backfill is needed."
 fi
 
 # Deploy / release
-if printf '%s' "$LOWER" | grep -qE '\b(deploy|release|production|prod\b|ship\b|rollout|hotfix)'; then
+if grep -qE '\b(deploy|release|production|prod\b|ship\b|rollout|hotfix)' <<< "$LOWER"; then
   append "[Deploy context] Treat as a sensitive action. Verify the change is on the right branch, CI is green, CHANGELOG is updated, and a rollback path is documented before tagging or pushing."
 fi
 
 # Dependencies
-if printf '%s' "$LOWER" | grep -qE '\b(add a dependency|new dependency|install package|npm install|pip install|cargo add|go get)'; then
+if grep -qE '\b(add a dependency|new dependency|install package|npm install|pip install|cargo add|go get)' <<< "$LOWER"; then
   append "[Dependency context] New dependencies are protected changes. Provide at least two alternatives and a tradeoff analysis before adding (per CLAUDE.md → Protected Changes)."
 fi
 

--- a/.claude/hooks/secret-scan.sh
+++ b/.claude/hooks/secret-scan.sh
@@ -25,7 +25,8 @@ FILE_PATH=$(parse_json_field "file_path")
 [ ! -f "$FILE_PATH" ] && exit 0
 
 # Skip binary files (check for "text" in file output — works on both macOS and Linux)
-if ! file "$FILE_PATH" | grep -qi "text"; then
+FILE_TYPE=$(file "$FILE_PATH" 2>/dev/null || true)
+if ! grep -qi "text" <<< "$FILE_TYPE"; then
   exit 0
 fi
 

--- a/.claude/hooks/skill-compliance.sh
+++ b/.claude/hooks/skill-compliance.sh
@@ -62,44 +62,44 @@ for skill_dir in "$SKILLS_DIR"/*/; do
   # Match by file extension mentions in the skill
   case "$EXT" in
     js|jsx|ts|tsx|mjs|cjs)
-      if echo "$SKILL_CONTENT" | grep -qiE 'javascript|typescript|react|next\.?js|node|\.tsx?|\.jsx?'; then
+      if grep -qiE 'javascript|typescript|react|next\.?js|node|\.tsx?|\.jsx?' <<< "$SKILL_CONTENT"; then
         RELEVANT=true
       fi
       ;;
     py)
-      if echo "$SKILL_CONTENT" | grep -qiE 'python|django|fastapi|flask|\.py'; then
+      if grep -qiE 'python|django|fastapi|flask|\.py' <<< "$SKILL_CONTENT"; then
         RELEVANT=true
       fi
       ;;
     go)
-      if echo "$SKILL_CONTENT" | grep -qiE 'golang|go\.mod|\.go'; then
+      if grep -qiE 'golang|go\.mod|\.go' <<< "$SKILL_CONTENT"; then
         RELEVANT=true
       fi
       ;;
     rs)
-      if echo "$SKILL_CONTENT" | grep -qiE 'rust|cargo|\.rs'; then
+      if grep -qiE 'rust|cargo|\.rs' <<< "$SKILL_CONTENT"; then
         RELEVANT=true
       fi
       ;;
     rb)
-      if echo "$SKILL_CONTENT" | grep -qiE 'ruby|rails|\.rb'; then
+      if grep -qiE 'ruby|rails|\.rb' <<< "$SKILL_CONTENT"; then
         RELEVANT=true
       fi
       ;;
     sql)
-      if echo "$SKILL_CONTENT" | grep -qiE 'sql|database|query|migration'; then
+      if grep -qiE 'sql|database|query|migration' <<< "$SKILL_CONTENT"; then
         RELEVANT=true
       fi
       ;;
   esac
 
   # Also match broadly applicable skills (security, error handling, testing)
-  if echo "$SKILL_CONTENT" | grep -qiE 'all (files|projects|languages)|any (file|project)'; then
+  if grep -qiE 'all (files|projects|languages)|any (file|project)' <<< "$SKILL_CONTENT"; then
     RELEVANT=true
   fi
 
   # Match by filename patterns mentioned in the skill
-  if echo "$SKILL_CONTENT" | grep -qF "$BASENAME"; then
+  if grep -qF "$BASENAME" <<< "$SKILL_CONTENT"; then
     RELEVANT=true
   fi
 

--- a/.claude/hooks/unicode-scan.sh
+++ b/.claude/hooks/unicode-scan.sh
@@ -33,7 +33,8 @@ FILE_PATH=$(parse_json_field "file_path")
 [ ! -f "$FILE_PATH" ] && exit 0
 
 # Skip binary files
-if ! file "$FILE_PATH" | grep -qi "text"; then
+FILE_TYPE=$(file "$FILE_PATH" 2>/dev/null || true)
+if ! grep -qi "text" <<< "$FILE_TYPE"; then
   exit 0
 fi
 
@@ -47,7 +48,7 @@ case "$BASENAME" in
 esac
 
 # Check for allowlist comment in file
-if head -5 "$FILE_PATH" | grep -q "kit-allow-unicode" 2>/dev/null; then
+if grep -q "kit-allow-unicode" <<< "$(head -5 "$FILE_PATH" 2>/dev/null)"; then
   exit 0
 fi
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -189,3 +189,36 @@ jobs:
         run: |
           chmod +x scripts/check-counts.sh
           ./scripts/check-counts.sh
+
+  pipefail-grep-guard:
+    name: Pipefail Grep Guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: No quiet grep on the receiving end of a pipe in pipefail scripts
+        run: |
+          # A quiet grep exits the moment it matches, which can leave the writer
+          # with EPIPE. Under `set -o pipefail` the pipeline then reports failure
+          # even though the pattern DID match, so the match is silently lost.
+          # That flipped wired hooks into phantom "orphan hook" warnings
+          # (TAN-5273) and made skill section checks flake (TAN-4746).
+          # Use a herestring — grep -q PATTERN <<< "$VAR" — or, for a plain
+          # substring test, bash's [[ "$VAR" == *"$NEEDLE"* ]].
+          PATTERN='[^|]\|[[:space:]]*grep[[:space:]]+(-[a-zA-Z]*q[a-zA-Z]*|--quiet)([[:space:]]|$)'
+          violations=0
+          for file in $(git ls-files '*.sh'); do
+            grep -q 'pipefail' "$file" || continue
+            hits=$(grep -nE "$PATTERN" "$file" | grep -vE '^[0-9]+:[[:space:]]*#' || true)
+            if [ -n "$hits" ]; then
+              echo "$file:"
+              echo "$hits" | sed 's/^/  /'
+              violations=$((violations + $(echo "$hits" | wc -l)))
+            fi
+          done
+          if [ "$violations" -gt 0 ]; then
+            echo ""
+            echo "$violations pipe(s) into a quiet grep found in pipefail scripts." >&2
+            exit 1
+          fi
+          echo "No quiet grep is fed by a pipe in a pipefail script."

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -188,7 +188,10 @@ if [ -f ".claude/settings.json" ]; then
     for hook in .claude/hooks/*.sh; do
       [ -f "$hook" ] || continue
       basename=$(basename "$hook")
-      if echo "$SETTINGS_CONTENT" | grep -qF "$basename"; then
+      # Substring-test in-process. Piping a variable into a quiet grep under
+      # `set -o pipefail` lets the writer's exit status become the pipeline's,
+      # which flipped wired hooks to phantom "orphan" warnings (TAN-5273).
+      if [[ "$SETTINGS_CONTENT" == *"$basename"* ]]; then
         pass "$basename is referenced in settings.json"
       elif [[ "$OPT_IN_HOOKS" == *" $basename "* ]]; then
         info "$basename is opt-in, not in standard profile (enable per agent_docs/hooks.md)"

--- a/scripts/lesson-resurface.sh
+++ b/scripts/lesson-resurface.sh
@@ -89,7 +89,7 @@ QUERY_LOWER=$(printf '%s' "$QUERY" | tr '[:upper:]' '[:lower:]')
 MATCHED_TOPICS=""
 while IFS= read -r topic; do
   [ -z "$topic" ] && continue
-  if printf '%s' "$QUERY_LOWER" | grep -q -- "$topic"; then
+  if grep -q -- "$topic" <<< "$QUERY_LOWER"; then
     MATCHED_TOPICS="${MATCHED_TOPICS}${topic}"$'\n'
   fi
 done <<<"$VOCAB"
@@ -117,10 +117,10 @@ while IFS= read -r f; do
   tags_clean=" $(printf '%s' "$tags" | tr -d "[]\"'" | tr ',' ' ') "
 
   for topic in $TOPICS_LIST; do
-    if printf '%s' "$applies_clean" | grep -wq -- "$topic"; then
+    if grep -wq -- "$topic" <<< "$applies_clean"; then
       score=$((score + 3))
     fi
-    if printf '%s' "$tags_clean" | grep -wq -- "$topic"; then
+    if grep -wq -- "$topic" <<< "$tags_clean"; then
       score=$((score + 1))
     fi
   done
@@ -158,10 +158,10 @@ while IFS=$'\t' read -r score path applies_to status confidence title; do
       active_status=$(get_field "$active" "status")
       [ "$active_status" = "active" ] || continue
       supersedes=$(get_field "$active" "supersedes" | tr -d "[]\"'" | tr ',' ' ')
-      if printf ' %s ' "$supersedes" | grep -wq -- "$base"; then
+      if grep -wq -- "$base" <<< " $supersedes "; then
         active_base=$(basename "$active" .md)
         # Is the successor already in match list?
-        if printf '%s' "$SCORED" | grep -q -- "${active_base}\.md"$'\t'; then
+        if grep -q -- "${active_base}\.md"$'\t' <<< "$SCORED"; then
           drop=1
           break
         fi

--- a/scripts/migrate-lessons.sh
+++ b/scripts/migrate-lessons.sh
@@ -65,7 +65,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Validate date format
-if ! echo "$DATE_PREFIX" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
+if ! grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}$' <<< "$DATE_PREFIX"; then
   err "Invalid date: $DATE_PREFIX (expected YYYY-MM-DD)"
   exit 1
 fi

--- a/scripts/test-cli.sh
+++ b/scripts/test-cli.sh
@@ -32,7 +32,8 @@ done
 
 # --- help / unknown command --------------------------------------------------
 echo "== help / unknown =="
-bash "$CLI" --help 2>/dev/null | grep -q "Usage:" && pass "--help prints usage" || fail "--help missing usage"
+CLI_HELP=$(bash "$CLI" --help 2>/dev/null || true)
+grep -q "Usage:" <<< "$CLI_HELP" && pass "--help prints usage" || fail "--help missing usage"
 if bash "$CLI" definitely-not-a-command >/dev/null 2>&1; then
   fail "unknown command exited 0"
 else


### PR DESCRIPTION
Closes TAN-5273.

## The defect

`scripts/doctor.sh` was nondeterministic. On an unchanged tree it reported a
different set of "orphan hooks" from run to run — naming hooks that *are* wired
in `settings.json`.

Measured on this repo at `origin/main`: **4 of 100 runs** emitted a phantom
warning (`bash-budget.sh`, `session-start.sh`, `subagent-pre.sh`,
`glob-guidance.sh` on separate runs). That matters because `doctor.sh` is the
deterministic install-health gate the fleet leans on — a check that invents a
warning every ~25 runs teaches everyone to discount its warnings, which is how a
real orphan gets waved through.

## Root cause — measured in situ, not inferred

A quiet grep exits the instant it matches and closes the read end of the pipe.
If the writer has not finished, it takes `SIGPIPE`. Under `set -o pipefail` the
pipeline adopts that status, so the `if` takes the `else` branch **even though
grep matched**.

Instrumenting the real pipeline (capturing `PIPESTATUS` before any intervening
test could clobber it) caught it directly:

```
ANOMALY hook=protect-files.sh echo=141 grep=0 recheck=1
```

`grep=0` — matched. `echo=141` — writer killed by SIGPIPE. `recheck=1` — the
hook really is in `settings.json`. `set -e` never fires because the pipeline is
an `if` condition, so the failure is silent and only ever surfaces as a wrong
warning.

Worth noting: this same class was already found and fixed once, in
`scripts/validate-skills.sh` (TAN-4746) — but only at that one call site, and
the pattern was left in place everywhere else. Hence the guard below.

## Why this is not only cosmetic

The same shape was **fail-open** in the safety hooks:

| Site | What a dropped match costs |
| --- | --- |
| `block-dangerous-commands.sh` (13 sites) | a matched `rm -rf /`, `git reset --hard`, `DROP TABLE` is not blocked |
| `branch-protect.sh` (6 sites) | a force-push or a push to `main` is not blocked |
| `secret-scan.sh`, `unicode-scan.sh` | `if ! file … \| grep -qi text` — a lost match makes the file look binary, so it is skipped **unscanned** |
| `mcp-gate.sh` | fail-closed instead: an allowlisted server gets blocked |
| `skill-compliance.sh` (8 sites) | stack detection silently misses on a multi-KB `SKILL.md` |

The window is small and load-dependent — short, single-`write()` payloads
essentially never hit it — but `$COMMAND` and the user prompt are unbounded and
attacker-influenced, so "usually short" is not a safety property worth relying on.

## The change

All 46 pipes into a quiet grep inside `pipefail` scripts, replaced with:

- `grep -q PATTERN <<< "$VAR"` — herestring, no writer process to kill; or
- `[[ "$VAR" == *"$NEEDLE"* ]]` — where the match was a fixed string
  (`doctor.sh`), so no subprocess at all.

Semantics are unchanged: a herestring appends the trailing newline that
`printf '%s'` omitted, which does not affect line matching, and the bash
substring test is exactly `grep -F` semantics for a needle with no newline.

Plus a **Pipefail Grep Guard** CI job so the pattern cannot come back. It runs
the same detector over every `pipefail` script and fails on any hit.

## Verification

| Check | Result |
| --- | --- |
| `doctor.sh` × 100, byte-identical output (AC1) | **100/100 identical** — and the hash equals the *correct* majority output from the baseline, so behaviour is unchanged, only stabilised |
| Phantom orphans | **0/100** (was 4/100) |
| Genuine orphan still flagged (AC2) | planted an unwired `zz-definitely-unwired.sh` → correctly reported, alongside the real `notify-waiting.sh`; 23 wired hooks all pass |
| No piped quiet grep left (AC3) | guard passes here, and reports **all 46** hits on `origin/main` |
| KitBench | **48/48 PASS** (unchanged from baseline) |
| `bash -n` on every `.sh` | clean |
| validate-skills / check-counts / sync-manifest --check / gen-strict-settings --check / test-cli / test-install | all pass |

Every changed file is `#!/usr/bin/env bash`, and hooks are invoked by path so
the shebang applies — herestrings are safe, including on the macOS bash 3.2 leg
that KitBench covers.

## Not done here

`notify-waiting.sh` is a *genuine* orphan — shipped by TAN-4751 but never wired
into the standard `settings.json`. It is the one warning `doctor.sh` was right
about, and it is left alone: it wants either wiring or an `OPT_IN_HOOKS` entry,
which is a product decision, not part of this fix.
